### PR TITLE
fix: correct searchEntries arg order and add missing bashExecution normalization

### DIFF
--- a/src/core/brief.ts
+++ b/src/core/brief.ts
@@ -156,6 +156,15 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
         lastHeader = "[user]";
         break;
       }
+      case "bash": {
+        const cmd = compressBash(b.command);
+        const ref = b.sourceIndex != null ? ` (#${b.sourceIndex})` : "";
+        if (cmd) {
+          push("[user]", `$ ${cmd}${ref}`);
+        }
+        lastHeader = "[user]";
+        break;
+      }
       case "assistant": {
         let raw = b.text;
         // Strip leading self-talk prefix (up to 2x; assistants sometimes chain "Hmm, actually, ...")

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -18,6 +18,13 @@ const normalizeOne = (msg: Message, msgIndex: number): NormalizedBlock[] => {
     return blocks.length > 0 ? blocks : [{ kind: "user", text: "", sourceIndex: msgIndex }];
   }
 
+  if (msg.role === "bashExecution") {
+    const cmd = (msg as any).command ?? "";
+    const out = (msg as any).output ?? "";
+    const exit = (msg as any).exitCode;
+    return [{ kind: "bash", command: cmd, output: out, exitCode: exit, sourceIndex: msgIndex }];
+  }
+
   if (msg.role === "toolResult") {
     return [{
       kind: "tool_result",

--- a/src/core/report.ts
+++ b/src/core/report.ts
@@ -192,7 +192,7 @@ const probesOf = (messages: Message[], summary: string): RecallProbe[] => {
         sourceText,
         query,
         summaryMentioned: matchesQuery(summary, query),
-        recallHits: searchEntries(rendered, query).length,
+        recallHits: searchEntries(rendered, messages, query).length,
       };
     })
     .filter((probe): probe is RecallProbe => probe !== null);

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,4 +11,5 @@ export type NormalizedBlock =
   | { kind: "assistant"; text: string; sourceIndex?: number }
   | { kind: "tool_call"; name: string; args: Record<string, unknown>; sourceIndex?: number }
   | { kind: "tool_result"; name: string; text: string; isError: boolean; sourceIndex?: number }
+  | { kind: "bash"; command: string; output: string; exitCode: number | undefined; sourceIndex?: number }
   | { kind: "thinking"; text: string; redacted: boolean; sourceIndex?: number };

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -19,6 +19,15 @@ describe("compileBrief", () => {
     expect(r).toContain("Let me look at the auth module.");
   });
 
+  it("renders bash commands as user actions", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "bash", command: "npm test", output: "FAIL noisy output", exitCode: 1, sourceIndex: 2 },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("[user]\n$ npm test (#2)");
+    expect(r).not.toContain("FAIL noisy output");
+  });
+
   it("strips filler prefixes but preserves meaningful lead-ins", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "assistant", text: "Okay, I found the root cause." },

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -87,10 +87,17 @@ describe("normalize", () => {
     expect(blocks[1]).toEqual({ kind: "user", text: "[image: image/png]", sourceIndex: 0 });
   });
 
-  it("skips unknown message roles gracefully", () => {
-    const weird = { role: "bashExecution", command: "ls", output: "files", exitCode: 0 } as any;
-    const blocks = normalize([weird]);
-    expect(blocks).toEqual([]);
+  it("normalizes bashExecution messages", () => {
+    const msg = { role: "bashExecution", command: "ls -la", output: "files", exitCode: 0 } as any;
+    const blocks = normalize([msg]);
+    expect(blocks).toEqual([
+      { kind: "bash", command: "ls -la", output: "files", exitCode: 0, sourceIndex: 0 },
+    ]);
+  });
+
+  it("skips truly unknown message roles gracefully", () => {
+    const custom = { role: "custom", content: "hello" } as any;
+    expect(normalize([custom])).toEqual([]);
   });
 });
 

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -41,4 +41,18 @@ describe("buildCompactReport", () => {
     const goalProbe = report.recall.probes.find((p) => p.label === "goal");
     expect(goalProbe?.summaryMentioned).toBe(true);
   });
+
+  it("counts recall hits with the probe query", () => {
+    const report = buildCompactReport({
+      messages: [
+        userMsg("Handle unrelated setup"),
+        assistantWithToolCall("Read", { path: "unique-auth-file.ts" }),
+        toolResult("Read", "code content"),
+        assistantText("Done"),
+      ],
+    });
+    const fileProbe = report.recall.probes.find((p) => p.label === "file");
+    expect(fileProbe?.query).toBe("unique-auth-file.ts");
+    expect(fileProbe?.recallHits).toBe(1);
+  });
 });


### PR DESCRIPTION
## Bug Fixes

### 1. `searchEntries` called with wrong argument order in `report.ts`

**File:** `src/core/report.ts`

`searchEntries` has the signature `(entries, messages, query)`, but `probesOf` called it as `searchEntries(rendered, query)` — passing the query string as the `messages` array. This meant `messages[i]` was always `undefined`, causing the fallback text path, and `query` itself was `undefined`, so search never actually ran. **Recall hit counts in benchmark reports were meaningless.**

**Fix:** Pass `messages` as the second argument: `searchEntries(rendered, messages, query)`.

### 2. `bashExecution` messages silently dropped during compaction

**Files:** `src/types.ts`, `src/core/normalize.ts`, `src/core/brief.ts`

`normalizeOne` handled `user`, `assistant`, and `toolResult` roles, but any other role (including `bashExecution`, which Pi uses for `!` command results) fell through to `return []`. Shell command context was completely invisible in compacted summaries.

**Fix:**
- Added `{ kind: "bash"; ... }` to `NormalizedBlock` union.
- Added `bashExecution` case in `normalizeOne` that extracts `command`, `output`, and `exitCode`.
- Added `case "bash"` in `buildBriefSections` so bash commands render under `[user]` like `$ ls -la (#N)`.

### Test update

Replaced the test in `tests/normalize.test.ts` that asserted `bashExecution` was skipped with one asserting it is correctly normalized. Added a test for truly unknown roles to preserve the safety net.
