### PR TITLE
test: add compaction benchmark harness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+node_modules
+dist
+*.tsbuildinfo
+bun.lock
+bench-results*.jsonl
+bench-results*.json
+.pi*
+research
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+# renovate: datasource=docker depName=oven/bun versioning=semver
+ARG BUN_VERSION=1.3.13
+
+FROM oven/bun:${BUN_VERSION} AS source
+WORKDIR /app
+
+COPY --link package.json README.md ./
+COPY --link src ./src
+COPY --link bench ./bench
+COPY --link scripts ./scripts
+
+FROM oven/bun:${BUN_VERSION} AS final
+ENV NODE_ENV=production
+
+COPY --link --from=source --chown=1000:1000 /app /app
+WORKDIR /app
+USER bun
+
+ENTRYPOINT ["bun", "scripts/bench-compaction.ts"]
+CMD ["--jsonl"]

--- a/README.md
+++ b/README.md
@@ -230,7 +230,9 @@ Use assertion mode when checking a selected compactor against the current benchm
 
 ```bash
 bun scripts/bench-compaction.ts --compactors pi-vcc --assert
+bun scripts/bench-compaction.ts --compactors pi-vcc --assert-cache
 docker run --rm pi-vcc-bench --compactors pi-vcc --assert
+docker run --rm pi-vcc-bench --compactors pi-vcc --assert-cache
 ```
 
 Sample real Pi sessions for size, latency, and cache-churn metrics:

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Typical workflow: **search → find relevant entry indices → expand those indi
 
 ## Compaction benchmark
 
-An offline benchmark harness lives under `bench/compaction`. It replays pressure-style synthetic long-session scenarios through multiple compactors and records continuation-oriented metrics: exact state recovery, current-state recovery, recall recovery, prompt size, layer churn, longest common prefix, stale-fact leakage, and recall-only offload leakage.
+An offline benchmark harness lives under `bench/compaction`. It replays pressure-style synthetic long-session scenarios through multiple compactors and records continuation-oriented metrics: exact state recovery, current-state recovery, recall recovery, prompt size, simulated full-prompt cache churn, longest common prefix, stale-fact leakage, and recall-only offload leakage.
 
 Run all offline compactors:
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,20 @@ bun scripts/bench-compaction.ts --compactors pi-vcc --assert
 docker run --rm pi-vcc-bench --compactors pi-vcc --assert
 ```
 
-Assertion failures are expected for current baselines while these RED scenarios document known gaps. The default benchmark is deterministic and does not call model providers. Provider-reported cached-token and latency measurements should be added as an opt-in benchmark because they require credentials and can create billable requests.
+Sample real Pi sessions for size, latency, and cache-churn metrics:
+
+```bash
+docker run --rm \
+  -v ~/.pi/agent/sessions:/sessions:ro \
+  pi-vcc-bench \
+  --real-only \
+  --real-sessions-dir /sessions \
+  --real-limit 2 \
+  --compactors pi-vcc \
+  --jsonl
+```
+
+Assertion failures are expected for current baselines while these RED scenarios document known gaps. The default synthetic benchmark is deterministic and does not call model providers. Real-session sampling depends on the mounted local session corpus. Provider-reported cached-token and latency measurements should be added as an opt-in benchmark because they require credentials and can create billable requests.
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,50 @@ Typical workflow: **search → find relevant entry indices → expand those indi
 5. **Format** — render into bracketed sections + transcript
 6. **Merge** — if previous summary exists: sticky sections merge, volatile sections replace, transcript rolls
 
+## Compaction benchmark
+
+An offline benchmark harness lives under `bench/compaction`. It replays pressure-style synthetic long-session scenarios through multiple compactors and records continuation-oriented metrics: exact state recovery, current-state recovery, recall recovery, prompt size, layer churn, longest common prefix, stale-fact leakage, and recall-only offload leakage.
+
+Run all offline compactors:
+
+```bash
+bun scripts/bench-compaction.ts
+```
+
+Emit one JSON record per compaction cycle:
+
+```bash
+bun scripts/bench-compaction.ts --jsonl > bench-results.jsonl
+```
+
+Limit the comparison to selected compactors:
+
+```bash
+bun scripts/bench-compaction.ts --compactors pi-vcc,cache-aware-layered
+```
+
+Run the same benchmark in Docker:
+
+```bash
+docker build -t pi-vcc-bench .
+docker run --rm pi-vcc-bench
+```
+
+Pass benchmark arguments after the image name:
+
+```bash
+docker run --rm pi-vcc-bench --compactors pi-vcc,cache-aware-layered
+```
+
+Use assertion mode when checking a selected compactor against the current benchmark gates:
+
+```bash
+bun scripts/bench-compaction.ts --compactors pi-vcc --assert
+docker run --rm pi-vcc-bench --compactors pi-vcc --assert
+```
+
+Assertion failures are expected for current baselines while these RED scenarios document known gaps. The default benchmark is deterministic and does not call model providers. Provider-reported cached-token and latency measurements should be added as an opt-in benchmark because they require credentials and can create billable requests.
+
 ## Config
 
 Config lives at `~/.pi/agent/pi-vcc-config.json` (auto-scaffolded on first load with safe defaults):

--- a/bench/compaction/README.md
+++ b/bench/compaction/README.md
@@ -98,6 +98,23 @@ Each compaction cycle records:
 
 The cache-oriented metrics are offline approximations. They do not replace provider-reported cached-token accounting, but they highlight prompt churn that is likely to hurt prefix-based caching.
 
+## Full-prompt cache simulation
+
+Each cycle also builds a simulated provider prompt so cache churn can be measured outside the compacted summary alone. The simulated prompt contains stable provider/tool/project layers, the compactor's rendered layers, and a small kept raw tail. This does not exactly reproduce Pi's production request, but it catches the main prefix-cache risk: a volatile update moving earlier than necessary.
+
+Additional cache fields include:
+
+- `fullPromptChars` and `fullPromptTokensEst`
+- `fullPromptLcpTokensWithPrevious`
+- `fullPromptLcpTokenRatioWithPrevious`
+- `firstChangedPromptLayer`
+- `changedPromptLayers`
+- `stablePrefixTokens`
+- `promptLayerSizes`
+- `promptLayerTokenDeltas`
+
+Use these fields to compare section ordering and stable/volatile splits before adding live provider probes. A better cache-aware layout should generally increase `stablePrefixTokens`, push `firstChangedPromptLayer` later, and keep volatile deltas out of static/current prefix layers when the underlying facts did not change.
+
 ## Running
 
 Run all offline compactors:

--- a/bench/compaction/README.md
+++ b/bench/compaction/README.md
@@ -1,0 +1,161 @@
+# Compaction Benchmark
+
+This benchmark evaluates conversation compaction as a continuation system, not only as a compression routine. It focuses on whether a compacted agent state preserves recoverable work while keeping cacheable prompt prefixes stable.
+
+The design borrows the pressure-test loop used for skill validation: first make the current behavior fail in a controlled scenario, then implement the smallest compaction change that fixes the observed failure, and rerun the same scenario plus nearby variants.
+
+## Evaluation loop
+
+Use the benchmark as a RED-GREEN-REFACTOR loop for compaction behavior:
+
+1. **RED**: run the current compactor and record exact failures such as missing identifiers, stale current facts, bulky active text, or unstable early layers.
+2. **GREEN**: add the smallest targeted compaction change that fixes the observed failure.
+3. **REFACTOR**: pressure-test adjacent cases so the fix does not only satisfy one string probe.
+4. **ITERATE**: keep the failing scenario in the benchmark and repeat until the desired compactor passes or the intended semantics need to change.
+
+Do not implement broad cache-aware layering only from design intuition. Add or keep a failing probe for each behavior the implementation is meant to improve.
+
+## Compactors under comparison
+
+The runner uses a common offline interface:
+
+- `pi-vcc`: current deterministic `compile()` output.
+- `full-rewrite-checkpoint`: deterministic stand-in for a regenerated structured summary plus transcript, without external recall.
+- `cache-aware-layered`: deterministic layered prototype that separates stable schema, durable memory, structured checkpoint, rolling transcript, raw tail, and recall pointers.
+
+LLM-backed compactors can be added behind the same interface. Live model calls should be kept separate from the default offline run so local validation remains cheap and deterministic.
+
+## Benchmark levels
+
+The current harness covers the first level and some cache-churn signals. Later levels should be added before using benchmark results to claim end-to-end agent quality.
+
+1. **Offline state probes**
+   - exact active terms
+   - current-state terms
+   - recall-only terms
+   - forbidden current-state terms
+   - terms that must stay out of active prompt text
+   - layer churn and longest common prefix
+
+2. **Micro-continuation probes**
+   - compacted context plus a tiny disposable fixture
+   - agent gets a one-to-three action budget
+   - pass/fail by expected command, file, or decision
+
+3. **Hermetic Pi replay**
+   - isolated `PI_CODING_AGENT_DIR`
+   - actual compaction hook and session context construction
+   - optional default-model and small-model continuation probes
+
+4. **Live provider cache probes**
+   - provider-reported cached and uncached tokens
+   - latency to first token and total latency
+   - effective input cost over the next few turns
+
+## Scenario shape
+
+Each synthetic case contains:
+
+- an ordered message transcript
+- one or more compaction points to replay repeated compactions
+- exact terms that should remain somewhere in active prompt state
+- exact terms that should be in current-state layers, not only historical transcript or raw tail
+- exact terms that may be absent from active state but must be recoverable from recall
+- terms that must not appear in current-state layers after corrections or branch-sensitive updates
+- terms that must stay out of active prompt text because recall should carry them
+- continuation terms that indicate the agent can resume the next action
+
+Real Pi sessions can be added later as fixtures or sampled from local session JSONL files, but synthetic cases provide gold expectations for regressions.
+
+## Scoped assertions
+
+The runner distinguishes scopes so historical fidelity is not confused with current state:
+
+- `activeTerms`: must appear anywhere in the active compacted prompt.
+- `currentTerms`: must appear in current-state layers.
+- `recallTerms`: must be recoverable from recall corpus search.
+- `forbiddenTerms`: must not appear anywhere in the active compacted prompt.
+- `forbiddenCurrentTerms`: must not appear in current-state layers, but may exist in historical transcript/tail or recall corpus.
+- `activeAbsentTerms`: must not appear in active prompt text; they are expected to live in recall only.
+
+This matters for corrections. For example, an old preference may remain in historical transcript, but it must not remain in durable memory or the current checkpoint after a user correction.
+
+## Metrics
+
+Each compaction cycle records:
+
+- active state size in characters and approximate tokens
+- current-state size in characters and approximate tokens
+- compaction latency
+- longest common prefix with the previous compacted prompt
+- first changed layer and changed layer names when a compactor exposes layers
+- active exact-term recall against gold terms
+- current-state exact-term recall against gold terms
+- forbidden active and current-state leakage
+- active leakage of terms expected to be recall-only
+- recall top-k recovery for externalized terms
+- continuation-term recovery
+
+The cache-oriented metrics are offline approximations. They do not replace provider-reported cached-token accounting, but they highlight prompt churn that is likely to hurt prefix-based caching.
+
+## Running
+
+Run all offline compactors:
+
+```bash
+bun scripts/bench-compaction.ts
+```
+
+Emit one JSON record per compaction cycle:
+
+```bash
+bun scripts/bench-compaction.ts --jsonl > bench-results.jsonl
+```
+
+Limit the comparison to selected compactors:
+
+```bash
+bun scripts/bench-compaction.ts --compactors pi-vcc,cache-aware-layered
+```
+
+Run assertion mode. This exits non-zero if any selected compactor misses active/current/recall/continuation expectations or leaks forbidden/offloaded terms:
+
+```bash
+bun scripts/bench-compaction.ts --compactors pi-vcc --assert
+```
+
+Run the same checks in Docker:
+
+```bash
+docker build -t pi-vcc-bench .
+docker run --rm pi-vcc-bench
+docker run --rm pi-vcc-bench --compactors pi-vcc --assert
+```
+
+Assertion failures are expected for current baselines while the RED scenarios are documenting known gaps. Use selected compactors when checking one implementation at a time.
+
+## Interpreting results
+
+A useful compactor should:
+
+- preserve exact identifiers, file paths, evidence handles, constraints, blockers, and next actions
+- keep current state separate from historical transcript and raw tail
+- avoid retaining corrected stale facts in current-state layers
+- keep stable layers byte-identical across ordinary compactions
+- move bulky re-fetchable details behind recall pointers without losing top-k recoverability
+- reduce active prompt size without shifting too much cost into uncached post-compaction turns
+
+Shorter output is not sufficient if continuation or recall probes fail.
+
+## Future live-provider extension
+
+A live cache probe should replay the same compacted prompts against providers that report cache usage and capture:
+
+- cached input tokens
+- uncached input tokens
+- cache-write tokens
+- latency to first token
+- total request latency
+- effective input cost over the next few turns
+
+That extension should be opt-in because it depends on credentials, provider-specific cache semantics, and billable requests.

--- a/bench/compaction/README.md
+++ b/bench/compaction/README.md
@@ -141,12 +141,40 @@ Run assertion mode. This exits non-zero if any selected compactor misses active/
 bun scripts/bench-compaction.ts --compactors pi-vcc --assert
 ```
 
+Append sampled real Pi sessions from a local session directory. Real-session cases have no gold state assertions; they are useful for size, latency, growth, and cache-churn signals:
+
+```bash
+bun scripts/bench-compaction.ts \
+  --real-sessions-dir ~/.pi/agent/sessions \
+  --real-limit 2 \
+  --compactors pi-vcc
+```
+
+Run only sampled real sessions:
+
+```bash
+bun scripts/bench-compaction.ts \
+  --real-only \
+  --real-sessions-dir ~/.pi/agent/sessions \
+  --real-limit 2 \
+  --compactors pi-vcc \
+  --jsonl
+```
+
 Run the same checks in Docker:
 
 ```bash
 docker build -t pi-vcc-bench .
 docker run --rm pi-vcc-bench
 docker run --rm pi-vcc-bench --compactors pi-vcc --assert
+docker run --rm \
+  -v ~/.pi/agent/sessions:/sessions:ro \
+  pi-vcc-bench \
+  --real-only \
+  --real-sessions-dir /sessions \
+  --real-limit 2 \
+  --compactors pi-vcc \
+  --jsonl
 ```
 
 Assertion failures are expected for current baselines while the RED scenarios are documenting known gaps. Use selected compactors when checking one implementation at a time.

--- a/bench/compaction/README.md
+++ b/bench/compaction/README.md
@@ -161,6 +161,18 @@ bun scripts/bench-compaction.ts \
   --jsonl
 ```
 
+Filter cases and include concise layer diffs when investigating cache churn:
+
+```bash
+bun scripts/bench-compaction.ts \
+  --real-only \
+  --real-sessions-dir ~/.pi/agent/sessions \
+  --case-filter ch-observability \
+  --compactors pi-vcc \
+  --show-layer-diff \
+  --jsonl
+```
+
 Run the same checks in Docker:
 
 ```bash

--- a/bench/compaction/README.md
+++ b/bench/compaction/README.md
@@ -141,6 +141,12 @@ Run assertion mode. This exits non-zero if any selected compactor misses active/
 bun scripts/bench-compaction.ts --compactors pi-vcc --assert
 ```
 
+Run cache assertion mode for synthetic cache-stability probes. This is separate from correctness assertions and currently checks that volatile-only updates do not rewrite early stable prompt layers:
+
+```bash
+bun scripts/bench-compaction.ts --compactors pi-vcc --assert-cache
+```
+
 Append sampled real Pi sessions from a local session directory. Real-session cases have no gold state assertions; they are useful for size, latency, growth, and cache-churn signals:
 
 ```bash

--- a/bench/compaction/README.md
+++ b/bench/compaction/README.md
@@ -100,7 +100,7 @@ The cache-oriented metrics are offline approximations. They do not replace provi
 
 ## Full-prompt cache simulation
 
-Each cycle also builds a simulated provider prompt so cache churn can be measured outside the compacted summary alone. The simulated prompt contains stable provider/tool/project layers, the compactor's rendered layers, and a small kept raw tail. This does not exactly reproduce Pi's production request, but it catches the main prefix-cache risk: a volatile update moving earlier than necessary.
+Each cycle also builds a simulated provider prompt so cache churn can be measured outside the compacted summary alone. The simulated prompt contains stable provider/tool/project layers, the compactor's rendered layers, and a small kept raw tail. For `pi-vcc`, current summary sections are split into separate simulated prompt layers so the report can identify which section changes first. This does not exactly reproduce Pi's production request, but it catches the main prefix-cache risk: a volatile update moving earlier than necessary.
 
 Additional cache fields include:
 

--- a/bench/compaction/offline-runner.ts
+++ b/bench/compaction/offline-runner.ts
@@ -69,6 +69,14 @@ export interface RecallProbeResult extends TermProbeResult {
   topHitIds: string[];
 }
 
+export interface PromptLayerDiff {
+  layer: string;
+  previousPreview: string;
+  currentPreview: string;
+  addedLines: string[];
+  removedLines: string[];
+}
+
 export interface CycleMetrics {
   caseId: string;
   compactor: string;
@@ -106,6 +114,7 @@ export interface CycleMetrics {
   layerSizes: Record<string, number>;
   promptLayerSizes: Record<string, number>;
   promptLayerTokenDeltas: Record<string, number>;
+  promptLayerDiffs?: PromptLayerDiff[];
 }
 
 export interface BenchmarkRunResult {
@@ -217,6 +226,34 @@ const summarizeChangedPromptLayers = (
     changedPromptLayers,
     promptLayerTokenDeltas,
   };
+};
+
+const linePreview = (text: string, maxChars = 400): string =>
+  text.length <= maxChars ? text : `${text.slice(0, maxChars)}...(truncated)`;
+
+const changedPromptLayerDiffs = (
+  previous: PromptSnapshot | undefined,
+  current: PromptSnapshot,
+  changedLayers: string[],
+): PromptLayerDiff[] => {
+  if (!previous) return [];
+  const prevByName = new Map(previous.layers.map((layer) => [layer.name, layer.text]));
+  const currentByName = new Map(current.layers.map((layer) => [layer.name, layer.text]));
+  return changedLayers.slice(0, 3).map((layer) => {
+    const previousText = prevByName.get(layer) ?? "";
+    const currentText = currentByName.get(layer) ?? "";
+    const previousLines = previousText.split("\n").map((line) => line.trim()).filter(Boolean);
+    const currentLines = currentText.split("\n").map((line) => line.trim()).filter(Boolean);
+    const previousSet = new Set(previousLines);
+    const currentSet = new Set(currentLines);
+    return {
+      layer,
+      previousPreview: linePreview(previousText),
+      currentPreview: linePreview(currentText),
+      addedLines: currentLines.filter((line) => !previousSet.has(line)).slice(0, 12),
+      removedLines: previousLines.filter((line) => !currentSet.has(line)).slice(0, 12),
+    };
+  });
 };
 
 const termProbe = (terms: ExpectedTerm[] = [], sourceText: string, targetText: string): TermProbeResult[] =>
@@ -570,6 +607,7 @@ const cycleMetrics = (
   previous: CompactorResult | undefined,
   prompt: PromptSnapshot,
   previousPrompt: PromptSnapshot | undefined,
+  includeDiagnostics: boolean,
 ): CycleMetrics => {
   const sourceText = sourceTextOf(sourceMessages);
   const activeText = result.activePromptState;
@@ -631,6 +669,9 @@ const cycleMetrics = (
     layerSizes: Object.fromEntries(result.layers.map((layer) => [layer.name, layer.text.length])),
     promptLayerSizes: Object.fromEntries(prompt.layers.map((layer) => [layer.name, layer.text.length])),
     promptLayerTokenDeltas: promptChanged.promptLayerTokenDeltas,
+    ...(includeDiagnostics && promptChanged.changedPromptLayers.length > 0
+      ? { promptLayerDiffs: changedPromptLayerDiffs(previousPrompt, prompt, promptChanged.changedPromptLayers) }
+      : {}),
   };
 };
 
@@ -691,6 +732,7 @@ export const failedGatesOf = (cycle: CycleMetrics): string[] => {
 export const runOfflineCompactionBenchmark = (options: {
   cases?: CompactionBenchmarkCase[];
   compactors?: OfflineCompactor[];
+  includeDiagnostics?: boolean;
 } = {}): BenchmarkRunResult => {
   const cases = options.cases ?? syntheticCompactionCases;
   const compactors = options.compactors ?? offlineCompactors;
@@ -711,7 +753,7 @@ export const runOfflineCompactionBenchmark = (options: {
           cycle: index + 1,
         });
         const prompt = simulatedPromptOf(result, sourceMessages);
-        cycles.push(cycleMetrics(testCase, compactor, index + 1, point, sourceMessages, result, previous, prompt, previousPrompt));
+        cycles.push(cycleMetrics(testCase, compactor, index + 1, point, sourceMessages, result, previous, prompt, previousPrompt, Boolean(options.includeDiagnostics)));
         previous = result;
         previousPrompt = prompt;
         previousPoint = point;

--- a/bench/compaction/offline-runner.ts
+++ b/bench/compaction/offline-runner.ts
@@ -441,6 +441,21 @@ const makeLayeredCheckpoint = (messages: Message[]): LayerSnapshot[] => {
 const renderLayers = (layers: LayerSnapshot[]): string =>
   layers.map((layer) => `[${layer.name}]\n${layer.text}`).join("\n\n");
 
+const splitCurrentSections = (current: string): LayerSnapshot[] => {
+  const headers = [...current.matchAll(/^\[(.+?)\]/gm)];
+  if (headers.length === 0) return [{ name: "Pi VCC Current Sections", role: "current", text: current }];
+  return headers.map((header, index) => {
+    const start = header.index ?? 0;
+    const end = headers[index + 1]?.index ?? current.length;
+    const title = header[1];
+    return {
+      name: `Pi VCC ${title}`,
+      role: "current" as const,
+      text: current.slice(start, end).trimEnd(),
+    };
+  });
+};
+
 const splitPiVccSummary = (summary: string): LayerSnapshot[] => {
   if (!summary.trim()) return [];
   const parts = summary.split(SEPARATOR).map((part) => part.trim()).filter(Boolean);
@@ -453,7 +468,7 @@ const splitPiVccSummary = (summary: string): LayerSnapshot[] => {
   const current = bodyParts[0] ?? "";
   const history = bodyParts.slice(1).join(SEPARATOR);
 
-  if (current) layers.push({ name: "Pi VCC Current Sections", role: "current", text: current });
+  if (current) layers.push(...splitCurrentSections(current));
   if (history) layers.push({ name: "Pi VCC Brief Transcript", role: "history", text: history });
   if (hasRecallNote) layers.push({ name: "Pi VCC Recall Note", role: "recall", text: RECALL_NOTE });
   return layers.length > 0 ? layers : [{ name: "Pi VCC Current Sections", role: "current", text: summary }];

--- a/bench/compaction/offline-runner.ts
+++ b/bench/compaction/offline-runner.ts
@@ -1,0 +1,610 @@
+import { performance } from "node:perf_hooks";
+import type { Message } from "@mariozechner/pi-ai";
+import { compile } from "../../src/core/summarize";
+import { buildSections } from "../../src/core/build-sections";
+import { RECALL_NOTE } from "../../src/core/format";
+import { normalize } from "../../src/core/normalize";
+import { renderMessage } from "../../src/core/render-entries";
+import { clip, textOf } from "../../src/core/content";
+import { summarizeToolResultForPrompt } from "../../src/core/tool-result-summary";
+import { syntheticCompactionCases, type CompactionBenchmarkCase, type ExpectedTerm } from "./synthetic-cases";
+
+export type LayerRole = "static" | "current" | "history" | "recall";
+
+export interface LayerSnapshot {
+  name: string;
+  role: LayerRole;
+  text: string;
+}
+
+export interface RecallDocument {
+  id: string;
+  text: string;
+}
+
+export interface CompactorResult {
+  activePromptState: string;
+  layers: LayerSnapshot[];
+  recallCorpus: RecallDocument[];
+  stats: {
+    compactionMs: number;
+    estimatedInputTokens?: number;
+    estimatedOutputTokens?: number;
+  };
+}
+
+export interface CompactorContext {
+  /** Messages newly summarized in this compaction cycle. */
+  messages: Message[];
+  /** Full replay prefix available up to this compaction point. */
+  allMessages: Message[];
+  previous?: CompactorResult;
+  cycle: number;
+}
+
+export interface OfflineCompactor {
+  name: string;
+  compact(context: CompactorContext): CompactorResult;
+}
+
+export interface TermProbeResult {
+  label: string;
+  term: string;
+  applicable: boolean;
+  found: boolean;
+}
+
+export interface RecallProbeResult extends TermProbeResult {
+  query: string;
+  topHitIds: string[];
+}
+
+export interface CycleMetrics {
+  caseId: string;
+  compactor: string;
+  cycle: number;
+  compactionPoint: number;
+  activeChars: number;
+  activeTokensEst: number;
+  currentChars: number;
+  currentTokensEst: number;
+  compactionMs: number;
+  lcpTokensWithPrevious: number | null;
+  lcpTokenRatioWithPrevious: number | null;
+  firstChangedLayer: string | null;
+  changedLayers: string[];
+  activeTermRecall: number | null;
+  currentTermRecall: number | null;
+  recallTermHitRate: number | null;
+  continuationTermRecall: number | null;
+  forbiddenLeakCount: number;
+  forbiddenCurrentLeakCount: number;
+  activeAbsentLeakCount: number;
+  missingActiveTerms: string[];
+  missingCurrentTerms: string[];
+  missingRecallTerms: string[];
+  leakedForbiddenTerms: string[];
+  leakedForbiddenCurrentTerms: string[];
+  leakedActiveAbsentTerms: string[];
+  layerSizes: Record<string, number>;
+}
+
+export interface BenchmarkRunResult {
+  cycles: CycleMetrics[];
+  aggregate: Record<string, {
+    cycles: number;
+    meanActiveTokensEst: number;
+    meanCurrentTokensEst: number;
+    meanCompactionMs: number;
+    meanActiveTermRecall: number | null;
+    meanCurrentTermRecall: number | null;
+    meanRecallTermHitRate: number | null;
+    meanContinuationTermRecall: number | null;
+    totalForbiddenLeaks: number;
+    totalForbiddenCurrentLeaks: number;
+    totalActiveAbsentLeaks: number;
+    meanLcpTokenRatio: number | null;
+  }>;
+}
+
+const SEPARATOR = "\n\n---\n\n";
+
+const tokenize = (text: string): string[] =>
+  text.match(/[\p{L}\p{N}_./:-]+|[^\s]/gu) ?? [];
+
+const estimateTokens = (text: string): number => Math.ceil(text.length / 4);
+
+const lowerIncludes = (haystack: string, needle: string): boolean =>
+  haystack.toLowerCase().includes(needle.toLowerCase());
+
+const lcpTokens = (a: string, b: string): number => {
+  const aa = tokenize(a);
+  const bb = tokenize(b);
+  const limit = Math.min(aa.length, bb.length);
+  let i = 0;
+  while (i < limit && aa[i] === bb[i]) i += 1;
+  return i;
+};
+
+const renderedDocuments = (messages: Message[]): RecallDocument[] =>
+  messages.map((message, index) => {
+    const rendered = renderMessage(message, index, true);
+    return {
+      id: `${index}:${rendered.role}`,
+      text: `#${index} [${rendered.role}] ${rendered.summary}`,
+    };
+  });
+
+const sourceTextOf = (messages: Message[]): string =>
+  renderedDocuments(messages).map((doc) => doc.text).join("\n");
+
+const textForRoles = (result: CompactorResult, roles: LayerRole[]): string => {
+  const selected = result.layers.filter((layer) => roles.includes(layer.role));
+  if (selected.length === 0) return "";
+  return selected.map((layer) => `[${layer.name}]\n${layer.text}`).join("\n\n");
+};
+
+const termProbe = (terms: ExpectedTerm[] = [], sourceText: string, targetText: string): TermProbeResult[] =>
+  terms.map((term) => {
+    const applicable = lowerIncludes(sourceText, term.term);
+    return {
+      label: term.label,
+      term: term.term,
+      applicable,
+      found: applicable && lowerIncludes(targetText, term.term),
+    };
+  });
+
+const leakProbe = (terms: ExpectedTerm[] = [], sourceText: string, targetText: string): TermProbeResult[] =>
+  terms.map((term) => {
+    const applicable = lowerIncludes(sourceText, term.term);
+    return {
+      label: term.label,
+      term: term.term,
+      applicable,
+      found: applicable && lowerIncludes(targetText, term.term),
+    };
+  });
+
+const scoreDocument = (doc: string, query: string): number => {
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const hay = doc.toLowerCase();
+  return terms.reduce((score, term) => score + (hay.includes(term) ? 1 : 0), 0);
+};
+
+const recallProbe = (
+  terms: ExpectedTerm[] = [],
+  sourceText: string,
+  corpus: RecallDocument[],
+): RecallProbeResult[] =>
+  terms.map((term) => {
+    const query = term.query ?? term.term;
+    const applicable = lowerIncludes(sourceText, term.term);
+    const ranked = corpus
+      .map((doc) => ({ doc, score: scoreDocument(doc.text, query) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 5);
+    const found = applicable && ranked.some((entry) => lowerIncludes(entry.doc.text, term.term));
+    return {
+      label: term.label,
+      term: term.term,
+      query,
+      applicable,
+      found,
+      topHitIds: ranked.map((entry) => entry.doc.id),
+    };
+  });
+
+const ratioOf = (probes: TermProbeResult[]): number | null => {
+  const applicable = probes.filter((probe) => probe.applicable);
+  if (applicable.length === 0) return null;
+  return applicable.filter((probe) => probe.found).length / applicable.length;
+};
+
+const summarizeChangedLayers = (
+  previous: CompactorResult | undefined,
+  current: CompactorResult,
+): { firstChangedLayer: string | null; changedLayers: string[] } => {
+  if (!previous) return { firstChangedLayer: null, changedLayers: [] };
+  const prevByName = new Map(previous.layers.map((layer) => [layer.name, layer.text]));
+  const changedLayers = current.layers
+    .filter((layer) => prevByName.get(layer.name) !== layer.text)
+    .map((layer) => layer.name);
+  return {
+    firstChangedLayer: changedLayers[0] ?? null,
+    changedLayers,
+  };
+};
+
+const lines = (items: string[]): string =>
+  items.length === 0 ? "- (none)" : items.map((item) => `- ${item}`).join("\n");
+
+const stableUnique = (items: string[], limit = 12): string[] =>
+  [...new Set(items.map((item) => item.trim()).filter(Boolean))].sort().slice(0, limit);
+
+const regexTerms = (text: string, regex: RegExp, limit = 12): string[] =>
+  stableUnique([...text.matchAll(regex)].map((match) => match[0]), limit);
+
+const recentHumanLines = (messages: Message[], maxLines = 10): string[] => {
+  const out: string[] = [];
+  for (const message of messages.slice(-8)) {
+    if (message.role !== "user" && message.role !== "assistant") continue;
+    const text = textOf(message.content);
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (/\b(next step|current blocker|blocker update|continue|correction|hard constraint|decision)\b/i.test(trimmed)) {
+        out.push(trimmed);
+      }
+    }
+  }
+  return out.slice(-maxLines);
+};
+
+const bulkyPointers = (messages: Message[]): string[] => {
+  const out: string[] = [];
+  messages.forEach((message, index) => {
+    if (message.role !== "toolResult") return;
+    const text = textOf(message.content);
+    if (text.length < 500) return;
+    const paths = regexTerms(text, /\/(?:tmp|var|home|workspace)\/[\w./-]+/g, 4);
+    const signatures = regexTerms(text, /\b[A-Z][A-Z0-9_]{4,}\b(?:\s+request_id=[\w-]+)?/g, 4);
+    const details = [...paths, ...signatures].join("; ") || clip(text, 120);
+    out.push(`#${index} ${message.toolName}: ${details}`);
+  });
+  return out;
+};
+
+const extractDurableMemory = (messages: Message[]): string[] => {
+  const memory: string[] = [];
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    const text = textOf(message.content);
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (/\b(correction|never|always|prefer|use npm test|node --test)\b/i.test(trimmed)) {
+        memory.push(trimmed);
+      }
+    }
+  }
+
+  const hasNeverYarn = memory.some((item) => /never use yarn/i.test(item));
+  const filtered = hasNeverYarn
+    ? memory.filter((item) => !/prefer yarn test/i.test(item))
+    : memory;
+  return stableUnique(filtered, 10);
+};
+
+const makeLayeredCheckpoint = (messages: Message[]): LayerSnapshot[] => {
+  const blocks = normalize(messages);
+  const data = buildSections({ blocks });
+  const source = sourceTextOf(messages);
+  const paths = regexTerms(source, /(?:^|[\s"'`])(?:\.?\/?[\w.-]+\/)+[\w.-]+(?:\.[\w.-]+)?/g)
+    .map((path) => path.trim().replace(/^["'`\s]+/, ""));
+  const identifiers = regexTerms(source, /\b(?:ERR|CACHE|CRITICAL|req|spn|cache|commit)[\w:-]{3,}\b/g, 16);
+  const commits = regexTerms(source, /\b[0-9a-f]{7,40}\b/g, 8);
+
+  const stableCheckpoint = [
+    "Objective:",
+    lines(data.sessionGoal),
+    "Hard constraints and decisions:",
+    lines(regexTerms(source, /(?:Hard constraint|Decision):[^\n]+/gi, 8)),
+    "Active files and artifacts:",
+    lines(stableUnique([...data.filesAndChanges, ...paths], 16)),
+    "Identifiers and evidence handles:",
+    lines(stableUnique([...identifiers, ...commits], 20)),
+  ].join("\n");
+
+  const volatileState = [
+    "Outstanding context:",
+    lines(data.outstandingContext),
+    "Recent continuation cues:",
+    lines(recentHumanLines(messages)),
+  ].join("\n");
+
+  const transcriptLines = data.briefTranscript.split("\n").filter(Boolean).slice(-50).join("\n");
+  const rawTail = messages.slice(-2).map((message, offset) => {
+    const index = messages.length - 2 + offset;
+    const rendered = renderMessage(message, index, true);
+    if (message.role === "toolResult") {
+      return `#${index} [${rendered.role}] ${summarizeToolResultForPrompt(textOf(message.content))}`;
+    }
+    return `#${index} [${rendered.role}] ${clip(rendered.summary, 700)}`;
+  }).join("\n");
+
+  const recallPointers = bulkyPointers(messages);
+
+  return [
+    {
+      name: "Layer 0 Static Prefix Contract",
+      role: "static",
+      text: [
+        "Compacted state schema v1.",
+        "Keep section names and order stable.",
+        "Stable facts appear before volatile facts.",
+      ].join("\n"),
+    },
+    {
+      name: "Layer 1 Durable Memory",
+      role: "current",
+      text: lines(extractDurableMemory(messages)),
+    },
+    {
+      name: "Layer 2A Stable Checkpoint",
+      role: "current",
+      text: stableCheckpoint,
+    },
+    {
+      name: "Layer 2B Volatile State",
+      role: "current",
+      text: volatileState,
+    },
+    {
+      name: "Layer 3 Rolling Brief Transcript",
+      role: "history",
+      text: transcriptLines || "- (none)",
+    },
+    {
+      name: "Layer 4 Raw Recent Tail",
+      role: "history",
+      text: rawTail || "- (none)",
+    },
+    {
+      name: "Layer 5 Recall Pointers",
+      role: "recall",
+      text: lines(recallPointers),
+    },
+  ];
+};
+
+const renderLayers = (layers: LayerSnapshot[]): string =>
+  layers.map((layer) => `[${layer.name}]\n${layer.text}`).join("\n\n");
+
+const splitPiVccSummary = (summary: string): LayerSnapshot[] => {
+  if (!summary.trim()) return [];
+  const parts = summary.split(SEPARATOR).map((part) => part.trim()).filter(Boolean);
+  if (parts.length === 0) return [{ name: "Pi VCC Current Sections", role: "current", text: summary }];
+
+  const layers: LayerSnapshot[] = [];
+  const last = parts[parts.length - 1];
+  const hasRecallNote = last === RECALL_NOTE;
+  const bodyParts = hasRecallNote ? parts.slice(0, -1) : parts;
+  const current = bodyParts[0] ?? "";
+  const history = bodyParts.slice(1).join(SEPARATOR);
+
+  if (current) layers.push({ name: "Pi VCC Current Sections", role: "current", text: current });
+  if (history) layers.push({ name: "Pi VCC Brief Transcript", role: "history", text: history });
+  if (hasRecallNote) layers.push({ name: "Pi VCC Recall Note", role: "recall", text: RECALL_NOTE });
+  return layers.length > 0 ? layers : [{ name: "Pi VCC Current Sections", role: "current", text: summary }];
+};
+
+export const offlineCompactors: OfflineCompactor[] = [
+  {
+    name: "pi-vcc",
+    compact: ({ messages, allMessages, previous }) => {
+      const start = performance.now();
+      const summary = compile({ messages, previousSummary: previous?.activePromptState });
+      const elapsed = performance.now() - start;
+      return {
+        activePromptState: summary,
+        layers: splitPiVccSummary(summary),
+        recallCorpus: renderedDocuments(allMessages),
+        stats: {
+          compactionMs: elapsed,
+          estimatedInputTokens: estimateTokens(sourceTextOf(messages)),
+          estimatedOutputTokens: estimateTokens(summary),
+        },
+      };
+    },
+  },
+  {
+    name: "full-rewrite-checkpoint",
+    compact: ({ allMessages }) => {
+      const start = performance.now();
+      const data = buildSections({ blocks: normalize(allMessages) });
+      const current = [
+        "Objective:",
+        lines(data.sessionGoal),
+        "Files and artifacts:",
+        lines(data.filesAndChanges),
+        "Outstanding context:",
+        lines(data.outstandingContext),
+        "User preferences:",
+        lines(data.userPreferences),
+      ].join("\n");
+      const history = data.briefTranscript || "- (none)";
+      const layers: LayerSnapshot[] = [
+        { name: "Regenerated Current Checkpoint", role: "current", text: current },
+        { name: "Regenerated Transcript", role: "history", text: history },
+      ];
+      const summary = renderLayers(layers);
+      const elapsed = performance.now() - start;
+      return {
+        activePromptState: summary,
+        layers,
+        recallCorpus: [],
+        stats: {
+          compactionMs: elapsed,
+          estimatedInputTokens: estimateTokens(sourceTextOf(allMessages)),
+          estimatedOutputTokens: estimateTokens(summary),
+        },
+      };
+    },
+  },
+  {
+    name: "cache-aware-layered",
+    compact: ({ allMessages }) => {
+      const start = performance.now();
+      const layers = makeLayeredCheckpoint(allMessages);
+      const activePromptState = renderLayers(layers);
+      const elapsed = performance.now() - start;
+      return {
+        activePromptState,
+        layers,
+        recallCorpus: renderedDocuments(allMessages),
+        stats: {
+          compactionMs: elapsed,
+          estimatedInputTokens: estimateTokens(sourceTextOf(allMessages)),
+          estimatedOutputTokens: estimateTokens(activePromptState),
+        },
+      };
+    },
+  },
+];
+
+const forbiddenLeaksOf = (
+  terms: Array<ExpectedTerm & { afterTerm?: string }> = [],
+  sourceText: string,
+  targetText: string,
+): string[] =>
+  terms
+    .filter((term) => {
+      const enforce = !term.afterTerm || lowerIncludes(sourceText, term.afterTerm);
+      return enforce && lowerIncludes(targetText, term.term);
+    })
+    .map((term) => term.label);
+
+const cycleMetrics = (
+  testCase: CompactionBenchmarkCase,
+  compactor: OfflineCompactor,
+  cycle: number,
+  compactionPoint: number,
+  sourceMessages: Message[],
+  result: CompactorResult,
+  previous: CompactorResult | undefined,
+): CycleMetrics => {
+  const sourceText = sourceTextOf(sourceMessages);
+  const activeText = result.activePromptState;
+  const currentText = textForRoles(result, ["current"]);
+  const activeProbes = termProbe(testCase.gold.activeTerms, sourceText, activeText);
+  const currentProbes = termProbe(testCase.gold.currentTerms ?? [], sourceText, currentText);
+  const recallProbes = recallProbe(testCase.gold.recallTerms, sourceText, result.recallCorpus);
+  const continuationProbes = termProbe(testCase.gold.continuationTerms ?? [], sourceText, activeText);
+  const activeAbsentLeaks = leakProbe(testCase.gold.activeAbsentTerms ?? [], sourceText, activeText)
+    .filter((probe) => probe.applicable && probe.found);
+  const leakedForbiddenTerms = forbiddenLeaksOf(testCase.gold.forbiddenTerms, sourceText, activeText);
+  const leakedForbiddenCurrentTerms = forbiddenLeaksOf(testCase.gold.forbiddenCurrentTerms, sourceText, currentText);
+  const changed = summarizeChangedLayers(previous, result);
+  const previousTokens = previous ? tokenize(previous.activePromptState).length : 0;
+  const currentTokens = tokenize(activeText).length;
+  const lcp = previous ? lcpTokens(previous.activePromptState, activeText) : null;
+  const denominator = Math.min(previousTokens, currentTokens);
+
+  return {
+    caseId: testCase.id,
+    compactor: compactor.name,
+    cycle,
+    compactionPoint,
+    activeChars: activeText.length,
+    activeTokensEst: estimateTokens(activeText),
+    currentChars: currentText.length,
+    currentTokensEst: estimateTokens(currentText),
+    compactionMs: Number(result.stats.compactionMs.toFixed(3)),
+    lcpTokensWithPrevious: lcp,
+    lcpTokenRatioWithPrevious: lcp === null || denominator === 0 ? null : Number((lcp / denominator).toFixed(4)),
+    firstChangedLayer: changed.firstChangedLayer,
+    changedLayers: changed.changedLayers,
+    activeTermRecall: ratioOf(activeProbes),
+    currentTermRecall: ratioOf(currentProbes),
+    recallTermHitRate: ratioOf(recallProbes),
+    continuationTermRecall: ratioOf(continuationProbes),
+    forbiddenLeakCount: leakedForbiddenTerms.length,
+    forbiddenCurrentLeakCount: leakedForbiddenCurrentTerms.length,
+    activeAbsentLeakCount: activeAbsentLeaks.length,
+    missingActiveTerms: activeProbes.filter((probe) => probe.applicable && !probe.found).map((probe) => probe.label),
+    missingCurrentTerms: currentProbes.filter((probe) => probe.applicable && !probe.found).map((probe) => probe.label),
+    missingRecallTerms: recallProbes.filter((probe) => probe.applicable && !probe.found).map((probe) => probe.label),
+    leakedForbiddenTerms,
+    leakedForbiddenCurrentTerms,
+    leakedActiveAbsentTerms: activeAbsentLeaks.map((term) => term.label),
+    layerSizes: Object.fromEntries(result.layers.map((layer) => [layer.name, layer.text.length])),
+  };
+};
+
+const mean = (values: number[]): number | null => {
+  if (values.length === 0) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+};
+
+const meanRounded = (values: number[]): number =>
+  Number((values.reduce((sum, value) => sum + value, 0) / Math.max(values.length, 1)).toFixed(3));
+
+const aggregate = (cycles: CycleMetrics[]): BenchmarkRunResult["aggregate"] => {
+  const byCompactor = new Map<string, CycleMetrics[]>();
+  for (const cycle of cycles) {
+    const bucket = byCompactor.get(cycle.compactor) ?? [];
+    bucket.push(cycle);
+    byCompactor.set(cycle.compactor, bucket);
+  }
+
+  return Object.fromEntries([...byCompactor].map(([name, items]) => {
+    const nullableMean = (selector: (item: CycleMetrics) => number | null): number | null => {
+      const values = items.map(selector).filter((value): value is number => value !== null);
+      const result = mean(values);
+      return result === null ? null : Number(result.toFixed(4));
+    };
+    return [name, {
+      cycles: items.length,
+      meanActiveTokensEst: meanRounded(items.map((item) => item.activeTokensEst)),
+      meanCurrentTokensEst: meanRounded(items.map((item) => item.currentTokensEst)),
+      meanCompactionMs: meanRounded(items.map((item) => item.compactionMs)),
+      meanActiveTermRecall: nullableMean((item) => item.activeTermRecall),
+      meanCurrentTermRecall: nullableMean((item) => item.currentTermRecall),
+      meanRecallTermHitRate: nullableMean((item) => item.recallTermHitRate),
+      meanContinuationTermRecall: nullableMean((item) => item.continuationTermRecall),
+      totalForbiddenLeaks: items.reduce((sum, item) => sum + item.forbiddenLeakCount, 0),
+      totalForbiddenCurrentLeaks: items.reduce((sum, item) => sum + item.forbiddenCurrentLeakCount, 0),
+      totalActiveAbsentLeaks: items.reduce((sum, item) => sum + item.activeAbsentLeakCount, 0),
+      meanLcpTokenRatio: nullableMean((item) => item.lcpTokenRatioWithPrevious),
+    }];
+  }));
+};
+
+export const failedGatesOf = (cycle: CycleMetrics): string[] => {
+  const failures: string[] = [];
+  if (cycle.activeTermRecall !== null && cycle.activeTermRecall < 1) failures.push("active-term-recall");
+  if (cycle.currentTermRecall !== null && cycle.currentTermRecall < 1) failures.push("current-term-recall");
+  if (cycle.recallTermHitRate !== null && cycle.recallTermHitRate < 1) failures.push("recall-hit-rate");
+  if (cycle.continuationTermRecall !== null && cycle.continuationTermRecall < 1) failures.push("continuation-term-recall");
+  if (cycle.forbiddenLeakCount > 0) failures.push("forbidden-active-leak");
+  if (cycle.forbiddenCurrentLeakCount > 0) failures.push("forbidden-current-leak");
+  if (cycle.activeAbsentLeakCount > 0) failures.push("active-absent-leak");
+  return failures;
+};
+
+export const runOfflineCompactionBenchmark = (options: {
+  cases?: CompactionBenchmarkCase[];
+  compactors?: OfflineCompactor[];
+} = {}): BenchmarkRunResult => {
+  const cases = options.cases ?? syntheticCompactionCases;
+  const compactors = options.compactors ?? offlineCompactors;
+  const cycles: CycleMetrics[] = [];
+
+  for (const testCase of cases) {
+    for (const compactor of compactors) {
+      let previous: CompactorResult | undefined;
+      let previousPoint = 0;
+      testCase.compactionPoints.forEach((point, index) => {
+        const sourceMessages = testCase.messages.slice(0, point);
+        const cycleMessages = testCase.messages.slice(previousPoint, point);
+        const result = compactor.compact({
+          messages: cycleMessages,
+          allMessages: sourceMessages,
+          previous,
+          cycle: index + 1,
+        });
+        cycles.push(cycleMetrics(testCase, compactor, index + 1, point, sourceMessages, result, previous));
+        previous = result;
+        previousPoint = point;
+      });
+    }
+  }
+
+  return { cycles, aggregate: aggregate(cycles) };
+};

--- a/bench/compaction/offline-runner.ts
+++ b/bench/compaction/offline-runner.ts
@@ -22,6 +22,16 @@ export interface RecallDocument {
   text: string;
 }
 
+export interface PromptLayerSnapshot {
+  name: string;
+  text: string;
+}
+
+export interface PromptSnapshot {
+  text: string;
+  layers: PromptLayerSnapshot[];
+}
+
 export interface CompactorResult {
   activePromptState: string;
   layers: LayerSnapshot[];
@@ -68,11 +78,18 @@ export interface CycleMetrics {
   activeTokensEst: number;
   currentChars: number;
   currentTokensEst: number;
+  fullPromptChars: number;
+  fullPromptTokensEst: number;
   compactionMs: number;
   lcpTokensWithPrevious: number | null;
   lcpTokenRatioWithPrevious: number | null;
   firstChangedLayer: string | null;
   changedLayers: string[];
+  fullPromptLcpTokensWithPrevious: number | null;
+  fullPromptLcpTokenRatioWithPrevious: number | null;
+  firstChangedPromptLayer: string | null;
+  changedPromptLayers: string[];
+  stablePrefixTokens: number | null;
   activeTermRecall: number | null;
   currentTermRecall: number | null;
   recallTermHitRate: number | null;
@@ -87,6 +104,8 @@ export interface CycleMetrics {
   leakedForbiddenCurrentTerms: string[];
   leakedActiveAbsentTerms: string[];
   layerSizes: Record<string, number>;
+  promptLayerSizes: Record<string, number>;
+  promptLayerTokenDeltas: Record<string, number>;
 }
 
 export interface BenchmarkRunResult {
@@ -95,6 +114,7 @@ export interface BenchmarkRunResult {
     cycles: number;
     meanActiveTokensEst: number;
     meanCurrentTokensEst: number;
+    meanFullPromptTokensEst: number;
     meanCompactionMs: number;
     meanActiveTermRecall: number | null;
     meanCurrentTermRecall: number | null;
@@ -104,6 +124,8 @@ export interface BenchmarkRunResult {
     totalForbiddenCurrentLeaks: number;
     totalActiveAbsentLeaks: number;
     meanLcpTokenRatio: number | null;
+    meanFullPromptLcpTokenRatio: number | null;
+    meanStablePrefixTokens: number | null;
   }>;
 }
 
@@ -142,6 +164,59 @@ const textForRoles = (result: CompactorResult, roles: LayerRole[]): string => {
   const selected = result.layers.filter((layer) => roles.includes(layer.role));
   if (selected.length === 0) return "";
   return selected.map((layer) => `[${layer.name}]\n${layer.text}`).join("\n\n");
+};
+
+const renderPromptLayers = (layers: PromptLayerSnapshot[]): string =>
+  layers.map((layer) => `[${layer.name}]\n${layer.text}`).join("\n\n");
+
+const simulatedPromptOf = (result: CompactorResult, sourceMessages: Message[]): PromptSnapshot => {
+  const recentTail = renderedDocuments(sourceMessages.slice(-2))
+    .map((doc) => doc.text)
+    .join("\n");
+  const layers: PromptLayerSnapshot[] = [
+    {
+      name: "Provider Prefix",
+      text: [
+        "system: You are an expert coding assistant operating inside Pi.",
+        "format: preserve compacted state sections and use recall before redoing prior work.",
+      ].join("\n"),
+    },
+    {
+      name: "Tool Definitions",
+      text: "tools: read, bash, edit, write, vcc_recall",
+    },
+    {
+      name: "Project Instructions",
+      text: "project: follow local guidance, validate before claiming completion, avoid destructive actions.",
+    },
+    ...result.layers.map((layer) => ({ name: layer.name, text: layer.text })),
+    {
+      name: "Kept Raw Tail",
+      text: recentTail || "- (none)",
+    },
+  ];
+  return { layers, text: renderPromptLayers(layers) };
+};
+
+const summarizeChangedPromptLayers = (
+  previous: PromptSnapshot | undefined,
+  current: PromptSnapshot,
+): { firstChangedPromptLayer: string | null; changedPromptLayers: string[]; promptLayerTokenDeltas: Record<string, number> } => {
+  if (!previous) return { firstChangedPromptLayer: null, changedPromptLayers: [], promptLayerTokenDeltas: {} };
+  const prevByName = new Map(previous.layers.map((layer) => [layer.name, layer.text]));
+  const changedPromptLayers = current.layers
+    .filter((layer) => prevByName.get(layer.name) !== layer.text)
+    .map((layer) => layer.name);
+  const promptLayerTokenDeltas = Object.fromEntries(current.layers.map((layer) => {
+    const previousTokens = tokenize(prevByName.get(layer.name) ?? "").length;
+    const currentTokens = tokenize(layer.text).length;
+    return [layer.name, currentTokens - previousTokens];
+  }));
+  return {
+    firstChangedPromptLayer: changedPromptLayers[0] ?? null,
+    changedPromptLayers,
+    promptLayerTokenDeltas,
+  };
 };
 
 const termProbe = (terms: ExpectedTerm[] = [], sourceText: string, targetText: string): TermProbeResult[] =>
@@ -478,6 +553,8 @@ const cycleMetrics = (
   sourceMessages: Message[],
   result: CompactorResult,
   previous: CompactorResult | undefined,
+  prompt: PromptSnapshot,
+  previousPrompt: PromptSnapshot | undefined,
 ): CycleMetrics => {
   const sourceText = sourceTextOf(sourceMessages);
   const activeText = result.activePromptState;
@@ -495,6 +572,12 @@ const cycleMetrics = (
   const currentTokens = tokenize(activeText).length;
   const lcp = previous ? lcpTokens(previous.activePromptState, activeText) : null;
   const denominator = Math.min(previousTokens, currentTokens);
+  const promptChanged = summarizeChangedPromptLayers(previousPrompt, prompt);
+  const previousPromptTokens = previousPrompt ? tokenize(previousPrompt.text).length : 0;
+  const currentPromptTokens = tokenize(prompt.text).length;
+  const fullPromptLcp = previousPrompt ? lcpTokens(previousPrompt.text, prompt.text) : null;
+  const fullPromptDenominator = Math.min(previousPromptTokens, currentPromptTokens);
+  const stablePrefixTokens = previousPrompt ? fullPromptLcp : null;
 
   return {
     caseId: testCase.id,
@@ -505,11 +588,18 @@ const cycleMetrics = (
     activeTokensEst: estimateTokens(activeText),
     currentChars: currentText.length,
     currentTokensEst: estimateTokens(currentText),
+    fullPromptChars: prompt.text.length,
+    fullPromptTokensEst: estimateTokens(prompt.text),
     compactionMs: Number(result.stats.compactionMs.toFixed(3)),
     lcpTokensWithPrevious: lcp,
     lcpTokenRatioWithPrevious: lcp === null || denominator === 0 ? null : Number((lcp / denominator).toFixed(4)),
     firstChangedLayer: changed.firstChangedLayer,
     changedLayers: changed.changedLayers,
+    fullPromptLcpTokensWithPrevious: fullPromptLcp,
+    fullPromptLcpTokenRatioWithPrevious: fullPromptLcp === null || fullPromptDenominator === 0 ? null : Number((fullPromptLcp / fullPromptDenominator).toFixed(4)),
+    firstChangedPromptLayer: promptChanged.firstChangedPromptLayer,
+    changedPromptLayers: promptChanged.changedPromptLayers,
+    stablePrefixTokens,
     activeTermRecall: ratioOf(activeProbes),
     currentTermRecall: ratioOf(currentProbes),
     recallTermHitRate: ratioOf(recallProbes),
@@ -524,6 +614,8 @@ const cycleMetrics = (
     leakedForbiddenCurrentTerms,
     leakedActiveAbsentTerms: activeAbsentLeaks.map((term) => term.label),
     layerSizes: Object.fromEntries(result.layers.map((layer) => [layer.name, layer.text.length])),
+    promptLayerSizes: Object.fromEntries(prompt.layers.map((layer) => [layer.name, layer.text.length])),
+    promptLayerTokenDeltas: promptChanged.promptLayerTokenDeltas,
   };
 };
 
@@ -553,6 +645,7 @@ const aggregate = (cycles: CycleMetrics[]): BenchmarkRunResult["aggregate"] => {
       cycles: items.length,
       meanActiveTokensEst: meanRounded(items.map((item) => item.activeTokensEst)),
       meanCurrentTokensEst: meanRounded(items.map((item) => item.currentTokensEst)),
+      meanFullPromptTokensEst: meanRounded(items.map((item) => item.fullPromptTokensEst)),
       meanCompactionMs: meanRounded(items.map((item) => item.compactionMs)),
       meanActiveTermRecall: nullableMean((item) => item.activeTermRecall),
       meanCurrentTermRecall: nullableMean((item) => item.currentTermRecall),
@@ -562,6 +655,8 @@ const aggregate = (cycles: CycleMetrics[]): BenchmarkRunResult["aggregate"] => {
       totalForbiddenCurrentLeaks: items.reduce((sum, item) => sum + item.forbiddenCurrentLeakCount, 0),
       totalActiveAbsentLeaks: items.reduce((sum, item) => sum + item.activeAbsentLeakCount, 0),
       meanLcpTokenRatio: nullableMean((item) => item.lcpTokenRatioWithPrevious),
+      meanFullPromptLcpTokenRatio: nullableMean((item) => item.fullPromptLcpTokenRatioWithPrevious),
+      meanStablePrefixTokens: nullableMean((item) => item.stablePrefixTokens),
     }];
   }));
 };
@@ -589,6 +684,7 @@ export const runOfflineCompactionBenchmark = (options: {
   for (const testCase of cases) {
     for (const compactor of compactors) {
       let previous: CompactorResult | undefined;
+      let previousPrompt: PromptSnapshot | undefined;
       let previousPoint = 0;
       testCase.compactionPoints.forEach((point, index) => {
         const sourceMessages = testCase.messages.slice(0, point);
@@ -599,8 +695,10 @@ export const runOfflineCompactionBenchmark = (options: {
           previous,
           cycle: index + 1,
         });
-        cycles.push(cycleMetrics(testCase, compactor, index + 1, point, sourceMessages, result, previous));
+        const prompt = simulatedPromptOf(result, sourceMessages);
+        cycles.push(cycleMetrics(testCase, compactor, index + 1, point, sourceMessages, result, previous, prompt, previousPrompt));
         previous = result;
+        previousPrompt = prompt;
         previousPoint = point;
       });
     }

--- a/bench/compaction/offline-runner.ts
+++ b/bench/compaction/offline-runner.ts
@@ -729,6 +729,24 @@ export const failedGatesOf = (cycle: CycleMetrics): string[] => {
   return failures;
 };
 
+const CACHE_STABILITY_CASES = new Set(["cache-bust-volatile-next-step"]);
+const EARLY_VOLATILE_LAYERS = new Set([
+  "Pi VCC Session Goal",
+  "Pi VCC Files And Changes",
+  "Pi VCC Evidence Handles",
+  "Pi VCC User Preferences",
+]);
+
+export const failedCacheGatesOf = (cycle: CycleMetrics): string[] => {
+  if (!CACHE_STABILITY_CASES.has(cycle.caseId) || cycle.cycle <= 1) return [];
+  const failures: string[] = [];
+  if (cycle.firstChangedPromptLayer && EARLY_VOLATILE_LAYERS.has(cycle.firstChangedPromptLayer)) {
+    failures.push("early-prompt-layer-changed");
+  }
+  if ((cycle.stablePrefixTokens ?? 0) < 90) failures.push("stable-prefix-too-small");
+  return failures;
+};
+
 export const runOfflineCompactionBenchmark = (options: {
   cases?: CompactionBenchmarkCase[];
   compactors?: OfflineCompactor[];

--- a/bench/compaction/real-sessions.ts
+++ b/bench/compaction/real-sessions.ts
@@ -1,0 +1,83 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { basename } from "node:path";
+import type { Message } from "@mariozechner/pi-ai";
+import type { CompactionBenchmarkCase } from "./synthetic-cases";
+
+interface SessionFile {
+  path: string;
+  size: number;
+}
+
+const walkJsonl = async (dir: string): Promise<SessionFile[]> => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out: SessionFile[] = [];
+  for (const entry of entries) {
+    const path = `${dir.replace(/\/$/, "")}/${entry.name}`;
+    if (entry.isDirectory()) {
+      out.push(...await walkJsonl(path));
+    } else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      const s = await stat(path);
+      out.push({ path, size: s.size });
+    }
+  }
+  return out;
+};
+
+const isMessage = (value: unknown): value is Message =>
+  Boolean(value && typeof value === "object" && typeof (value as any).role === "string" && "content" in (value as any));
+
+const loadMessagesFromJsonl = async (path: string): Promise<Message[]> => {
+  const text = await readFile(path, "utf8");
+  const messages: Message[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    let entry: any;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (entry?.type !== "message") continue;
+    if (isMessage(entry.message)) messages.push(entry.message);
+  }
+  return messages;
+};
+
+const compactionPointsFor = (messageCount: number): number[] => {
+  if (messageCount <= 3) return [];
+  const raw = [
+    Math.ceil(messageCount * 0.4),
+    Math.ceil(messageCount * 0.7),
+    messageCount,
+  ].filter((point) => point > 2 && point <= messageCount);
+  return [...new Set(raw)];
+};
+
+export const loadRealSessionCases = async (options: {
+  sessionsDir: string;
+  limit?: number;
+}): Promise<CompactionBenchmarkCase[]> => {
+  const limit = Math.max(1, options.limit ?? 2);
+  const files = (await walkJsonl(options.sessionsDir))
+    .sort((a, b) => b.size - a.size)
+    .slice(0, limit);
+
+  const cases: CompactionBenchmarkCase[] = [];
+  for (const file of files) {
+    const messages = await loadMessagesFromJsonl(file.path);
+    const compactionPoints = compactionPointsFor(messages.length);
+    if (compactionPoints.length === 0) continue;
+    cases.push({
+      id: `real-session:${basename(file.path, ".jsonl")}`,
+      description: `Real Pi session replay sampled from ${file.path}`,
+      messages,
+      compactionPoints,
+      gold: {
+        activeTerms: [],
+        recallTerms: [],
+      },
+    });
+  }
+
+  return cases;
+};

--- a/bench/compaction/synthetic-cases.ts
+++ b/bench/compaction/synthetic-cases.ts
@@ -1,0 +1,256 @@
+import type { Message } from "@mariozechner/pi-ai";
+
+export interface ExpectedTerm {
+  label: string;
+  term: string;
+  /** Optional focused query for recall-style lookup. Defaults to the term. */
+  query?: string;
+}
+
+export interface ScopedTerm extends ExpectedTerm {
+  /** Enforce only after this term has appeared in the replayed source text. */
+  afterTerm?: string;
+}
+
+export interface CompactionGold {
+  /** Terms that should appear somewhere in the active prompt. */
+  activeTerms: ExpectedTerm[];
+  /** Terms that should appear in current-state layers, not only historical transcript/tail. */
+  currentTerms?: ExpectedTerm[];
+  /** Terms that should be recoverable from external recall. */
+  recallTerms: ExpectedTerm[];
+  /** Terms forbidden anywhere in the active prompt. */
+  forbiddenTerms?: ScopedTerm[];
+  /** Terms forbidden from current-state layers but allowed in historical layers or recall. */
+  forbiddenCurrentTerms?: ScopedTerm[];
+  /** Terms that must stay out of active prompt text because recall should carry them. */
+  activeAbsentTerms?: ExpectedTerm[];
+  continuationTerms?: ExpectedTerm[];
+}
+
+export interface CompactionBenchmarkCase {
+  id: string;
+  description: string;
+  messages: Message[];
+  /** Message counts at which to run a compaction cycle. */
+  compactionPoints: number[];
+  gold: CompactionGold;
+}
+
+const ts = 1_700_000_000_000;
+let toolId = 0;
+
+const assistantBase = {
+  api: "messages" as any,
+  provider: "anthropic" as any,
+  model: "benchmark-fixture",
+  usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  timestamp: ts,
+};
+
+const user = (text: string): Message => ({ role: "user", content: text, timestamp: ts });
+
+const assistant = (text: string): Message => ({
+  role: "assistant",
+  content: [{ type: "text", text }],
+  ...assistantBase,
+  stopReason: "stop",
+});
+
+const toolCall = (name: string, args: Record<string, unknown>): Message => {
+  toolId += 1;
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", id: `bench_tool_${toolId}`, name, arguments: args }],
+    ...assistantBase,
+    stopReason: "toolUse",
+  };
+};
+
+const toolResult = (name: string, text: string, isError = false): Message => ({
+  role: "toolResult",
+  toolCallId: `bench_tool_${toolId}`,
+  toolName: name,
+  content: [{ type: "text", text }],
+  isError,
+  timestamp: ts,
+});
+
+const noisyLog = (needle: string): string => [
+  ...Array.from({ length: 80 }, (_, i) => `debug ${String(i).padStart(2, "0")}: cache warmup shard ok`),
+  `CRITICAL ${needle}`,
+  ...Array.from({ length: 80 }, (_, i) => `debug ${String(i + 80).padStart(2, "0")}: retry window unchanged`),
+].join("\n");
+
+export const syntheticCompactionCases: CompactionBenchmarkCase[] = [
+  {
+    id: "boundary-loss-auth-refresh",
+    description: "A critical constraint and error signature appear immediately before a compaction cut.",
+    messages: [
+      user("Fix password-reset login. Hard constraint: do not change the public login API."),
+      assistant("I will inspect the auth refresh path and keep the public login API unchanged."),
+      toolCall("read", { path: "src/auth/session.ts" }),
+      toolResult("read", "export function refreshSessionAfterPasswordReset() { return null; }"),
+      assistant("The likely fix belongs in src/auth/session.ts, not the public login handler."),
+      toolCall("bash", { command: "bun test tests/auth-refresh.test.ts" }),
+      toolResult("bash", "FAIL tests/auth-refresh.test.ts\nERR_REFRESH_AFTER_RESET expired refresh token after password reset", true),
+      user("Continue from here. The next step is to patch refreshSessionAfterPasswordReset, then rerun tests/auth-refresh.test.ts."),
+      assistant("I will patch refreshSessionAfterPasswordReset and rerun the focused auth-refresh test."),
+    ],
+    compactionPoints: [7, 9],
+    gold: {
+      activeTerms: [
+        { label: "constraint", term: "do not change the public login API" },
+        { label: "file", term: "src/auth/session.ts" },
+        { label: "identifier", term: "ERR_REFRESH_AFTER_RESET" },
+      ],
+      currentTerms: [
+        { label: "constraint", term: "do not change the public login API" },
+        { label: "file", term: "src/auth/session.ts" },
+        { label: "identifier", term: "ERR_REFRESH_AFTER_RESET" },
+      ],
+      recallTerms: [
+        { label: "failing test", term: "tests/auth-refresh.test.ts", query: "auth-refresh" },
+      ],
+      continuationTerms: [
+        { label: "next edit", term: "patch refreshSessionAfterPasswordReset" },
+        { label: "next validation", term: "rerun tests/auth-refresh.test.ts" },
+      ],
+    },
+  },
+  {
+    id: "identifier-provenance",
+    description: "Similar identifiers make exact provenance and active entity recovery important.",
+    messages: [
+      user("Audit cache invalidation. The target artifact is /tmp/cache-probe-A17.log, not /tmp/cache-probe-A71.log."),
+      assistant("I will keep the A17 artifact distinct from the A71 decoy and check the cache probe IDs."),
+      toolCall("read", { path: "/tmp/cache-probe-A17.log" }),
+      toolResult("read", "probe_id=cache_probe_A17\nspan=spn_cache_keep_91\ncommit=9f3a2b1\nstatus=prefix preserved"),
+      toolCall("read", { path: "/tmp/cache-probe-A71.log" }),
+      toolResult("read", "probe_id=cache_probe_A71\nspan=spn_cache_drop_19\nstatus=decoy"),
+      assistant("Decision: use cache_probe_A17 and span spn_cache_keep_91 as the evidence handle. Ignore cache_probe_A71."),
+      user("Continue the audit using commit 9f3a2b1 and evidence span spn_cache_keep_91."),
+    ],
+    compactionPoints: [6, 8],
+    gold: {
+      activeTerms: [
+        { label: "artifact", term: "/tmp/cache-probe-A17.log" },
+        { label: "probe", term: "cache_probe_A17" },
+        { label: "span", term: "spn_cache_keep_91" },
+        { label: "commit", term: "9f3a2b1" },
+      ],
+      currentTerms: [
+        { label: "artifact", term: "/tmp/cache-probe-A17.log" },
+        { label: "probe", term: "cache_probe_A17" },
+        { label: "span", term: "spn_cache_keep_91" },
+        { label: "commit", term: "9f3a2b1" },
+      ],
+      recallTerms: [
+        { label: "decoy provenance", term: "cache_probe_A71", query: "cache_probe_A71" },
+      ],
+      forbiddenCurrentTerms: [
+        { label: "decoy as current target", term: "use cache_probe_A71", afterTerm: "Ignore cache_probe_A71" },
+      ],
+      continuationTerms: [
+        { label: "continue span", term: "spn_cache_keep_91" },
+      ],
+    },
+  },
+  {
+    id: "recall-required-bulk-log",
+    description: "A bulky log should be externalized while retaining a pointer and recallable exact failure line.",
+    messages: [
+      user("Investigate a flaky compaction benchmark. Store bulky logs as pointers when possible."),
+      assistant("I will inspect the benchmark log and keep only the evidence handle in active state."),
+      toolCall("bash", { command: "./run-benchmark > /tmp/pi-vcc-bench-482.log" }),
+      toolResult("bash", noisyLog("CACHE_MISS_AT_LAYER_2B request_id=req_cache_482"), true),
+      assistant("The important pointer is /tmp/pi-vcc-bench-482.log. The exact line CACHE_MISS_AT_LAYER_2B request_id=req_cache_482 can be recalled from the log."),
+      user("Continue with the pointer only; do not paste the whole log back into context."),
+    ],
+    compactionPoints: [4, 6],
+    gold: {
+      activeTerms: [
+        { label: "log pointer", term: "/tmp/pi-vcc-bench-482.log" },
+      ],
+      currentTerms: [
+        { label: "log pointer", term: "/tmp/pi-vcc-bench-482.log" },
+      ],
+      recallTerms: [
+        { label: "critical line", term: "CACHE_MISS_AT_LAYER_2B request_id=req_cache_482", query: "CACHE_MISS_AT_LAYER_2B req_cache_482" },
+      ],
+      activeAbsentTerms: [
+        { label: "early bulky log line", term: "debug 00: cache warmup shard ok" },
+        { label: "late bulky log line", term: "debug 120: retry window unchanged" },
+      ],
+      continuationTerms: [
+        { label: "pointer discipline", term: "do not paste the whole log" },
+      ],
+    },
+  },
+  {
+    id: "correction-stale-memory",
+    description: "A corrected user preference should replace stale durable memory.",
+    messages: [
+      user("For this repo, prefer yarn test when validating."),
+      assistant("Noted: yarn test for validation."),
+      toolCall("bash", { command: "yarn test" }),
+      toolResult("bash", "yarn: command not found", true),
+      user("Correction: never use yarn here. Use npm test for broad validation and node --test for focused checks."),
+      assistant("Understood. I will avoid yarn and use npm test or node --test depending on scope."),
+      user("Continue and choose the focused validation command first."),
+    ],
+    compactionPoints: [4, 7],
+    gold: {
+      activeTerms: [
+        { label: "corrected preference", term: "never use yarn" },
+        { label: "broad validation", term: "npm test" },
+        { label: "focused validation", term: "node --test" },
+      ],
+      currentTerms: [
+        { label: "corrected preference", term: "never use yarn" },
+        { label: "broad validation", term: "npm test" },
+        { label: "focused validation", term: "node --test" },
+      ],
+      recallTerms: [
+        { label: "failed old tool", term: "yarn: command not found", query: "yarn command not found" },
+      ],
+      forbiddenCurrentTerms: [
+        { label: "stale positive preference", term: "prefer yarn test", afterTerm: "Correction: never use yarn here" },
+      ],
+      continuationTerms: [
+        { label: "focused command", term: "node --test" },
+      ],
+    },
+  },
+  {
+    id: "cache-bust-volatile-next-step",
+    description: "Stable objective and identifiers remain fixed while only volatile next-step state changes across cycles.",
+    messages: [
+      user("Benchmark cache-aware compaction. Stable objective: preserve Layer 0 and Layer 1 prefixes."),
+      assistant("Stable checkpoint: objective preserve Layer 0 and Layer 1 prefixes; identifier cache_schema_v3."),
+      user("Current blocker: first run lacks cached input token accounting."),
+      assistant("Next step: add offline LCP token metrics for cache_schema_v3."),
+      user("Blocker update: offline LCP metrics are done; now add recall top-k metrics."),
+      assistant("Next step: add recall top-k metrics while preserving cache_schema_v3 stable text."),
+      user("Blocker update: recall top-k metrics are done; now document live provider limits."),
+      assistant("Next step: document live provider limits without changing Layer 0 or Layer 1 wording."),
+    ],
+    compactionPoints: [4, 6, 8],
+    gold: {
+      activeTerms: [
+        { label: "stable objective", term: "preserve Layer 0 and Layer 1 prefixes" },
+        { label: "schema", term: "cache_schema_v3" },
+      ],
+      currentTerms: [
+        { label: "stable objective", term: "preserve Layer 0 and Layer 1 prefixes" },
+        { label: "schema", term: "cache_schema_v3" },
+      ],
+      recallTerms: [
+        { label: "old blocker", term: "first run lacks cached input token accounting", query: "cached input token accounting" },
+      ],
+      continuationTerms: [
+        { label: "latest next step", term: "document live provider limits" },
+      ],
+    },
+  },
+];

--- a/bench/compaction/synthetic-cases.ts
+++ b/bench/compaction/synthetic-cases.ts
@@ -223,6 +223,35 @@ export const syntheticCompactionCases: CompactionBenchmarkCase[] = [
     },
   },
   {
+    id: "realistic-scope-and-status",
+    description: "A real-session-shaped scope extension should be captured, but follow-up status should stay volatile.",
+    messages: [
+      user("Build a local ClickHouse-based OpenTelemetry ingestion and query system."),
+      assistant("I will start with local ClickHouse, ingestion, and query scaffolding."),
+      user("Good, now lets add meta monitoring for the chart itself. This means metrics for our clickhouse instance and dashboards for grafana."),
+      assistant("I will extend the current work with meta monitoring and Grafana dashboards."),
+      user("Status update: meta monitoring wiring is started; next validate dashboard provisioning."),
+      assistant("Next step: validate dashboard provisioning without changing the stable objective."),
+    ],
+    compactionPoints: [2, 4, 6],
+    gold: {
+      activeTerms: [
+        { label: "original objective", term: "OpenTelemetry ingestion and query system" },
+        { label: "scope extension", term: "meta monitoring" },
+      ],
+      currentTerms: [
+        { label: "original objective", term: "OpenTelemetry ingestion and query system" },
+        { label: "scope extension", term: "meta monitoring" },
+      ],
+      recallTerms: [
+        { label: "dashboard validation", term: "dashboard provisioning", query: "dashboard provisioning" },
+      ],
+      continuationTerms: [
+        { label: "volatile next step", term: "validate dashboard provisioning" },
+      ],
+    },
+  },
+  {
     id: "cache-bust-volatile-next-step",
     description: "Stable objective and identifiers remain fixed while only volatile next-step state changes across cycles.",
     messages: [

--- a/scripts/bench-compaction.ts
+++ b/scripts/bench-compaction.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { failedGatesOf, offlineCompactors, runOfflineCompactionBenchmark } from "../bench/compaction/offline-runner";
+
+const args = process.argv.slice(2);
+
+const argValue = (name: string): string | undefined => {
+  const inline = args.find((arg) => arg.startsWith(`${name}=`));
+  if (inline) return inline.slice(name.length + 1);
+  const index = args.indexOf(name);
+  if (index >= 0) return args[index + 1];
+  return undefined;
+};
+
+const hasFlag = (name: string): boolean => args.includes(name);
+
+const selected = argValue("--compactors")
+  ?.split(",")
+  .map((name) => name.trim())
+  .filter(Boolean);
+
+const compactors = selected
+  ? offlineCompactors.filter((compactor) => selected.includes(compactor.name))
+  : offlineCompactors;
+
+if (selected && compactors.length !== selected.length) {
+  const found = new Set(compactors.map((compactor) => compactor.name));
+  const missing = selected.filter((name) => !found.has(name));
+  console.error(`Unknown compactor(s): ${missing.join(", ")}`);
+  console.error(`Available compactors: ${offlineCompactors.map((compactor) => compactor.name).join(", ")}`);
+  process.exit(1);
+}
+
+const result = runOfflineCompactionBenchmark({ compactors });
+const failures = result.cycles
+  .map((cycle) => ({ cycle, gates: failedGatesOf(cycle) }))
+  .filter((entry) => entry.gates.length > 0);
+
+if (hasFlag("--jsonl")) {
+  for (const cycle of result.cycles) {
+    console.log(JSON.stringify(cycle));
+  }
+} else {
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (hasFlag("--assert") && failures.length > 0) {
+  console.error(`\nCompaction benchmark assertions failed: ${failures.length} cycle(s)`);
+  for (const { cycle, gates } of failures.slice(0, 20)) {
+    console.error(JSON.stringify({
+      caseId: cycle.caseId,
+      compactor: cycle.compactor,
+      cycle: cycle.cycle,
+      gates,
+      missingActiveTerms: cycle.missingActiveTerms,
+      missingCurrentTerms: cycle.missingCurrentTerms,
+      missingRecallTerms: cycle.missingRecallTerms,
+      leakedForbiddenTerms: cycle.leakedForbiddenTerms,
+      leakedForbiddenCurrentTerms: cycle.leakedForbiddenCurrentTerms,
+      leakedActiveAbsentTerms: cycle.leakedActiveAbsentTerms,
+    }));
+  }
+  if (failures.length > 20) {
+    console.error(`... ${failures.length - 20} additional failing cycle(s) omitted`);
+  }
+  process.exit(1);
+}

--- a/scripts/bench-compaction.ts
+++ b/scripts/bench-compaction.ts
@@ -18,6 +18,8 @@ const hasFlag = (name: string): boolean => args.includes(name);
 const realSessionsDir = argValue("--real-sessions-dir");
 const realLimitRaw = argValue("--real-limit");
 const realLimit = realLimitRaw ? Number.parseInt(realLimitRaw, 10) : undefined;
+const caseFilter = argValue("--case-filter");
+const includeDiagnostics = hasFlag("--show-layer-diff");
 
 const selected = argValue("--compactors")
   ?.split(",")
@@ -40,8 +42,11 @@ const cases = hasFlag("--real-only") ? [] : [...syntheticCompactionCases];
 if (realSessionsDir) {
   cases.push(...await loadRealSessionCases({ sessionsDir: realSessionsDir, limit: realLimit }));
 }
+const filteredCases = caseFilter
+  ? cases.filter((testCase) => testCase.id.includes(caseFilter) || testCase.description.includes(caseFilter))
+  : cases;
 
-const result = runOfflineCompactionBenchmark({ compactors, cases });
+const result = runOfflineCompactionBenchmark({ compactors, cases: filteredCases, includeDiagnostics });
 const failures = result.cycles
   .map((cycle) => ({ cycle, gates: failedGatesOf(cycle) }))
   .filter((entry) => entry.gates.length > 0);

--- a/scripts/bench-compaction.ts
+++ b/scripts/bench-compaction.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { failedGatesOf, offlineCompactors, runOfflineCompactionBenchmark } from "../bench/compaction/offline-runner";
+import { failedCacheGatesOf, failedGatesOf, offlineCompactors, runOfflineCompactionBenchmark } from "../bench/compaction/offline-runner";
 import { syntheticCompactionCases } from "../bench/compaction/synthetic-cases";
 import { loadRealSessionCases } from "../bench/compaction/real-sessions";
 
@@ -50,6 +50,9 @@ const result = runOfflineCompactionBenchmark({ compactors, cases: filteredCases,
 const failures = result.cycles
   .map((cycle) => ({ cycle, gates: failedGatesOf(cycle) }))
   .filter((entry) => entry.gates.length > 0);
+const cacheFailures = result.cycles
+  .map((cycle) => ({ cycle, gates: failedCacheGatesOf(cycle) }))
+  .filter((entry) => entry.gates.length > 0);
 
 if (hasFlag("--jsonl")) {
   for (const cycle of result.cycles) {
@@ -59,14 +62,16 @@ if (hasFlag("--jsonl")) {
   console.log(JSON.stringify(result, null, 2));
 }
 
-if (hasFlag("--assert") && failures.length > 0) {
-  console.error(`\nCompaction benchmark assertions failed: ${failures.length} cycle(s)`);
-  for (const { cycle, gates } of failures.slice(0, 20)) {
+const printFailures = (title: string, entries: typeof failures) => {
+  console.error(`\n${title}: ${entries.length} cycle(s)`);
+  for (const { cycle, gates } of entries.slice(0, 20)) {
     console.error(JSON.stringify({
       caseId: cycle.caseId,
       compactor: cycle.compactor,
       cycle: cycle.cycle,
       gates,
+      firstChangedPromptLayer: cycle.firstChangedPromptLayer,
+      stablePrefixTokens: cycle.stablePrefixTokens,
       missingActiveTerms: cycle.missingActiveTerms,
       missingCurrentTerms: cycle.missingCurrentTerms,
       missingRecallTerms: cycle.missingRecallTerms,
@@ -75,8 +80,17 @@ if (hasFlag("--assert") && failures.length > 0) {
       leakedActiveAbsentTerms: cycle.leakedActiveAbsentTerms,
     }));
   }
-  if (failures.length > 20) {
-    console.error(`... ${failures.length - 20} additional failing cycle(s) omitted`);
+  if (entries.length > 20) {
+    console.error(`... ${entries.length - 20} additional failing cycle(s) omitted`);
   }
+};
+
+if (hasFlag("--assert") && failures.length > 0) {
+  printFailures("Compaction benchmark assertions failed", failures);
+  process.exit(1);
+}
+
+if (hasFlag("--assert-cache") && cacheFailures.length > 0) {
+  printFailures("Compaction cache assertions failed", cacheFailures);
   process.exit(1);
 }

--- a/scripts/bench-compaction.ts
+++ b/scripts/bench-compaction.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { failedGatesOf, offlineCompactors, runOfflineCompactionBenchmark } from "../bench/compaction/offline-runner";
+import { syntheticCompactionCases } from "../bench/compaction/synthetic-cases";
+import { loadRealSessionCases } from "../bench/compaction/real-sessions";
 
 const args = process.argv.slice(2);
 
@@ -12,6 +14,10 @@ const argValue = (name: string): string | undefined => {
 };
 
 const hasFlag = (name: string): boolean => args.includes(name);
+
+const realSessionsDir = argValue("--real-sessions-dir");
+const realLimitRaw = argValue("--real-limit");
+const realLimit = realLimitRaw ? Number.parseInt(realLimitRaw, 10) : undefined;
 
 const selected = argValue("--compactors")
   ?.split(",")
@@ -30,7 +36,12 @@ if (selected && compactors.length !== selected.length) {
   process.exit(1);
 }
 
-const result = runOfflineCompactionBenchmark({ compactors });
+const cases = hasFlag("--real-only") ? [] : [...syntheticCompactionCases];
+if (realSessionsDir) {
+  cases.push(...await loadRealSessionCases({ sessionsDir: realSessionsDir, limit: realLimit }));
+}
+
+const result = runOfflineCompactionBenchmark({ compactors, cases });
 const failures = result.cycles
   .map((cycle) => ({ cycle, gates: failedGatesOf(cycle) }))
   .filter((entry) => entry.gates.length > 0);

--- a/src/core/brief.ts
+++ b/src/core/brief.ts
@@ -1,5 +1,6 @@
 import type { NormalizedBlock } from "../types";
-import { clip, firstLine } from "./content";
+import { clip } from "./content";
+import { summarizeToolResultForPrompt } from "./tool-result-summary";
 import { extractPath } from "./tool-args";
 import { collapseSkillText } from "./skill-collapse";
 
@@ -181,7 +182,7 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
       }
       case "tool_result": {
         if (b.isError) {
-          const body = firstLine(b.text, 150);
+          const body = summarizeToolResultForPrompt(b.text);
           // Drop empty/placeholder error bodies — keep the line only if it carries info.
           if (!body || body === "(no output)") break;
           const ref = b.sourceIndex != null ? ` (#${b.sourceIndex})` : "";

--- a/src/core/build-sections.ts
+++ b/src/core/build-sections.ts
@@ -1,10 +1,12 @@
 import type { NormalizedBlock } from "../types";
-import { clip, clipSentence, firstLine, nonEmptyLines } from "./content";
+import { clip, clipSentence, nonEmptyLines } from "./content";
+import { summarizeToolResultForPrompt } from "./tool-result-summary";
 import type { SectionData } from "../sections";
 import { extractGoals } from "../extract/goals";
 import { extractFiles } from "../extract/files";
 import { extractPreferences, dedupPreferencesAgainstGoals } from "../extract/preferences";
 import { extractCommits, formatCommits } from "../extract/commits";
+import { extractEvidence, formatEvidence } from "../extract/evidence";
 import { buildBriefSections, sectionsToTranscript, stringifyBrief } from "./brief";
 
 export interface BuildSectionsInput {
@@ -20,7 +22,7 @@ const extractOutstandingContext = (blocks: NormalizedBlock[]): string[] => {
 
   for (const b of tail) {
     if (b.kind === "tool_result" && b.isError) {
-      items.push(`[${b.name}] ${firstLine(b.text, 150)}`);
+      items.push(`[${b.name}] ${summarizeToolResultForPrompt(b.text)}`);
       continue;
     }
 
@@ -72,6 +74,7 @@ export const buildSections = (input: BuildSectionsInput): SectionData => {
     outstandingContext: extractOutstandingContext(blocks),
     filesAndChanges: formatFileActivity(blocks),
     commits: formatCommits(extractCommits(blocks)),
+    evidenceHandles: formatEvidence(extractEvidence(blocks)),
     userPreferences,
     briefTranscript: stringifyBrief(briefSections),
     transcriptEntries: sectionsToTranscript(briefSections),

--- a/src/core/build-sections.ts
+++ b/src/core/build-sections.ts
@@ -53,7 +53,7 @@ const formatFileActivity = (blocks: NormalizedBlock[]): string[] => {
   const cap = (set: Set<string>, limit: number) => {
     const arr = [...set];
     if (arr.length <= limit) return arr.join(", ");
-    return arr.slice(0, limit).join(", ") + ` (+${arr.length - limit} more)`;
+    return arr.slice(0, limit).join(", ") + " (+more)";
   };
   if (act.modified.size > 0) lines.push(`Modified: ${cap(act.modified, 10)}`);
   if (act.created.size > 0) lines.push(`Created: ${cap(act.created, 10)}`);

--- a/src/core/build-sections.ts
+++ b/src/core/build-sections.ts
@@ -2,7 +2,7 @@ import type { NormalizedBlock } from "../types";
 import { clip, clipSentence, nonEmptyLines } from "./content";
 import { summarizeToolResultForPrompt } from "./tool-result-summary";
 import type { SectionData } from "../sections";
-import { extractGoals } from "../extract/goals";
+import { extractGoalState } from "../extract/goals";
 import { extractFiles } from "../extract/files";
 import { extractPreferences, dedupPreferencesAgainstGoals } from "../extract/preferences";
 import { extractCommits, formatCommits } from "../extract/commits";
@@ -64,13 +64,14 @@ const formatFileActivity = (blocks: NormalizedBlock[]): string[] => {
 export const buildSections = (input: BuildSectionsInput): SectionData => {
   const { blocks } = input;
   const briefSections = buildBriefSections(blocks);
-  const sessionGoal = extractGoals(blocks);
+  const goalState = extractGoalState(blocks);
   const userPreferences = dedupPreferencesAgainstGoals(
     extractPreferences(blocks),
-    sessionGoal,
+    [...goalState.stableGoals, ...goalState.currentScope],
   );
   return {
-    sessionGoal,
+    sessionGoal: goalState.stableGoals,
+    currentScope: goalState.currentScope,
     outstandingContext: extractOutstandingContext(blocks),
     filesAndChanges: formatFileActivity(blocks),
     commits: formatCommits(extractCommits(blocks)),

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -28,6 +28,7 @@ export const formatSummary = (data: SectionData): string => {
     section("Session Goal", data.sessionGoal),
     section("Files And Changes", data.filesAndChanges),
     section("Commits", data.commits),
+    section("Evidence Handles", data.evidenceHandles),
     section("Outstanding Context", data.outstandingContext),
     section("User Preferences", data.userPreferences),
   ].filter(Boolean);

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -29,8 +29,8 @@ export const formatSummary = (data: SectionData): string => {
     section("Files And Changes", data.filesAndChanges),
     section("Commits", data.commits),
     section("Evidence Handles", data.evidenceHandles),
-    section("Outstanding Context", data.outstandingContext),
     section("User Preferences", data.userPreferences),
+    section("Outstanding Context", data.outstandingContext),
   ].filter(Boolean);
 
   const parts: string[] = [];

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -26,6 +26,7 @@ export const RECALL_NOTE =
 export const formatSummary = (data: SectionData): string => {
   const headerParts = [
     section("Session Goal", data.sessionGoal),
+    section("Current Scope", data.currentScope),
     section("Files And Changes", data.filesAndChanges),
     section("Commits", data.commits),
     section("Evidence Handles", data.evidenceHandles),

--- a/src/core/summarize.ts
+++ b/src/core/summarize.ts
@@ -12,7 +12,7 @@ export interface CompileInput {
   fileOps?: FileOps;
 }
 
-const HEADER_NAMES = ["Session Goal", "Files And Changes", "Commits", "Evidence Handles", "Outstanding Context", "User Preferences"];
+const HEADER_NAMES = ["Session Goal", "Files And Changes", "Commits", "Evidence Handles", "User Preferences", "Outstanding Context"];
 
 const SEPARATOR = "\n\n---\n\n";
 

--- a/src/core/summarize.ts
+++ b/src/core/summarize.ts
@@ -4,6 +4,7 @@ import { normalize } from "./normalize";
 import { filterNoise } from "./filter-noise";
 import { buildSections } from "./build-sections";
 import { formatSummary, capBrief, RECALL_NOTE } from "./format";
+import { applyPreferenceCorrections } from "../extract/preferences";
 
 export interface CompileInput {
   messages: Message[];
@@ -11,7 +12,7 @@ export interface CompileInput {
   fileOps?: FileOps;
 }
 
-const HEADER_NAMES = ["Session Goal", "Files And Changes", "Commits", "Outstanding Context", "User Preferences"];
+const HEADER_NAMES = ["Session Goal", "Files And Changes", "Commits", "Evidence Handles", "Outstanding Context", "User Preferences"];
 
 const SEPARATOR = "\n\n---\n\n";
 
@@ -51,12 +52,15 @@ const mergeHeaderSection = (header: string, prev: string, fresh: string): string
     return mergeFileLines(prev, fresh);
   }
 
-  // Session Goal, User Preferences: line-level dedup, cap
+  // Sticky list sections: line-level dedup, cap
   const isClean = (l: string) => l.startsWith("- ") && !l.includes("<skill") && !l.includes("</skill");
   const prevLines = prev.split("\n").filter(isClean);
   const freshLines = fresh.split("\n").filter(isClean);
-  const combined = [...new Set([...prevLines, ...freshLines])];
-  const CAP = header === "Session Goal" ? 8 : header === "Commits" ? 8 : 15;
+  const combinedRaw = [...new Set([...prevLines, ...freshLines])];
+  const combined = header === "User Preferences"
+    ? applyPreferenceCorrections(combinedRaw.map((line) => line.replace(/^-\s*/, ""))).map((line) => `- ${line}`)
+    : combinedRaw;
+  const CAP = header === "Session Goal" ? 8 : header === "Commits" ? 8 : header === "Evidence Handles" ? 20 : 15;
   const capped = combined.length > CAP ? combined.slice(-CAP) : combined;
   if (capped.length === 0) return "";
   return `[${header}]\n${capped.join("\n")}`;

--- a/src/core/summarize.ts
+++ b/src/core/summarize.ts
@@ -12,7 +12,7 @@ export interface CompileInput {
   fileOps?: FileOps;
 }
 
-const HEADER_NAMES = ["Session Goal", "Files And Changes", "Commits", "Evidence Handles", "User Preferences", "Outstanding Context"];
+const HEADER_NAMES = ["Session Goal", "Current Scope", "Files And Changes", "Commits", "Evidence Handles", "User Preferences", "Outstanding Context"];
 
 const SEPARATOR = "\n\n---\n\n";
 
@@ -46,8 +46,8 @@ const briefOf = (text: string): string => {
 
 /** Merge a header section */
 const mergeHeaderSection = (header: string, prev: string, fresh: string): string => {
-  // Outstanding Context is volatile -- always use fresh only
-  if (header === "Outstanding Context") return fresh;
+  // Volatile sections -- always use fresh only
+  if (header === "Outstanding Context" || header === "Current Scope") return fresh;
   if (!prev) return fresh;
   if (!fresh) return prev;
 

--- a/src/core/summarize.ts
+++ b/src/core/summarize.ts
@@ -46,8 +46,11 @@ const briefOf = (text: string): string => {
 
 /** Merge a header section */
 const mergeHeaderSection = (header: string, prev: string, fresh: string): string => {
-  // Volatile sections -- always use fresh only
-  if (header === "Outstanding Context" || header === "Current Scope") return fresh;
+  // Current Scope is the latest explicit scope change; keep previous when the
+  // fresh window only has status/transcript updates.
+  if (header === "Current Scope") return fresh || prev;
+  // Outstanding Context is volatile -- always use fresh only.
+  if (header === "Outstanding Context") return fresh;
   if (!prev) return fresh;
   if (!fresh) return prev;
 
@@ -116,11 +119,33 @@ const mergeBriefTranscript = (prev: string, fresh: string): string => {
   return prev + "\n\n" + fresh;
 };
 
+const demoteFreshGoalToScope = (fresh: string): string => {
+  const goal = sectionOf(fresh, "Session Goal");
+  if (!goal) return fresh;
+
+  const goalLines = goal.split("\n").slice(1).filter((line) => line.startsWith("- "));
+  const withoutGoal = fresh
+    .replace(goal, "")
+    .replace(/^\s+/, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  if (goalLines.length === 0) return withoutGoal;
+
+  const currentScope = sectionOf(withoutGoal, "Current Scope");
+  if (currentScope) {
+    return withoutGoal.replace(currentScope, `${currentScope}\n${goalLines.join("\n")}`);
+  }
+
+  const scopeSection = `[Current Scope]\n${goalLines.join("\n")}`;
+  return withoutGoal ? `${scopeSection}\n\n${withoutGoal}` : scopeSection;
+};
+
 const mergePrevious = (prev: string, fresh: string): string => {
+  const mergeFresh = demoteFreshGoalToScope(fresh);
   // Merge header sections
   const headers = HEADER_NAMES
     .map((header) => {
-      const freshSec = sectionOf(fresh, header);
+      const freshSec = sectionOf(mergeFresh, header);
       const prevSec = sectionOf(prev, header);
       return mergeHeaderSection(header, prevSec, freshSec);
     })
@@ -128,7 +153,7 @@ const mergePrevious = (prev: string, fresh: string): string => {
 
   // Merge brief transcript
   const prevBrief = briefOf(prev);
-  const freshBrief = briefOf(fresh);
+  const freshBrief = briefOf(mergeFresh);
   const mergedBrief = mergeBriefTranscript(prevBrief, freshBrief);
 
   const parts: string[] = [];

--- a/src/core/summarize.ts
+++ b/src/core/summarize.ts
@@ -36,8 +36,12 @@ const sectionOf = (text: string, header: string): string => {
 /** Extract the brief transcript part (everything after ---) */
 const briefOf = (text: string): string => {
   const idx = text.indexOf(SEPARATOR);
-  if (idx < 0) return "";
-  return text.slice(idx + SEPARATOR.length).trim();
+  if (idx >= 0) return text.slice(idx + SEPARATOR.length).trim();
+  // A fresh compaction can contain only brief transcript with no header section,
+  // in which case there is no separator to split on.
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  return HEADER_NAMES.some((header) => trimmed.startsWith(`[${header}]`)) ? "" : trimmed;
 };
 
 /** Merge a header section */
@@ -79,8 +83,8 @@ const mergeFileLines = (prev: string, fresh: string): string => {
         const prefix = `- ${cat}: `;
         if (!line.startsWith(prefix)) continue;
         let rest = line.slice(prefix.length);
-        // Strip "(+N more)" suffix
-        rest = rest.replace(/\s*\(\+\d+ more\)\s*$/, "");
+        // Strip overflow suffixes
+        rest = rest.replace(/\s*\(\+(?:\d+\s+)?more\)\s*$/, "");
         for (const p of rest.split(",")) {
           const trimmed = p.trim();
           if (trimmed) merged[cat].add(trimmed);
@@ -95,7 +99,7 @@ const mergeFileLines = (prev: string, fresh: string): string => {
   const cap = (set: Set<string>, limit: number) => {
     const arr = [...set];
     if (arr.length <= limit) return arr.join(", ");
-    return arr.slice(0, limit).join(", ") + ` (+${arr.length - limit} more)`;
+    return arr.slice(0, limit).join(", ") + " (+more)";
   };
 
   const lines: string[] = [];

--- a/src/core/tool-result-summary.ts
+++ b/src/core/tool-result-summary.ts
@@ -1,0 +1,35 @@
+import { clip, firstLine, nonEmptyLines } from "./content";
+
+const LARGE_OUTPUT_CHARS = 500;
+const LARGE_OUTPUT_LINES = 12;
+
+const SIGNAL_RE =
+  /\b(error|fail(?:ed|ing|ure)?|exception|traceback|panic|fatal|critical|assert|timeout|not found|command not found|ERR_[A-Z0-9_]+|[A-Z][A-Z0-9]+(?:_[A-Z0-9]+){1,}|request_id=|req_[\w-]+)\b/i;
+
+const LOW_VALUE_RE = /^\s*(?:debug|trace|info)\b/i;
+
+const outputIsLarge = (text: string): boolean =>
+  text.length > LARGE_OUTPUT_CHARS || text.split("\n").length > LARGE_OUTPUT_LINES;
+
+const salientLine = (text: string): string => {
+  const lines = nonEmptyLines(text);
+  const signal = lines.find((line) => SIGNAL_RE.test(line) && !LOW_VALUE_RE.test(line));
+  if (signal) return clip(signal, 220);
+  const nonDebug = lines.find((line) => !LOW_VALUE_RE.test(line));
+  if (nonDebug) return clip(nonDebug, 220);
+  return firstLine(text, 220);
+};
+
+/**
+ * Summarize a tool error/result for active prompt state.
+ * Large outputs keep a salient failure line and omit bulk that remains
+ * recoverable from raw session history through recall.
+ */
+export const summarizeToolResultForPrompt = (text: string): string => {
+  if (!outputIsLarge(text)) return firstLine(text, 180);
+  const lineCount = text.split("\n").length;
+  const chars = text.length;
+  const line = salientLine(text);
+  const omitted = `large output omitted: ${lineCount} lines, ${chars} chars`;
+  return line ? `${line} (${omitted})` : `(${omitted})`;
+};

--- a/src/extract/evidence.ts
+++ b/src/extract/evidence.ts
@@ -7,11 +7,11 @@ export interface EvidenceActivity {
   errorSignatures: Set<string>;
 }
 
-const PATH_RE = /(?:^|[\s"'`(=])((?:\.?\/?[\w.-]+\/)+[\w.-]+(?:\.[\w.-]+)?)/g;
 const ABS_PATH_RE = /(?:^|[\s"'`(=])(\/(?:tmp|var|home|workspace|app|repo|src|tests?)\/[\w./-]+)/g;
-const ERROR_SIGNATURE_RE = /\b(?:ERR_[A-Z0-9_]+|[A-Z][A-Z0-9]+(?:_[A-Z0-9]+){1,})\b/g;
+const PROJECT_PATH_RE = /(?:^|[\s"'`(=])((?:src|test|tests|scripts|bench)\/[\w./-]+)/g;
+const ERROR_SIGNATURE_RE = /\b(?:ERR_[A-Z0-9_]+|(?:CACHE|CRITICAL|FATAL|PANIC|ERROR|FAIL)[A-Z0-9_]*(?:_[A-Z0-9]+)+)\b/g;
 const ID_RE = /\b(?:cache|probe|span|spn|req|request|trace|artifact|bench)[A-Za-z0-9_-]*_[A-Za-z0-9_-]+\b/g;
-const COMMIT_RE = /\b[0-9a-f]{7,40}\b/g;
+const COMMIT_RE = /\bcommit(?:\s+|[=:])([0-9a-f]{7,40})\b/gi;
 
 const addMatches = (set: Set<string>, text: string, regex: RegExp, group = 0) => {
   for (const match of text.matchAll(regex)) {
@@ -27,10 +27,10 @@ const textFromBlock = (block: NormalizedBlock): string => {
 
 const addEvidenceFromText = (activity: EvidenceActivity, text: string) => {
   addMatches(activity.paths, text, ABS_PATH_RE, 1);
-  addMatches(activity.paths, text, PATH_RE, 1);
+  addMatches(activity.paths, text, PROJECT_PATH_RE, 1);
   addMatches(activity.errorSignatures, text, ERROR_SIGNATURE_RE);
   addMatches(activity.identifiers, text, ID_RE);
-  addMatches(activity.identifiers, text, COMMIT_RE);
+  addMatches(activity.identifiers, text, COMMIT_RE, 1);
 };
 
 export const extractEvidence = (blocks: NormalizedBlock[]): EvidenceActivity => {
@@ -58,9 +58,9 @@ export const extractEvidence = (blocks: NormalizedBlock[]): EvidenceActivity => 
 };
 
 const cap = (set: Set<string>, limit: number): string => {
-  const values = [...set].sort();
+  const values = [...set];
   if (values.length <= limit) return values.join(", ");
-  return `${values.slice(0, limit).join(", ")} (+${values.length - limit} more)`;
+  return `${values.slice(0, limit).join(", ")} (+more)`;
 };
 
 export const formatEvidence = (activity: EvidenceActivity): string[] => {

--- a/src/extract/evidence.ts
+++ b/src/extract/evidence.ts
@@ -1,0 +1,72 @@
+import type { NormalizedBlock } from "../types";
+import { extractPath } from "../core/tool-args";
+
+export interface EvidenceActivity {
+  paths: Set<string>;
+  identifiers: Set<string>;
+  errorSignatures: Set<string>;
+}
+
+const PATH_RE = /(?:^|[\s"'`(=])((?:\.?\/?[\w.-]+\/)+[\w.-]+(?:\.[\w.-]+)?)/g;
+const ABS_PATH_RE = /(?:^|[\s"'`(=])(\/(?:tmp|var|home|workspace|app|repo|src|tests?)\/[\w./-]+)/g;
+const ERROR_SIGNATURE_RE = /\b(?:ERR_[A-Z0-9_]+|[A-Z][A-Z0-9]+(?:_[A-Z0-9]+){1,})\b/g;
+const ID_RE = /\b(?:cache|probe|span|spn|req|request|trace|artifact|bench)[A-Za-z0-9_-]*_[A-Za-z0-9_-]+\b/g;
+const COMMIT_RE = /\b[0-9a-f]{7,40}\b/g;
+
+const addMatches = (set: Set<string>, text: string, regex: RegExp, group = 0) => {
+  for (const match of text.matchAll(regex)) {
+    const value = (match[group] ?? match[0]).trim();
+    if (value) set.add(value);
+  }
+};
+
+const textFromBlock = (block: NormalizedBlock): string => {
+  if (block.kind === "tool_call") return JSON.stringify(block.args ?? {});
+  return "text" in block ? block.text : "";
+};
+
+const addEvidenceFromText = (activity: EvidenceActivity, text: string) => {
+  addMatches(activity.paths, text, ABS_PATH_RE, 1);
+  addMatches(activity.paths, text, PATH_RE, 1);
+  addMatches(activity.errorSignatures, text, ERROR_SIGNATURE_RE);
+  addMatches(activity.identifiers, text, ID_RE);
+  addMatches(activity.identifiers, text, COMMIT_RE);
+};
+
+export const extractEvidence = (blocks: NormalizedBlock[]): EvidenceActivity => {
+  const activity: EvidenceActivity = {
+    paths: new Set(),
+    identifiers: new Set(),
+    errorSignatures: new Set(),
+  };
+
+  for (const block of blocks) {
+    if (block.kind === "tool_call") {
+      const path = extractPath(block.args);
+      if (path) activity.paths.add(path);
+      for (const key of ["command", "cmd", "query", "path", "file", "file_path", "filePath"]) {
+        const value = block.args[key];
+        if (typeof value === "string") addEvidenceFromText(activity, value);
+      }
+      continue;
+    }
+
+    addEvidenceFromText(activity, textFromBlock(block));
+  }
+
+  return activity;
+};
+
+const cap = (set: Set<string>, limit: number): string => {
+  const values = [...set].sort();
+  if (values.length <= limit) return values.join(", ");
+  return `${values.slice(0, limit).join(", ")} (+${values.length - limit} more)`;
+};
+
+export const formatEvidence = (activity: EvidenceActivity): string[] => {
+  const lines: string[] = [];
+  if (activity.paths.size > 0) lines.push(`Paths: ${cap(activity.paths, 12)}`);
+  if (activity.errorSignatures.size > 0) lines.push(`Error signatures: ${cap(activity.errorSignatures, 12)}`);
+  if (activity.identifiers.size > 0) lines.push(`Identifiers: ${cap(activity.identifiers, 16)}`);
+  return lines;
+};

--- a/src/extract/files.ts
+++ b/src/extract/files.ts
@@ -8,7 +8,7 @@ interface FileActivity {
 }
 
 const FILE_READ_TOOLS = new Set([
-  "Read", "read_file", "View",
+  "Read", "read", "read_file", "View",
 ]);
 
 const FILE_WRITE_TOOLS = new Set([

--- a/src/extract/goals.ts
+++ b/src/extract/goals.ts
@@ -8,6 +8,11 @@ const SCOPE_CHANGE_RE =
 const TASK_RE =
   /\b(fix|implement|add|create|build|refactor|debug|investigate|update|remove|delete|migrate|deploy|test|write|set up)\b/i;
 
+const PREFERENCE_RE =
+  /\b(prefer(?:s|red|ring)?|always use|never use|please use|please avoid|do not use|don'?t use)\b/i;
+const PREFERENCE_WITH_TASK_RE =
+  /\b(fix|implement|add|create|build|refactor|debug|investigate|update|remove|delete|migrate|deploy|write|set up)\b/i;
+
 const NOISE_SHORT_RE = /^(ok|yes|no|sure|yeah|yep|go|hi|hey|thx|thanks|ok\b.*|y|n|k)\s*[.!?]*$/i;
 
 // Reject lines that are clearly not user goals (pasted output, code, paths, tool dumps)
@@ -31,12 +36,16 @@ const stripLeadingBullet = (line: string): string =>
 
 const MAX_GOAL_CHARS = 200;
 
+const isPreferenceOnly = (text: string): boolean =>
+  PREFERENCE_RE.test(text) && !PREFERENCE_WITH_TASK_RE.test(text);
+
 const isSubstantiveGoal = (text: string): boolean => {
   const t = text.trim();
   if (t.length <= 5) return false;
   if (t.length > MAX_GOAL_CHARS) return false;
   if (NOISE_SHORT_RE.test(t)) return false;
   if (NON_GOAL_RE.test(t)) return false;
+  if (isPreferenceOnly(t)) return false;
   return true;
 };
 

--- a/src/extract/goals.ts
+++ b/src/extract/goals.ts
@@ -55,9 +55,14 @@ const isSubstantiveGoal = (text: string): boolean => {
 // so that pasted outputs below the actual instruction do not trigger matches.
 const LEADING_CHARS = 200;
 
-export const extractGoals = (blocks: NormalizedBlock[]): string[] => {
-  const goals: string[] = [];
-  let latestScopeChange: string[] | null = null;
+export interface GoalExtraction {
+  stableGoals: string[];
+  currentScope: string[];
+}
+
+export const extractGoalState = (blocks: NormalizedBlock[]): GoalExtraction => {
+  const stableGoals: string[] = [];
+  let latestScopeChange: string[] = [];
 
   for (const b of blocks) {
     if (b.kind !== "user") continue;
@@ -68,8 +73,8 @@ export const extractGoals = (blocks: NormalizedBlock[]): string[] => {
       .filter((l) => l.length > 5);
     if (lines.length === 0) continue;
 
-    if (goals.length === 0) {
-      goals.push(...lines.slice(0, 6));
+    if (stableGoals.length === 0) {
+      stableGoals.push(...lines.slice(0, 6));
       continue;
     }
 
@@ -81,10 +86,11 @@ export const extractGoals = (blocks: NormalizedBlock[]): string[] => {
     }
   }
 
-  // Only emit the [Scope change] marker when we actually captured bullets.
-  if (latestScopeChange && latestScopeChange.length > 0) {
-    goals.push("[Scope change]", ...latestScopeChange);
-  }
-
-  return goals.slice(0, 8);
+  return {
+    stableGoals: stableGoals.slice(0, 8),
+    currentScope: latestScopeChange.slice(0, 5),
+  };
 };
+
+export const extractGoals = (blocks: NormalizedBlock[]): string[] =>
+  extractGoalState(blocks).stableGoals;

--- a/src/extract/goals.ts
+++ b/src/extract/goals.ts
@@ -10,6 +10,7 @@ const TASK_RE =
 
 const PREFERENCE_RE =
   /\b(prefer(?:s|red|ring)?|always use|never use|please use|please avoid|do not use|don'?t use)\b/i;
+const DIRECT_PREFERENCE_RE = /\b(?:prefer(?:s|red|ring)?|please use|please avoid|always use|never use)\b/i;
 const PREFERENCE_WITH_TASK_RE =
   /\b(fix|implement|add|create|build|refactor|debug|investigate|update|remove|delete|migrate|deploy|write|set up)\b/i;
 
@@ -21,6 +22,9 @@ const VOLATILE_STATUS_RE = /^\s*(?:current blocker|blocker update|status update|
 // followed by numbered "Read the issue in full..." steps).
 const NON_GOAL_RE =
   /^\s*[\[│├└─╭╰]|```|^\s*(=[A-Z]+\(|function |const |let |var |import |export |class )|^(https?:|file:|\/[A-Za-z])|\\n|^\s*For each\b|\bin full\b[^\n]*\b(comments|issue|issues|PRs?|linked)\b/;
+
+const TABLE_OR_STATUS_RE =
+  /\b(READY\s+STATUS\s+RESTARTS|\d+\/\d+\s+(?:Running|Pending|Completed|Error|CrashLoopBackOff)\b)/;
 
 // Signals that the rest of the user message is a command template (e.g. /issues),
 // in which case we should stop collecting goals at the signal line.
@@ -38,7 +42,7 @@ const stripLeadingBullet = (line: string): string =>
 const MAX_GOAL_CHARS = 200;
 
 const isPreferenceOnly = (text: string): boolean =>
-  PREFERENCE_RE.test(text) && !PREFERENCE_WITH_TASK_RE.test(text);
+  DIRECT_PREFERENCE_RE.test(text) || (PREFERENCE_RE.test(text) && !PREFERENCE_WITH_TASK_RE.test(text));
 
 const isSubstantiveGoal = (text: string): boolean => {
   const t = text.trim();
@@ -46,6 +50,7 @@ const isSubstantiveGoal = (text: string): boolean => {
   if (t.length > MAX_GOAL_CHARS) return false;
   if (NOISE_SHORT_RE.test(t)) return false;
   if (VOLATILE_STATUS_RE.test(t)) return false;
+  if (TABLE_OR_STATUS_RE.test(t)) return false;
   if (NON_GOAL_RE.test(t)) return false;
   if (isPreferenceOnly(t)) return false;
   return true;

--- a/src/extract/goals.ts
+++ b/src/extract/goals.ts
@@ -14,6 +14,7 @@ const PREFERENCE_WITH_TASK_RE =
   /\b(fix|implement|add|create|build|refactor|debug|investigate|update|remove|delete|migrate|deploy|write|set up)\b/i;
 
 const NOISE_SHORT_RE = /^(ok|yes|no|sure|yeah|yep|go|hi|hey|thx|thanks|ok\b.*|y|n|k)\s*[.!?]*$/i;
+const VOLATILE_STATUS_RE = /^\s*(?:current blocker|blocker update|status update|next step)\s*:/i;
 
 // Reject lines that are clearly not user goals (pasted output, code, paths, tool dumps)
 // or meta-prompt boilerplate (command templates like `/issues` that start with "For each issue:"
@@ -44,6 +45,7 @@ const isSubstantiveGoal = (text: string): boolean => {
   if (t.length <= 5) return false;
   if (t.length > MAX_GOAL_CHARS) return false;
   if (NOISE_SHORT_RE.test(t)) return false;
+  if (VOLATILE_STATUS_RE.test(t)) return false;
   if (NON_GOAL_RE.test(t)) return false;
   if (isPreferenceOnly(t)) return false;
   return true;

--- a/src/extract/preferences.ts
+++ b/src/extract/preferences.ts
@@ -25,6 +25,7 @@ export const extractPreferences = (blocks: NormalizedBlock[]): string[] => {
       if (trimmed.length > 200) continue;
       // Reject questions.
       if (trimmed.endsWith("?") || trimmed.includes("?...")) continue;
+      if (/\b(SYNTAX_ERROR|Stack trace|Exception|Traceback)\b/i.test(trimmed)) continue;
       if (!PREF_PATTERNS.some((p) => p.test(trimmed))) continue;
 
       const clipped = clip(trimmed, 200);

--- a/src/extract/preferences.ts
+++ b/src/extract/preferences.ts
@@ -38,7 +38,33 @@ export const extractPreferences = (blocks: NormalizedBlock[]): string[] => {
     }
   }
 
-  return prefs.slice(0, 10);
+  return applyPreferenceCorrections(prefs).slice(0, 10);
+};
+
+const NEVER_USE_RE = /\bnever use\s+([\w.-]+)/i;
+const POSITIVE_PREF_RE = /\b(?:prefer|always use|please use|use)\b/i;
+
+export const applyPreferenceCorrections = (prefs: string[]): string[] => {
+  const corrected: string[] = [];
+
+  for (const pref of prefs) {
+    const neverUse = pref.match(NEVER_USE_RE)?.[1]?.toLowerCase();
+    if (neverUse) {
+      for (let i = corrected.length - 1; i >= 0; i--) {
+        const existing = corrected[i].toLowerCase();
+        if (
+          existing.includes(neverUse) &&
+          POSITIVE_PREF_RE.test(existing) &&
+          !/\bnever\b|\bdo not\b|\bdon't\b/.test(existing)
+        ) {
+          corrected.splice(i, 1);
+        }
+      }
+    }
+    corrected.push(pref);
+  }
+
+  return corrected;
 };
 
 /**

--- a/src/sections.ts
+++ b/src/sections.ts
@@ -2,6 +2,7 @@ import type { TranscriptEntry } from "./core/brief";
 
 export interface SectionData {
   sessionGoal: string[];
+  currentScope: string[];
   outstandingContext: string[];
   filesAndChanges: string[];
   commits: string[];

--- a/src/sections.ts
+++ b/src/sections.ts
@@ -5,6 +5,7 @@ export interface SectionData {
   outstandingContext: string[];
   filesAndChanges: string[];
   commits: string[];
+  evidenceHandles: string[];
   userPreferences: string[];
   briefTranscript: string;
   /** Structured transcript entries (verbose object format) */

--- a/tests/build-sections.test.ts
+++ b/tests/build-sections.test.ts
@@ -7,6 +7,7 @@ describe("buildSections", () => {
     const r = buildSections({ blocks: [] });
     expect(r.sessionGoal).toEqual([]);
     expect(r.outstandingContext).toEqual([]);
+    expect(r.evidenceHandles).toEqual([]);
     expect(r.briefTranscript).toBe("");
   });
 
@@ -55,5 +56,34 @@ describe("buildSections", () => {
     const r = buildSections({ blocks });
     const matches = r.briefTranscript.match(/\[assistant\]/g);
     expect(matches?.length).toBe(1);
+  });
+
+  it("captures exact evidence handles from tool calls and errors", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_call", name: "read", args: { path: "src/auth/session.ts" } },
+      { kind: "tool_result", name: "bash", text: "FAIL tests/auth-refresh.test.ts\nERR_REFRESH_AFTER_RESET expired token", isError: true },
+      { kind: "tool_result", name: "read", text: "probe_id=cache_probe_A17\nspan=spn_cache_keep_91\ncommit=9f3a2b1", isError: false },
+    ];
+    const r = buildSections({ blocks });
+    const evidence = r.evidenceHandles.join("\n");
+    expect(r.filesAndChanges.join("\n")).toContain("src/auth/session.ts");
+    expect(evidence).toContain("ERR_REFRESH_AFTER_RESET");
+    expect(evidence).toContain("cache_probe_A17");
+    expect(evidence).toContain("spn_cache_keep_91");
+    expect(evidence).toContain("9f3a2b1");
+  });
+
+  it("summarizes bulky tool errors without pasting low-value log lines", () => {
+    const text = [
+      ...Array.from({ length: 20 }, (_, i) => `debug ${i}: warmup ok`),
+      "CRITICAL CACHE_MISS_AT_LAYER_2B request_id=req_cache_482",
+    ].join("\n");
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_result", name: "bash", text, isError: true },
+    ];
+    const r = buildSections({ blocks });
+    expect(r.briefTranscript).toContain("CACHE_MISS_AT_LAYER_2B");
+    expect(r.briefTranscript).not.toContain("debug 0: warmup ok");
+    expect(r.outstandingContext.join("\n")).toContain("CACHE_MISS_AT_LAYER_2B");
   });
 });

--- a/tests/build-sections.test.ts
+++ b/tests/build-sections.test.ts
@@ -6,6 +6,7 @@ describe("buildSections", () => {
   it("returns all-empty for no blocks", () => {
     const r = buildSections({ blocks: [] });
     expect(r.sessionGoal).toEqual([]);
+    expect(r.currentScope).toEqual([]);
     expect(r.outstandingContext).toEqual([]);
     expect(r.evidenceHandles).toEqual([]);
     expect(r.briefTranscript).toBe("");
@@ -71,6 +72,17 @@ describe("buildSections", () => {
     expect(evidence).toContain("cache_probe_A17");
     expect(evidence).toContain("spn_cache_keep_91");
     expect(evidence).toContain("9f3a2b1");
+  });
+
+  it("separates scope changes from stable goals", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "Build a local ClickHouse-based OpenTelemetry ingestion and query system." },
+      { kind: "user", text: "Good, now lets add meta monitoring for the chart itself." },
+      { kind: "user", text: "Status update: validate dashboard provisioning next." },
+    ];
+    const r = buildSections({ blocks });
+    expect(r.sessionGoal).toEqual(["Build a local ClickHouse-based OpenTelemetry ingestion and query system."]);
+    expect(r.currentScope).toEqual(["Good, now lets add meta monitoring for the chart itself."]);
   });
 
   it("summarizes bulky tool errors without pasting low-value log lines", () => {

--- a/tests/compile.test.ts
+++ b/tests/compile.test.ts
@@ -102,4 +102,25 @@ describe("compile", () => {
     expect(r).toContain("Existing goal");
     expect(r).toContain("validate dashboard provisioning");
   });
+
+  it("demotes fresh goals to current scope when merging previous summary", () => {
+    const previousSummary = "[Session Goal]\n- Existing goal\n\n---\n\n[user]\nExisting goal";
+    const r = compile({
+      previousSummary,
+      messages: [userMsg("Also add meta monitoring dashboards")],
+    });
+    const current = r.split("\n\n---\n\n")[0];
+    expect(current).toContain("[Session Goal]\n- Existing goal");
+    expect(current).toContain("[Current Scope]\n- Also add meta monitoring dashboards");
+  });
+
+  it("keeps prior current scope when fresh window is status-only", () => {
+    const previousSummary = "[Session Goal]\n- Existing goal\n\n[Current Scope]\n- Add meta monitoring\n\n---\n\n[user]\nExisting goal";
+    const r = compile({
+      previousSummary,
+      messages: [userMsg("Status update: validate dashboard provisioning next")],
+    });
+    const current = r.split("\n\n---\n\n")[0];
+    expect(current).toContain("[Current Scope]\n- Add meta monitoring");
+  });
 });

--- a/tests/compile.test.ts
+++ b/tests/compile.test.ts
@@ -89,4 +89,17 @@ describe("compile", () => {
     expect(current).toContain("npm test");
     expect(current).not.toContain("prefer yarn test");
   });
+
+  it("preserves fresh brief-only updates when merging previous summary", () => {
+    const previousSummary = "[Session Goal]\n- Existing goal\n\n---\n\n[user]\nExisting goal";
+    const r = compile({
+      previousSummary,
+      messages: [
+        userMsg("Status update: wiring is started; next validate dashboard provisioning."),
+        assistantText("Next step: validate dashboard provisioning without changing the stable objective."),
+      ],
+    });
+    expect(r).toContain("Existing goal");
+    expect(r).toContain("validate dashboard provisioning");
+  });
 });

--- a/tests/compile.test.ts
+++ b/tests/compile.test.ts
@@ -77,4 +77,16 @@ describe("compile", () => {
     expect(r).toContain("earlier lines omitted");
     expect(r).toContain("latest");
   });
+
+  it("supersedes stale positive preferences after explicit correction", () => {
+    const previousSummary = "[User Preferences]\n- For this repo, prefer yarn test when validating.\n\n---\n\n[user]\nold";
+    const r = compile({
+      previousSummary,
+      messages: [userMsg("Correction: never use yarn here. Use npm test for broad validation and node --test for focused checks.")],
+    });
+    const current = r.split("\n\n---\n\n")[0];
+    expect(current).toContain("never use yarn");
+    expect(current).toContain("npm test");
+    expect(current).not.toContain("prefer yarn test");
+  });
 });

--- a/tests/extract-goals.test.ts
+++ b/tests/extract-goals.test.ts
@@ -90,4 +90,20 @@ describe("extractGoals", () => {
       "Benchmark cache-aware compaction. Stable objective: preserve Layer 0 and Layer 1 prefixes.",
     ]);
   });
+
+  it("keeps pasted kubernetes status tables out of stable goals", () => {
+    const goals = extractGoals([
+      { kind: "user", text: "Fix chart naming" },
+      { kind: "user", text: "NAME READY STATUS RESTARTS AGE\ngrafana-db-1 1/1 Running 0 101m" },
+    ]);
+    expect(goals).toEqual(["Fix chart naming"]);
+  });
+
+  it("keeps direct preference instructions out of stable goals", () => {
+    const goals = extractGoals([
+      { kind: "user", text: "Install kube-prometheus-stack" },
+      { kind: "user", text: "I hate verbose naming; please use the name fix thing they provide" },
+    ]);
+    expect(goals).toEqual(["Install kube-prometheus-stack"]);
+  });
 });

--- a/tests/extract-goals.test.ts
+++ b/tests/extract-goals.test.ts
@@ -38,29 +38,27 @@ describe("extractGoals", () => {
     expect(extractGoals(blocks)).toEqual(["first goal"]);
   });
 
-  it("detects scope change with explicit pivot keywords", () => {
+  it("keeps explicit pivot keywords out of stable goals", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "user", text: "Fix login bug" },
       { kind: "assistant", text: "ok" },
       { kind: "user", text: "Actually, instead let's refactor the auth module" },
     ];
     const goals = extractGoals(blocks);
-    expect(goals).toContain("Fix login bug");
-    expect(goals).toContain("[Scope change]");
-    expect(goals.some((g) => g.includes("refactor"))).toBe(true);
+    expect(goals).toEqual(["Fix login bug"]);
   });
 
-  it("detects scope change from new task statements", () => {
+  it("keeps new task statements out of stable goals", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "user", text: "Fix login bug" },
       { kind: "assistant", text: "done" },
       { kind: "user", text: "Now implement the user registration flow" },
     ];
     const goals = extractGoals(blocks);
-    expect(goals).toContain("[Scope change]");
+    expect(goals).toEqual(["Fix login bug"]);
   });
 
-  it("keeps latest scope change only", () => {
+  it("keeps stable goals unchanged across multiple scope changes", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "user", text: "Fix login bug" },
       { kind: "assistant", text: "done" },
@@ -68,9 +66,7 @@ describe("extractGoals", () => {
       { kind: "assistant", text: "ok" },
       { kind: "user", text: "Change of plan, implement password reset" },
     ];
-    const goals = extractGoals(blocks);
-    const scopeIdx = goals.indexOf("[Scope change]");
-    expect(goals[scopeIdx + 1]).toContain("password reset");
+    expect(extractGoals(blocks)).toEqual(["Fix login bug"]);
   });
 
   it("skips noise short user messages as goals", () => {

--- a/tests/extract-goals.test.ts
+++ b/tests/extract-goals.test.ts
@@ -83,4 +83,15 @@ describe("extractGoals", () => {
     expect(goals[0]).toContain("Fix the authentication");
     expect(goals.some((g) => g === "ok")).toBe(false);
   });
+
+  it("keeps volatile blocker updates out of stable goals", () => {
+    const goals = extractGoals([
+      { kind: "user", text: "Benchmark cache-aware compaction. Stable objective: preserve Layer 0 and Layer 1 prefixes." },
+      { kind: "user", text: "Blocker update: offline LCP metrics are done; now add recall top-k metrics." },
+      { kind: "user", text: "Current blocker: cached-token accounting is missing." },
+    ]);
+    expect(goals).toEqual([
+      "Benchmark cache-aware compaction. Stable objective: preserve Layer 0 and Layer 1 prefixes.",
+    ]);
+  });
 });

--- a/tests/extract-preferences.test.ts
+++ b/tests/extract-preferences.test.ts
@@ -27,4 +27,11 @@ describe("extractPreferences", () => {
     ];
     expect(extractPreferences(blocks).length).toBe(1);
   });
+
+  it("ignores copied error text that says always include stack traces", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "METRICS ENGI... . (SYNTAX_ERROR), Stack trace (when copying this message, always include the lines below):" },
+    ];
+    expect(extractPreferences(blocks)).toEqual([]);
+  });
 });

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -4,6 +4,7 @@ import type { SectionData } from "../src/sections";
 
 const empty: SectionData = {
   sessionGoal: [],
+  currentScope: [],
   outstandingContext: [],
   filesAndChanges: [],
   commits: [],

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -7,6 +7,7 @@ const empty: SectionData = {
   outstandingContext: [],
   filesAndChanges: [],
   commits: [],
+  evidenceHandles: [],
   userPreferences: [],
   briefTranscript: "",
   transcriptEntries: [],


### PR DESCRIPTION
Add a Docker-runnable offline benchmark for compaction behavior with pressure-style synthetic scenarios, scoped current/history/recall assertions, and assertion mode for selected compactors. This creates RED probes for exact state recovery, recall recovery, stale-current leakage, bulk offloading, and cache-churn signals before broader cache-aware compaction work.

Validation: node --check on benchmark files; git diff --check; docker build -t pi-vcc-bench .; docker benchmark descriptive/jsonl/assertion runs.