### PR TITLE
fix: wrap compaction summaries for TUI display

### DIFF
--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -7,6 +7,33 @@ const section = (title: string, items: string[]): string => {
 };
 
 const BRIEF_MAX_LINES = 120;
+const TUI_SAFE_LINE_CHARS = 120;
+
+const wrapLine = (line: string, maxChars: number): string[] => {
+  if (line.length <= maxChars) return [line];
+
+  const indent = line.match(/^\s*(?:[-*]\s+|\d+\.\s+)?/)?.[0] ?? "";
+  const continuationIndent = indent ? " ".repeat(Math.min(indent.length, 8)) : "";
+  const wrapped: string[] = [];
+  let remaining = line;
+  let prefix = "";
+
+  while (prefix.length + remaining.length > maxChars) {
+    const available = Math.max(20, maxChars - prefix.length);
+    let splitAt = remaining.lastIndexOf(" ", available);
+    if (splitAt < Math.floor(available * 0.5)) splitAt = available;
+
+    wrapped.push(prefix + remaining.slice(0, splitAt).trimEnd());
+    remaining = remaining.slice(splitAt).trimStart();
+    prefix = continuationIndent;
+  }
+
+  if (remaining) wrapped.push(prefix + remaining);
+  return wrapped;
+};
+
+export const wrapLongLines = (text: string, maxChars = TUI_SAFE_LINE_CHARS): string =>
+  text.split("\n").flatMap((line) => wrapLine(line, maxChars)).join("\n");
 
 export const capBrief = (text: string): string => {
   const lines = text.split("\n");
@@ -45,5 +72,5 @@ export const formatSummary = (data: SectionData): string => {
   // NOTE: RECALL_NOTE is intentionally NOT appended here.
   // It is appended once by `compile()` at the very end, after merge-with-previous,
   // to avoid the note compounding inside the brief transcript across compactions.
-  return parts.join("\n\n---\n\n");
+  return wrapLongLines(parts.join("\n\n---\n\n"));
 };

--- a/src/core/summarize.ts
+++ b/src/core/summarize.ts
@@ -145,7 +145,7 @@ export const compile = (input: CompileInput): string => {
     : undefined;
   const merged = prev ? mergePrevious(prev, fresh) : fresh;
   if (!merged) return "";
-  return wrapLongLines(merged) + SEPARATOR + RECALL_NOTE;
+  return wrapLongLines(merged + SEPARATOR + RECALL_NOTE);
 };
 
 const stripRecallNote = (text: string): string => {

--- a/src/core/summarize.ts
+++ b/src/core/summarize.ts
@@ -3,7 +3,7 @@ import type { FileOps } from "../types";
 import { normalize } from "./normalize";
 import { filterNoise } from "./filter-noise";
 import { buildSections } from "./build-sections";
-import { formatSummary, capBrief, RECALL_NOTE } from "./format";
+import { formatSummary, capBrief, RECALL_NOTE, wrapLongLines } from "./format";
 
 export interface CompileInput {
   messages: Message[];
@@ -145,7 +145,7 @@ export const compile = (input: CompileInput): string => {
     : undefined;
   const merged = prev ? mergePrevious(prev, fresh) : fresh;
   if (!merged) return "";
-  return merged + SEPARATOR + RECALL_NOTE;
+  return wrapLongLines(merged) + SEPARATOR + RECALL_NOTE;
 };
 
 const stripRecallNote = (text: string): string => {

--- a/tests/compile.test.ts
+++ b/tests/compile.test.ts
@@ -77,4 +77,13 @@ describe("compile", () => {
     expect(r).toContain("earlier lines omitted");
     expect(r).toContain("latest");
   });
+
+  it("wraps final output including recall note", () => {
+    const r = compile({
+      messages: [userMsg("check final summary wrapping")],
+    });
+    const maxLineLength = Math.max(...r.split("\n").map((line) => line.length));
+    expect(r).toContain("vcc_recall");
+    expect(maxLineLength).toBeLessThanOrEqual(120);
+  });
 });

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -59,4 +59,13 @@ describe("formatSummary", () => {
     expect(r).toContain("[Outstanding Context]");
     expect(r).toContain("\n\n");
   });
+
+  it("wraps long lines so compaction TUI rendering stays bounded", () => {
+    const data = {
+      ...empty,
+      briefTranscript: `[assistant]\n${"word ".repeat(80)}`,
+    };
+    const r = formatSummary(data);
+    expect(Math.max(...r.split("\n").map((line) => line.length))).toBeLessThanOrEqual(120);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #6.

This makes pi-vcc compaction summaries TUI-safe by wrapping long lines before they are returned to Pi's compaction system.

Changes:

- add `wrapLongLines()` in `src/core/format.ts`
- wrap `formatSummary()` output at 120 chars
- wrap merged summaries in `compile()` so previous summaries cannot reintroduce very long lines
- add a regression test for bounded summary line length

## Why

A real pi-vcc compaction summary contained an otherwise-normal markdown summary with one 1,658-character line. Pi's TUI rendered that compaction as a huge mostly-empty block with scattered text across the terminal.

Bounding emitted summary line length keeps the summary readable and avoids relying on downstream TUI renderers to handle pathological lines.

## Verification

```text
bun test tests/format.test.ts tests/compile.test.ts tests/before-compact-hook.test.ts tests/before-compact.test.ts
27 pass / 0 fail
```

Local regression check on the observed bad summary:

```text
before max line: 1658
after max line: 120
```
