### PR TITLE
refactor: remove unused message normalization noise

### DIFF
--- a/src/core/brief.ts
+++ b/src/core/brief.ts
@@ -1,5 +1,5 @@
 import type { NormalizedBlock } from "../types";
-import { clip, firstLine } from "./content";
+import { clip } from "./content";
 import { extractPath } from "./tool-args";
 import { collapseSkillText } from "./skill-collapse";
 
@@ -111,21 +111,10 @@ const toolOneLiner = (name: string, args: Record<string, unknown>): string => {
 };
 
 export interface BriefLine {
-  /** Section header like "[user]", "[assistant]", "[tool_error] bash" */
+  /** Section header like "[user]" or "[assistant]" */
   header: string;
   /** Content lines for this section */
   lines: string[];
-}
-
-/** Structured transcript entry for JSON output */
-export interface TranscriptEntry {
-  role: "user" | "assistant" | "tool_error";
-  text?: string;
-  tool?: string;
-  cmd?: string;
-  ref?: string;
-  /** Collapse count when identical tool calls are grouped */
-  count?: number;
 }
 
 /**
@@ -188,19 +177,8 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
         push("[assistant]", summary);
         break;
       }
-      case "tool_result": {
-        if (b.isError) {
-          const body = firstLine(b.text, 150);
-          // Drop empty/placeholder error bodies — keep the line only if it carries info.
-          if (!body || body === "(no output)") break;
-          const ref = b.sourceIndex != null ? ` (#${b.sourceIndex})` : "";
-          const header = `[tool_error] ${b.name}${ref}`;
-          push(header, body);
-          lastHeader = header;
-        }
-        break;
-      }
-      case "thinking":
+      case "tool_result":
+        // Tool result bodies are intentionally omitted from compact briefs.
         break;
     }
   }
@@ -252,34 +230,6 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
     sec.lines = next;
   }
 
-  // Collapse consecutive identical [tool_error] sections (same tool, same body).
-  // E.g. 20 back-to-back `[tool_error] bash (#N) ... Command aborted` become one
-  // `[tool_error] bash (#refs...) x20` entry.
-  const collapsedErrors: BriefLine[] = [];
-  for (const sec of sections) {
-    const m = sec.header.match(/^\[tool_error\]\s+(\S+?)(?:\s*\(#(\d+)\))?$/);
-    if (!m || sec.lines.length !== 1) {
-      collapsedErrors.push(sec);
-      continue;
-    }
-    const tool = m[1];
-    const ref = m[2];
-    const body = sec.lines[0];
-    const prev = collapsedErrors[collapsedErrors.length - 1];
-    const prevMatch = prev?.header.match(
-      /^\[tool_error\]\s+(\S+?)\s*\(((?:#\d+(?:,\s*)?)+)\)(?:\s*x(\d+))?$/,
-    );
-    if (prev && prevMatch && prevMatch[1] === tool && prev.lines.length === 1 && prev.lines[0] === body) {
-      const refs = prevMatch[2] + (ref ? `, #${ref}` : "");
-      const count = prevMatch[3] ? parseInt(prevMatch[3]) + 1 : 2;
-      prev.header = `[tool_error] ${tool} (${refs}) x${count}`;
-    } else {
-      collapsedErrors.push(sec);
-    }
-  }
-  sections.length = 0;
-  sections.push(...collapsedErrors);
-
   return sections;
 };
 
@@ -309,80 +259,6 @@ export const stringifyBrief = (sections: BriefLine[]): string => {
   }
 
   return out.join("\n");
-};
-
-/** Parse a text line into a structured TranscriptEntry */
-const parseToolLine = (line: string): { tool: string; cmd?: string; ref?: string; count?: number } | null => {
-  // * bash "cmd" (#5)
-  // * bash "cmd" (#1, #3) x2
-  // * tilth "query" (#7)
-  const m = line.match(/^\* (\S+)\s*(?:"([^"]*)")?\s*(?:\((#[\d, #]+)\))?\s*(?:x(\d+))?$/);
-  if (!m) return null;
-  return {
-    tool: m[1],
-    cmd: m[2] || undefined,
-    ref: m[3] || undefined,
-    count: m[4] ? parseInt(m[4]) : undefined,
-  };
-};
-
-const extractRef = (text: string): { clean: string; ref?: string } => {
-  const m = text.match(/\s*\(#(\d+)\)$/);
-  if (!m) return { clean: text };
-  return { clean: text.slice(0, m.index).trimEnd(), ref: `#${m[1]}` };
-};
-
-/**
- * Convert BriefLine sections to structured TranscriptEntry array for JSON output.
- */
-export const sectionsToTranscript = (sections: BriefLine[]): TranscriptEntry[] => {
-  const entries: TranscriptEntry[] = [];
-
-  for (const sec of sections) {
-    if (sec.header === "[user]") {
-      for (const line of sec.lines) {
-        const { clean, ref } = extractRef(line);
-        entries.push({ role: "user", text: clean, ...(ref && { ref }) });
-      }
-    } else if (sec.header === "[assistant]") {
-      for (const line of sec.lines) {
-        if (line.startsWith("* ")) {
-          const parsed = parseToolLine(line);
-          if (parsed) {
-            entries.push({
-              role: "assistant",
-              tool: parsed.tool,
-              ...(parsed.cmd && { cmd: parsed.cmd }),
-              ...(parsed.ref && { ref: parsed.ref }),
-              ...(parsed.count && { count: parsed.count }),
-            });
-          } else {
-            // Fallback: unparseable tool line
-            const { clean, ref } = extractRef(line.slice(2));
-            entries.push({ role: "assistant", text: clean, ...(ref && { ref }) });
-          }
-        } else {
-          const { clean, ref } = extractRef(line);
-          entries.push({ role: "assistant", text: clean, ...(ref && { ref }) });
-        }
-      }
-    } else if (sec.header.startsWith("[tool_error]")) {
-      // [tool_error] bash (#5)
-      const headerMatch = sec.header.match(/^\[tool_error\]\s+(\S+)\s*(?:\(#(\d+)\))?/);
-      const tool = headerMatch?.[1] ?? "unknown";
-      const ref = headerMatch?.[2] ? `#${headerMatch[2]}` : undefined;
-      for (const line of sec.lines) {
-        entries.push({
-          role: "tool_error",
-          tool,
-          text: line,
-          ...(ref && { ref }),
-        });
-      }
-    }
-  }
-
-  return entries;
 };
 
 /** Convenience: build sections from blocks and stringify to text */

--- a/src/core/build-sections.ts
+++ b/src/core/build-sections.ts
@@ -1,11 +1,11 @@
 import type { NormalizedBlock } from "../types";
-import { clip, clipSentence, firstLine, nonEmptyLines } from "./content";
+import { clip, clipSentence, nonEmptyLines } from "./content";
 import type { SectionData } from "../sections";
 import { extractGoals } from "../extract/goals";
 import { extractFiles } from "../extract/files";
 import { extractPreferences, dedupPreferencesAgainstGoals } from "../extract/preferences";
 import { extractCommits, formatCommits } from "../extract/commits";
-import { buildBriefSections, sectionsToTranscript, stringifyBrief } from "./brief";
+import { buildBriefSections, stringifyBrief } from "./brief";
 
 export interface BuildSectionsInput {
   blocks: NormalizedBlock[];
@@ -19,11 +19,6 @@ const extractOutstandingContext = (blocks: NormalizedBlock[]): string[] => {
   const tail = blocks.slice(-20);
 
   for (const b of tail) {
-    if (b.kind === "tool_result" && b.isError) {
-      items.push(`[${b.name}] ${firstLine(b.text, 150)}`);
-      continue;
-    }
-
     if (b.kind === "assistant" || b.kind === "user") {
       for (const line of nonEmptyLines(b.text)) {
         if (!BLOCKER_RE.test(line)) continue;
@@ -74,6 +69,5 @@ export const buildSections = (input: BuildSectionsInput): SectionData => {
     commits: formatCommits(extractCommits(blocks)),
     userPreferences,
     briefTranscript: stringifyBrief(briefSections),
-    transcriptEntries: sectionsToTranscript(briefSections),
   };
 };

--- a/src/core/filter-noise.ts
+++ b/src/core/filter-noise.ts
@@ -26,7 +26,6 @@ const cleanUserText = (text: string): string =>
 export const filterNoise = (blocks: NormalizedBlock[]): NormalizedBlock[] => {
   const out: NormalizedBlock[] = [];
   for (const b of blocks) {
-    if (b.kind === "thinking") continue;
     if (b.kind === "tool_call" && NOISE_TOOLS.has(b.name)) continue;
     if (b.kind === "tool_result" && NOISE_TOOLS.has(b.name)) continue;
     if (b.kind === "user") {

--- a/src/core/load-messages.ts
+++ b/src/core/load-messages.ts
@@ -5,7 +5,6 @@ import { renderMessage, type RenderedEntry } from "./render-entries";
 export interface LoadedMessages {
   rendered: RenderedEntry[];
   rawMessages: Message[];
-  entryIds: string[];
 }
 
 export const loadAllMessages = (
@@ -21,7 +20,6 @@ export const loadAllMessages = (
   }
   const rendered: RenderedEntry[] = [];
   const rawMessages: Message[] = [];
-  const entryIds: string[] = [];
 
   let messageIndex = 0;
   for (const e of entries) {
@@ -32,10 +30,9 @@ export const loadAllMessages = (
     if (allowed) {
       rendered.push(renderMessage(e.message, messageIndex, full));
       rawMessages.push(e.message);
-      entryIds.push(String(e.id));
     }
     messageIndex++;
   }
 
-  return { rendered, rawMessages, entryIds };
+  return { rendered, rawMessages };
 };

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -30,7 +30,6 @@ const normalizeOne = (msg: Message, msgIndex: number): NormalizedBlock[] => {
       kind: "tool_result",
       name: msg.toolName,
       text: sanitize(textOf(msg.content)),
-      isError: msg.isError,
       sourceIndex: msgIndex,
     }];
   }
@@ -45,13 +44,6 @@ const normalizeOne = (msg: Message, msgIndex: number): NormalizedBlock[] => {
     for (const part of msg.content) {
       if (part.type === "text") {
         blocks.push({ kind: "assistant", text: sanitize(part.text), sourceIndex: msgIndex });
-      } else if (part.type === "thinking") {
-        blocks.push({
-          kind: "thinking",
-          text: sanitize(part.thinking),
-          redacted: part.redacted ?? false,
-          sourceIndex: msgIndex,
-        });
       } else if (part.type === "toolCall") {
         blocks.push({
           kind: "tool_call",

--- a/src/core/render-entries.ts
+++ b/src/core/render-entries.ts
@@ -31,11 +31,10 @@ export const renderMessage = (msg: Message, index: number, full = false): Render
     return { index, role: "user", summary: full ? textOf(msg.content) : clip(textOf(msg.content), 300) };
   }
   if (msg.role === "toolResult") {
-    const prefix = msg.isError ? "ERROR " : "";
     const text = full ? textOf(msg.content) : clip(textOf(msg.content), 200);
     return {
       index, role: "tool_result",
-      summary: `${prefix}[${msg.toolName}] ${text}`,
+      summary: `[${msg.toolName}] ${text}`,
     };
   }
   // bashExecution has command+output instead of content

--- a/src/core/report.ts
+++ b/src/core/report.ts
@@ -19,7 +19,6 @@ interface BlockCounts {
   assistant: number;
   toolCalls: number;
   toolResults: number;
-  thinking: number;
 }
 
 export interface RecallProbe {
@@ -80,7 +79,6 @@ const countBlocks = (messages: Message[]): BlockCounts => {
     assistant: 0,
     toolCalls: 0,
     toolResults: 0,
-    thinking: 0,
   };
 
   for (const block of normalize(messages)) {
@@ -88,7 +86,6 @@ const countBlocks = (messages: Message[]): BlockCounts => {
     else if (block.kind === "assistant") counts.assistant += 1;
     else if (block.kind === "tool_call") counts.toolCalls += 1;
     else if (block.kind === "tool_result") counts.toolResults += 1;
-    else if (block.kind === "thinking") counts.thinking += 1;
   }
 
   return counts;

--- a/src/sections.ts
+++ b/src/sections.ts
@@ -1,5 +1,3 @@
-import type { TranscriptEntry } from "./core/brief";
-
 export interface SectionData {
   sessionGoal: string[];
   outstandingContext: string[];
@@ -7,6 +5,4 @@ export interface SectionData {
   commits: string[];
   userPreferences: string[];
   briefTranscript: string;
-  /** Structured transcript entries (verbose object format) */
-  transcriptEntries: TranscriptEntry[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,5 @@ export type NormalizedBlock =
   | { kind: "user"; text: string; sourceIndex?: number }
   | { kind: "assistant"; text: string; sourceIndex?: number }
   | { kind: "tool_call"; name: string; args: Record<string, unknown>; sourceIndex?: number }
-  | { kind: "tool_result"; name: string; text: string; isError: boolean; sourceIndex?: number }
-  | { kind: "bash"; command: string; output: string; exitCode: number | undefined; sourceIndex?: number }
-  | { kind: "thinking"; text: string; redacted: boolean; sourceIndex?: number };
+  | { kind: "tool_result"; name: string; text: string; sourceIndex?: number }
+  | { kind: "bash"; command: string; output: string; exitCode: number | undefined; sourceIndex?: number };

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -56,29 +56,18 @@ describe("compileBrief", () => {
 
   it("hides non-error tool results", () => {
     const blocks: NormalizedBlock[] = [
-      { kind: "tool_result", name: "Read", text: "const x = 1;\nconst y = 2;\n// lots of code", isError: false },
+      { kind: "tool_result", name: "Read", text: "const x = 1;\nconst y = 2;\n// lots of code" },
     ];
     const r = compileBrief(blocks);
     expect(r).toBe("");
   });
 
-  it("shows tool errors with first line", () => {
+  it("hides tool results regardless of output text", () => {
     const blocks: NormalizedBlock[] = [
-      { kind: "tool_result", name: "bash", text: "FAIL auth.test.ts\nexpected 200 got 401", isError: true },
+      { kind: "tool_result", name: "bash", text: "FAIL auth.test.ts\nexpected 200 got 401" },
     ];
     const r = compileBrief(blocks);
-    expect(r).toContain("[tool_error] bash");
-    expect(r).toContain("FAIL auth.test.ts");
-  });
-
-  it("hides thinking blocks", () => {
-    const blocks: NormalizedBlock[] = [
-      { kind: "thinking", text: "Let me think about this...", redacted: false },
-      { kind: "assistant", text: "Here's what I found." },
-    ];
-    const r = compileBrief(blocks);
-    expect(r).not.toContain("think");
-    expect(r).toContain("Here's what I found.");
+    expect(r).toBe("");
   });
 
   it("merges adjacent assistant sections", () => {
@@ -128,27 +117,26 @@ describe("compileBrief", () => {
   it("renders a realistic conversation flow", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "user", text: "fix the login bug" },
-      { kind: "thinking", text: "I need to check...", redacted: false },
       { kind: "assistant", text: "Let me investigate." },
       { kind: "tool_call", name: "Read", args: { file_path: "login.ts" } },
-      { kind: "tool_result", name: "Read", text: "export function login() { ... }", isError: false },
+      { kind: "tool_result", name: "Read", text: "export function login() { ... }" },
       { kind: "tool_call", name: "bash", args: { command: "npm test" } },
-      { kind: "tool_result", name: "bash", text: "FAIL: login test\nExpected true, got false", isError: true },
+      { kind: "tool_result", name: "bash", text: "FAIL: login test\nExpected true, got false" },
       { kind: "assistant", text: "The test is failing because..." },
       { kind: "tool_call", name: "Edit", args: { file_path: "login.ts" } },
-      { kind: "tool_result", name: "Edit", text: "File edited successfully", isError: false },
+      { kind: "tool_result", name: "Edit", text: "File edited successfully" },
       { kind: "user", text: "test lại đi" },
       { kind: "assistant", text: "Running tests again." },
       { kind: "tool_call", name: "bash", args: { command: "npm test" } },
-      { kind: "tool_result", name: "bash", text: "All tests passed", isError: false },
+      { kind: "tool_result", name: "bash", text: "All tests passed" },
     ];
     const r = compileBrief(blocks);
 
     // Check structure
     expect(r).toContain("[user]\nfix the login bug");
     expect(r).toContain('[assistant]\nLet me investigate.\n* Read "login.ts"');
-    expect(r).toContain("[tool_error] bash\nFAIL: login test");
-    expect(r).toContain('[assistant]\nThe test is failing because...\n* Edit "login.ts"');
+    expect(r).toContain('* bash "npm test"');
+    expect(r).toContain('The test is failing because...\n* Edit "login.ts"');
     expect(r).toContain("[user]\ntest lại đi");
     expect(r).toContain('[assistant]\nRunning tests again.\n* bash "npm test"');
 
@@ -173,11 +161,11 @@ describe("compileBrief", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "assistant", text: "Checking files." },
       { kind: "tool_call", name: "Read", args: { file_path: "a.ts" } },
-      { kind: "tool_result", name: "Read", text: "...", isError: false },
+      { kind: "tool_result", name: "Read", text: "..." },
       // tool_result hidden → next tool_call starts new assistant section
       // but since both are tool-only, no blank line between
       { kind: "tool_call", name: "Read", args: { file_path: "b.ts" } },
-      { kind: "tool_result", name: "Read", text: "...", isError: false },
+      { kind: "tool_result", name: "Read", text: "..." },
     ];
     const r = compileBrief(blocks);
     // The first assistant section has text + tool, so it's NOT tool-only

--- a/tests/build-sections.test.ts
+++ b/tests/build-sections.test.ts
@@ -14,9 +14,9 @@ describe("buildSections", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "user", text: "Fix the auth bug" },
       { kind: "tool_call", name: "Read", args: { file_path: "auth.ts" } },
-      { kind: "tool_result", name: "Read", text: "const x = 1;", isError: false },
+      { kind: "tool_result", name: "Read", text: "const x = 1;" },
       { kind: "tool_call", name: "Edit", args: { file_path: "auth.ts" } },
-      { kind: "tool_result", name: "Edit", text: "ok", isError: false },
+      { kind: "tool_result", name: "Edit", text: "ok" },
       { kind: "assistant", text: "- run tests next" },
     ];
     const r = buildSections({ blocks });
@@ -26,24 +26,22 @@ describe("buildSections", () => {
     expect(r.briefTranscript).toContain('* Edit "auth.ts"');
   });
 
-  it("captures outstanding context from errors", () => {
+  it("captures outstanding context from user and assistant text", () => {
     const blocks: NormalizedBlock[] = [
-      { kind: "tool_result", name: "bash", text: "FAIL: test broken\ndetails here", isError: true },
+      { kind: "assistant", text: "Tests are still failing after the retry." },
     ];
     const r = buildSections({ blocks });
     expect(r.outstandingContext.length).toBeGreaterThan(0);
-    expect(r.outstandingContext[0]).toContain("FAIL");
+    expect(r.outstandingContext[0]).toContain("Tests are still failing");
   });
 
-  it("brief transcript hides tool results but shows errors", () => {
+  it("brief transcript hides tool results", () => {
     const blocks: NormalizedBlock[] = [
-      { kind: "tool_result", name: "Read", text: "lots of code here ...", isError: false },
-      { kind: "tool_result", name: "bash", text: "Command not found", isError: true },
+      { kind: "tool_result", name: "Read", text: "lots of code here ..." },
+      { kind: "tool_result", name: "bash", text: "Command not found" },
     ];
     const r = buildSections({ blocks });
-    expect(r.briefTranscript).not.toContain("lots of code");
-    expect(r.briefTranscript).toContain("[tool_error] bash");
-    expect(r.briefTranscript).toContain("Command not found");
+    expect(r.briefTranscript).toBe("");
   });
 
   it("brief transcript merges adjacent assistant sections", () => {

--- a/tests/filter-noise.test.ts
+++ b/tests/filter-noise.test.ts
@@ -3,18 +3,10 @@ import { filterNoise } from "../src/core/filter-noise";
 import type { NormalizedBlock } from "../src/types";
 
 describe("filterNoise", () => {
-  it("removes thinking blocks", () => {
-    const blocks: NormalizedBlock[] = [
-      { kind: "thinking", text: "hmm", redacted: false },
-      { kind: "assistant", text: "hello" },
-    ];
-    expect(filterNoise(blocks)).toEqual([{ kind: "assistant", text: "hello" }]);
-  });
-
   it("removes noise tool calls and results", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "tool_call", name: "TodoWrite", args: {} },
-      { kind: "tool_result", name: "TodoWrite", text: "ok", isError: false },
+      { kind: "tool_result", name: "TodoWrite", text: "ok" },
       { kind: "tool_call", name: "Read", args: { path: "x.ts" } },
     ];
     const result = filterNoise(blocks);
@@ -54,7 +46,7 @@ describe("filterNoise", () => {
   it("preserves non-noise tool calls", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "tool_call", name: "Edit", args: { path: "a.ts" } },
-      { kind: "tool_result", name: "Edit", text: "ok", isError: false },
+      { kind: "tool_result", name: "Edit", text: "ok" },
     ];
     expect(filterNoise(blocks)).toHaveLength(2);
   });

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -48,13 +48,12 @@ export const assistantWithToolCall = (
 export const toolResult = (
   name: string,
   text: string,
-  isError = false,
 ): Message => ({
   role: "toolResult",
   toolCallId: "tc_1",
   toolName: name,
   content: [{ type: "text", text }],
-  isError,
+  isError: false,
   timestamp: ts,
 });
 

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -9,7 +9,6 @@ const empty: SectionData = {
   commits: [],
   userPreferences: [],
   briefTranscript: "",
-  transcriptEntries: [],
 };
 
 describe("formatSummary", () => {

--- a/tests/load-messages.test.ts
+++ b/tests/load-messages.test.ts
@@ -21,7 +21,6 @@ describe("loadAllMessages", () => {
       const loaded = loadAllMessages(file, false);
       expect(loaded.rendered).toHaveLength(3);
       expect(loaded.rawMessages).toHaveLength(3);
-      expect(loaded.entryIds).toEqual(["m1", "m2", "m3"]);
       expect(loaded.rendered.map((e) => e.index)).toEqual([0, 1, 2]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -42,7 +41,6 @@ describe("loadAllMessages", () => {
       const loaded = loadAllMessages(file, false, new Set(["m2"]));
       expect(loaded.rendered).toHaveLength(1);
       expect(loaded.rawMessages).toHaveLength(1);
-      expect(loaded.entryIds).toEqual(["m2"]);
       expect(loaded.rendered[0].index).toBe(1);
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -28,13 +28,9 @@ describe("normalize", () => {
     expect(normalize([msg])).toEqual([{ kind: "assistant", text: "plain text", sourceIndex: 0 }]);
   });
 
-  it("splits assistant thinking + text", () => {
+  it("skips assistant thinking blocks", () => {
     const blocks = normalize([assistantWithThinking("result", "hmm")]);
-    expect(blocks).toHaveLength(2);
-    expect(blocks[0]).toEqual({
-      kind: "thinking", text: "hmm", redacted: false, sourceIndex: 0,
-    });
-    expect(blocks[1]).toEqual({ kind: "assistant", text: "result", sourceIndex: 0 });
+    expect(blocks).toEqual([{ kind: "assistant", text: "result", sourceIndex: 0 }]);
   });
 
   it("normalizes tool call", () => {
@@ -48,15 +44,8 @@ describe("normalize", () => {
     const blocks = normalize([toolResult("Read", "file contents")]);
     expect(blocks).toEqual([{
       kind: "tool_result", name: "Read",
-      text: "file contents", isError: false, sourceIndex: 0,
+      text: "file contents", sourceIndex: 0,
     }]);
-  });
-
-  it("normalizes error tool result", () => {
-    const blocks = normalize([toolResult("Edit", "not found", true)]);
-    expect(blocks[0]).toMatchObject({
-      kind: "tool_result", isError: true,
-    });
   });
 
   it("handles mixed message sequence", () => {

--- a/tests/render-entries.test.ts
+++ b/tests/render-entries.test.ts
@@ -26,9 +26,9 @@ describe("renderMessage", () => {
     expect(r.summary).toContain("Read(path=a.ts)");
   });
 
-  it("renders error tool result with prefix", () => {
-    const r = renderMessage(toolResult("bash", "not found", true), 3);
-    expect(r.summary).toStartWith("ERROR");
+  it("renders tool results without error prefix", () => {
+    const r = renderMessage(toolResult("bash", "not found"), 3);
+    expect(r.summary).toBe("[bash] not found");
   });
 
   it("truncates long user text", () => {


### PR DESCRIPTION
## Summary
- Remove thinking blocks from normalized output since the summary pipeline discards them
- Remove tool result error handling from normalization/brief output so tool results are hidden uniformly
- Remove unused loadAllMessages entryIds and SectionData transcriptEntries outputs

## Verification
- bun test (133 pass, 0 fail)

Note: attempted `bunx tsc --noEmit`, but this repo has no tsconfig, so TypeScript printed CLI help instead of running a project check.