### PR TITLE
fix: compact-all when no user message instead of cancelling

### DIFF
--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -51,8 +51,7 @@ interface EntryWithMessage {
 
 export type OwnCutCancelReason =
   | "no_live_messages"
-  | "too_few_live_messages"
-  | "no_user_message";
+  | "too_few_live_messages";
 
 export type OwnCutResult =
   | { ok: true; messages: any[]; firstKeptEntryId: string; compactAll: boolean }
@@ -110,11 +109,13 @@ export function buildOwnCut(branchEntries: any[]): OwnCutResult {
 
   if (cutIdx <= 0) {
     // Single user prompt scenario (or no user at all).
-    // If there's at least one user message, compact EVERYTHING and keep no tail.
+    // Compact EVERYTHING and keep no tail. This handles both:
+    //  - Single user prompt at index 0: compact all, fresh start after summary
+    //  - No user message at all (e.g., long assistant/tool chain): still compact
+    //    to recover from context overflow rather than cancelling and leaving
+    //    the session unrecoverable.
     // firstKeptEntryId="" is a sentinel: pi-core's buildSessionContext won't match it
     // (so 0 kept from pre-compaction), and next buildOwnCut triggers orphan recovery.
-    const hasUser = liveMessages.some((m) => m.message.role === "user");
-    if (!hasUser) return { ok: false, reason: "no_user_message" };
     return {
       ok: true,
       messages: liveMessages.map((e) => e.message),
@@ -134,7 +135,6 @@ export function buildOwnCut(branchEntries: any[]): OwnCutResult {
 const REASON_MESSAGES: Record<OwnCutCancelReason, string> = {
   no_live_messages: "pi-vcc: Nothing to compact (no live messages)",
   too_few_live_messages: "pi-vcc: Too few messages to compact",
-  no_user_message: "pi-vcc: Cannot compact — no user message found",
 };
 
 export const registerBeforeCompactHook = (pi: ExtensionAPI) => {

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -88,14 +88,17 @@ describe("registerBeforeCompactHook: cancel paths", () => {
     expect(notifyCalls[0].msg).toContain("Too few messages");
   });
 
-  test("/pi-vcc with no user message cancels with no_user_message reason", () => {
+  test("/pi-vcc with no user message compacts all instead of cancelling", () => {
     setConfig({ debug: false, overrideDefaultCompaction: false });
     const { pi, invoke, notifyCalls } = createMockPi();
     registerBeforeCompactHook(pi);
 
     const entries = [msg("m1", "assistant"), msg("m2", "assistant"), msg("m3", "assistant")];
-    expect(invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
-    expect(notifyCalls[0].msg).toContain("no user message");
+    const result = invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+    // No longer cancels — compacts all to recover from context overflow
+    expect(result.cancel).toBeUndefined();
+    expect(result.compaction).toBeDefined();
+    expect(result.compaction.firstKeptEntryId).toBe("");
   });
 
   test("/compact with override=true cancels and notifies (NEW: was silent before)", () => {
@@ -119,23 +122,22 @@ describe("registerBeforeCompactHook: cancel paths", () => {
     expect(notifyCalls).toHaveLength(0);
   });
 
-  test("debug:true writes metrics-only snapshot with no content leakage", () => {
+  test("debug:true writes metrics-only snapshot on cancel with no content leakage", () => {
     setConfig({ debug: true, overrideDefaultCompaction: false });
     const { pi, invoke } = createMockPi();
     registerBeforeCompactHook(pi);
 
+    // Use too_few_live_messages cancel path to test content leakage
     const entries = [
-      msg("m1", "assistant", "SECRET_TOKEN_abc123"),
+      msg("m1", "user", "SECRET_TOKEN_abc123"),
       msg("m2", "assistant", "sensitive response"),
-      msg("m3", "assistant", "more text"),
     ];
     expect(invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
 
     expect(existsSync(DEBUG_PATH)).toBe(true);
     const snapshot = JSON.parse(readFileSync(DEBUG_PATH, "utf-8"));
     expect(snapshot.cancelled).toBe(true);
-    expect(snapshot.reason).toBe("no_user_message");
-    expect(snapshot.isPiVcc).toBe(true);
+    expect(snapshot.reason).toBe("too_few_live_messages");
 
     // No content leakage
     const serialized = JSON.stringify(snapshot);

--- a/tests/before-compact.test.ts
+++ b/tests/before-compact.test.ts
@@ -91,15 +91,20 @@ describe("buildOwnCut", () => {
     expect(r.messages).toHaveLength(6);
   });
 
-  test("no_user_message when no user role at all", () => {
+  test("no user message: compact-all instead of cancelling", () => {
+    // When there are enough live messages but none are from the user
+    // (e.g., long assistant/tool chain), compact all rather than
+    // cancelling and leaving the session unrecoverable.
     const r = buildOwnCut([
       msg("m1", "assistant", "a"),
       msg("m2", "assistant", "b"),
       msg("m3", "assistant", "c"),
     ]);
-    expect(r.ok).toBe(false);
-    if (r.ok) return;
-    expect(r.reason).toBe("no_user_message");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.compactAll).toBe(true);
+    expect(r.firstKeptEntryId).toBe("");
+    expect(r.messages).toHaveLength(3);
   });
 
   test("compact-all then more chat: orphan recovery + normal cut", () => {


### PR DESCRIPTION
## Problem

When the live messages after the last compaction contain no `user` role messages (e.g., a long assistant/tool chain after the user's last prompt), `buildOwnCut` returned `{ ok: false, reason: "no_user_message" }`, which **cancelled compaction entirely**. This left the session in an unrecoverable state:

1. Context overflows (~205k tokens)
2. pi-core triggers auto-compaction
3. pi-vcc cancels with "Cannot compact — no user message found"
4. Context overflow error persists (400 error)
5. Auto-compaction retry also fails → session is stuck

## Fix

When there are enough live messages but none are from the user, **compact ALL of them** (`compactAll: true`, `firstKeptEntryId: ""`), same as the single-user-prompt-at-index-0 case. The summary replaces everything, and the next user message starts fresh.

The orphan-recovery mechanism (`firstKeptEntryId=""` sentinel) already handles the follow-up compaction correctly.

## Changes

- Remove `no_user_message` from `OwnCutCancelReason` union type
- Remove the `hasUser` guard in the `cutIdx <= 0` branch — always compact-all
- Remove `"no_user_message"` from `REASON_MESSAGES` map
- Update `before-compact.test.ts`: "no user message" test now expects `compactAll: true`
- Update `before-compact-hook.test.ts`: "no user message" test now expects compaction result, debug snapshot test refactored to use `too_few_live_messages` cancel path for content-leakage assertions

## Test Results

All 131 tests pass (including the updated tests).