### PR TITLE
feat: support follow-up prompts after compaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sting8k/pi-vcc",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Algorithmic conversation compactor for pi - transcript-preserving structured summaries, no LLM calls",
   "main": "index.ts",
   "keywords": [

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -9,7 +9,8 @@ const formatTokens = (n: number): string => {
 export const registerPiVccCommand = (pi: ExtensionAPI) => {
   pi.registerCommand("pi-vcc", {
     description: "Compact conversation with pi-vcc structured summary",
-    handler: async (_args, ctx) => {
+    handler: async (args: string, ctx) => {
+      const followUpPrompt = args.trim();
       ctx.compact({
         customInstructions: PI_VCC_COMPACT_INSTRUCTION,
         onComplete: () => {
@@ -22,6 +23,7 @@ export const registerPiVccCommand = (pi: ExtensionAPI) => {
           } else {
             ctx.ui.notify("Compacted with pi-vcc", "info");
           }
+          if (followUpPrompt) pi.sendUserMessage(followUpPrompt);
         },
         onError: (err) => {
           if (err.message === "Compaction cancelled" || err.message === "Already compacted") {

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -23,7 +23,11 @@ export const registerPiVccCommand = (pi: ExtensionAPI) => {
           } else {
             ctx.ui.notify("Compacted with pi-vcc", "info");
           }
-          if (followUpPrompt) pi.sendUserMessage(followUpPrompt);
+          if (followUpPrompt) {
+            try {
+              void Promise.resolve(pi.sendUserMessage(followUpPrompt)).catch(() => {});
+            } catch {}
+          }
         },
         onError: (err) => {
           if (err.message === "Compaction cancelled" || err.message === "Already compacted") {

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -308,9 +308,9 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
   // Fire success toast for /compact path only (delayed to let UI settle).
   // /pi-vcc path uses its own onComplete callback in the command handler.
   pi.on("session_compact", async (event, ctx) => {
+    if (!event.fromExtension) return;
     const followUpPrompt = pendingFollowUpPrompt;
     pendingFollowUpPrompt = null;
-    if (!event.fromExtension) return;
     if (lastCompactWasPiVcc) return; // /pi-vcc handles its own toast via onComplete
     const stats = lastStats;
     if (!stats) return;

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -15,11 +15,17 @@ export interface CompactionStats {
 
 let lastStats: CompactionStats | null = null;
 let lastCompactWasPiVcc = false;
+let pendingFollowUpPrompt: string | null = null;
 export const getLastCompactionStats = () => lastStats;
 
 const formatTokens = (n: number): string => {
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
   return String(n);
+};
+
+const normalizeCustomInstructions = (customInstructions?: string): string | null => {
+  const trimmed = customInstructions?.trim();
+  return trimmed ? trimmed : null;
 };
 
 const dbg = (settings: PiVccSettings, data: Record<string, unknown>) => {
@@ -145,6 +151,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     // Always handle explicit /pi-vcc marker.
     // Otherwise, only handle when user opted in via settings.
     const isPiVcc = customInstructions === PI_VCC_COMPACT_INSTRUCTION;
+    const followUpPrompt = isPiVcc ? null : normalizeCustomInstructions(customInstructions);
     if (!isPiVcc && !settings.overrideDefaultCompaction) return;
 
     const ownCut = buildOwnCut(branchEntries as any[]);
@@ -175,6 +182,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       }
       const userIndices = liveRoles.reduce<number[]>((acc, r, i) => (r === "user" ? (acc.push(i), acc) : acc), []);
 
+      pendingFollowUpPrompt = null;
       dbg(settings, {
         cancelled: true,
         reason: ownCut.reason,
@@ -213,6 +221,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       return { cancel: true };
     }
 
+    pendingFollowUpPrompt = followUpPrompt;
     const agentMessages = ownCut.messages;
     const firstKeptEntryId = ownCut.firstKeptEntryId;
     const messages = convertToLlm(agentMessages);
@@ -297,11 +306,18 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
 
   // Fire success toast for /compact path only (delayed to let UI settle).
   // /pi-vcc path uses its own onComplete callback in the command handler.
-  pi.on("session_compact", (event, ctx) => {
+  pi.on("session_compact", async (event, ctx) => {
     if (!event.fromExtension) return;
+    const followUpPrompt = pendingFollowUpPrompt;
+    pendingFollowUpPrompt = null;
     if (lastCompactWasPiVcc) return; // /pi-vcc handles its own toast via onComplete
     const stats = lastStats;
     if (!stats) return;
+    if (followUpPrompt) {
+      try {
+        await pi.sendUserMessage(followUpPrompt);
+      } catch {}
+    }
     setTimeout(() => {
       try {
         ctx?.ui?.notify?.(

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -152,6 +152,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     // Otherwise, only handle when user opted in via settings.
     const isPiVcc = customInstructions === PI_VCC_COMPACT_INSTRUCTION;
     const followUpPrompt = isPiVcc ? null : normalizeCustomInstructions(customInstructions);
+    pendingFollowUpPrompt = null;
     if (!isPiVcc && !settings.overrideDefaultCompaction) return;
 
     const ownCut = buildOwnCut(branchEntries as any[]);
@@ -307,9 +308,9 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
   // Fire success toast for /compact path only (delayed to let UI settle).
   // /pi-vcc path uses its own onComplete callback in the command handler.
   pi.on("session_compact", async (event, ctx) => {
-    if (!event.fromExtension) return;
     const followUpPrompt = pendingFollowUpPrompt;
     pendingFollowUpPrompt = null;
+    if (!event.fromExtension) return;
     if (lastCompactWasPiVcc) return; // /pi-vcc handles its own toast via onComplete
     const stats = lastStats;
     if (!stats) return;

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -21,8 +21,10 @@ afterAll(() => {
 
 // Minimal ExtensionAPI stub: capture handler + provide ctx with mocked ui.notify
 function createMockPi() {
-  let handler: ((event: any, ctx: any) => any) | undefined;
+  let beforeHandler: ((event: any, ctx: any) => any) | undefined;
+  let compactHandler: ((event: any, ctx: any) => any) | undefined;
   const notifyCalls: Array<{ msg: string; level: string }> = [];
+  const userMessages: Array<string | unknown[]> = [];
   const ctx = {
     hasUI: true,
     ui: {
@@ -34,18 +36,24 @@ function createMockPi() {
   return {
     pi: {
       on: (eventName: string, h: (e: any, c: any) => any) => {
-        if (eventName === "session_before_compact") handler = h;
+        if (eventName === "session_before_compact") beforeHandler = h;
+        if (eventName === "session_compact") compactHandler = h;
+      },
+      sendUserMessage: (content: string | unknown[]) => {
+        userMessages.push(content);
       },
     } as any,
-    invoke: (event: any) => handler!(event, ctx),
+    invokeBefore: (event: any) => beforeHandler!(event, ctx),
+    invokeCompact: (event: any) => compactHandler!(event, ctx),
     notifyCalls,
+    userMessages,
   };
 }
-
+ 
 function setConfig(cfg: Record<string, unknown>) {
   writeFileSync(CONFIG_PATH, JSON.stringify(cfg));
 }
-
+ 
 function makeEvent(branchEntries: any[], customInstructions?: string) {
   return {
     type: "session_before_compact",
@@ -59,14 +67,14 @@ function makeEvent(branchEntries: any[], customInstructions?: string) {
     signal: new AbortController().signal,
   };
 }
-
+ 
 const msg = (id: string, role: "user" | "assistant" | "toolResult", content = "x") => ({
   id,
   type: "message",
   message: { role, content },
 });
 const comp = (id: string, firstKeptEntryId?: string) => ({ id, type: "compaction", firstKeptEntryId });
-
+ 
 describe("registerBeforeCompactHook: cancel paths", () => {
   beforeEach(() => {
     if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
@@ -75,86 +83,86 @@ describe("registerBeforeCompactHook: cancel paths", () => {
     if (existsSync(CONFIG_PATH)) unlinkSync(CONFIG_PATH);
     if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
   });
-
+ 
   test("/pi-vcc with too few live messages cancels and notifies warning", () => {
     setConfig({ debug: false, overrideDefaultCompaction: false });
-    const { pi, invoke, notifyCalls } = createMockPi();
+    const { pi, invokeBefore, notifyCalls } = createMockPi();
     registerBeforeCompactHook(pi);
-
+ 
     const entries = [msg("m1", "user"), msg("m2", "assistant")];
-    expect(invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
+    expect(invokeBefore(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
     expect(notifyCalls).toHaveLength(1);
     expect(notifyCalls[0].level).toBe("warning");
     expect(notifyCalls[0].msg).toContain("Too few messages");
   });
-
+ 
   test("/pi-vcc with no user message compacts all instead of cancelling", () => {
     setConfig({ debug: false, overrideDefaultCompaction: false });
-    const { pi, invoke, notifyCalls } = createMockPi();
+    const { pi, invokeBefore, notifyCalls } = createMockPi();
     registerBeforeCompactHook(pi);
-
+ 
     const entries = [msg("m1", "assistant"), msg("m2", "assistant"), msg("m3", "assistant")];
-    const result = invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+    const result = invokeBefore(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
     // No longer cancels — compacts all to recover from context overflow
     expect(result.cancel).toBeUndefined();
     expect(result.compaction).toBeDefined();
     expect(result.compaction.firstKeptEntryId).toBe("");
   });
-
+ 
   test("/compact with override=true cancels and notifies (NEW: was silent before)", () => {
     setConfig({ debug: false, overrideDefaultCompaction: true });
-    const { pi, invoke, notifyCalls } = createMockPi();
+    const { pi, invokeBefore, notifyCalls } = createMockPi();
     registerBeforeCompactHook(pi);
-
+ 
     const entries = [msg("m1", "user"), msg("m2", "assistant")];
-    expect(invoke(makeEvent(entries, undefined))).toEqual({ cancel: true });
+    expect(invokeBefore(makeEvent(entries, undefined))).toEqual({ cancel: true });
     expect(notifyCalls).toHaveLength(1);
     expect(notifyCalls[0].level).toBe("warning");
   });
-
+ 
   test("/compact with override=false short-circuits (no notify, returns undefined)", () => {
     setConfig({ debug: false, overrideDefaultCompaction: false });
-    const { pi, invoke, notifyCalls } = createMockPi();
+    const { pi, invokeBefore, notifyCalls } = createMockPi();
     registerBeforeCompactHook(pi);
-
+ 
     const entries = [msg("m1", "user"), msg("m2", "assistant")];
-    expect(invoke(makeEvent(entries, undefined))).toBeUndefined();
+    expect(invokeBefore(makeEvent(entries, undefined))).toBeUndefined();
     expect(notifyCalls).toHaveLength(0);
   });
-
+ 
   test("debug:true writes metrics-only snapshot on cancel with no content leakage", () => {
     setConfig({ debug: true, overrideDefaultCompaction: false });
-    const { pi, invoke } = createMockPi();
+    const { pi, invokeBefore } = createMockPi();
     registerBeforeCompactHook(pi);
-
+ 
     // Use too_few_live_messages cancel path to test content leakage
     const entries = [
       msg("m1", "user", "SECRET_TOKEN_abc123"),
       msg("m2", "assistant", "sensitive response"),
     ];
-    expect(invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
-
+    expect(invokeBefore(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
+ 
     expect(existsSync(DEBUG_PATH)).toBe(true);
     const snapshot = JSON.parse(readFileSync(DEBUG_PATH, "utf-8"));
     expect(snapshot.cancelled).toBe(true);
     expect(snapshot.reason).toBe("too_few_live_messages");
-
+ 
     // No content leakage
     const serialized = JSON.stringify(snapshot);
     expect(serialized).not.toContain("SECRET_TOKEN_abc123");
     expect(serialized).not.toContain("sensitive response");
   });
-
+ 
   test("debug:false does NOT write snapshot", () => {
     setConfig({ debug: false, overrideDefaultCompaction: false });
-    const { pi, invoke } = createMockPi();
+    const { pi, invokeBefore } = createMockPi();
     registerBeforeCompactHook(pi);
     const entries = [msg("m1", "user"), msg("m2", "assistant")];
-    expect(invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
+    expect(invokeBefore(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
     expect(existsSync(DEBUG_PATH)).toBe(false);
   });
 });
-
+ 
 describe("registerBeforeCompactHook: compact-all path", () => {
   beforeEach(() => {
     if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
@@ -163,21 +171,31 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     if (existsSync(CONFIG_PATH)) unlinkSync(CONFIG_PATH);
     if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
   });
-
+ 
   test("single-user + autonomous tail → returns compaction with empty firstKeptEntryId", () => {
     setConfig({ debug: false, overrideDefaultCompaction: false });
-    const { pi, invoke, notifyCalls } = createMockPi();
+    const { pi, invokeBefore, notifyCalls } = createMockPi();
     registerBeforeCompactHook(pi);
-
+ 
     const entries = [
       msg("m1", "user", "go"),
       msg("m2", "assistant", "calling tool"),
       msg("m3", "toolResult", "result"),
       msg("m4", "assistant", "done"),
     ];
-    const result = invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+    const result = invokeBefore(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
     expect(result.compaction).toBeDefined();
     expect(result.compaction.firstKeptEntryId).toBe("");
     expect(notifyCalls).toHaveLength(0); // no cancel notify on success
+  });
+ 
+  test("override=true + customInstructions sends follow-up user message after compact", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true });
+    const { pi, invokeBefore, invokeCompact, userMessages } = createMockPi();
+    registerBeforeCompactHook(pi);
+    const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+    invokeBefore(makeEvent(entries, "continue"));
+    await invokeCompact({ type: "session_compact", fromExtension: true });
+    expect(userMessages).toEqual(["continue"]);
   });
 });

--- a/tests/pi-vcc-command.test.ts
+++ b/tests/pi-vcc-command.test.ts
@@ -8,7 +8,7 @@ type CompactOptions = {
   onError?: (err: Error) => void;
 };
 
-function createHarness() {
+function createHarness(sendUserMessage?: (content: string | unknown[]) => unknown) {
   let handler: ((args: string, ctx: any) => Promise<void>) | undefined;
   const compactCalls: CompactOptions[] = [];
   const notifyCalls: Array<{ msg: string; level: string }> = [];
@@ -19,9 +19,9 @@ function createHarness() {
       expect(name).toBe("pi-vcc");
       handler = command.handler;
     },
-    sendUserMessage: (content: string | unknown[]) => {
+    sendUserMessage: sendUserMessage ?? ((content: string | unknown[]) => {
       userMessages.push(content);
-    },
+    }),
   } as any;
 
   const ctx = {
@@ -64,6 +64,15 @@ describe("registerPiVccCommand", () => {
     compactCalls[0].onComplete?.();
 
     expect(userMessages).toEqual(["continue"]);
+  });
+
+  test("handles rejected follow-up send without throwing", async () => {
+    const { invoke, compactCalls } = createHarness(() => Promise.reject(new Error("send failed")));
+
+    await invoke("continue");
+
+    expect(() => compactCalls[0].onComplete?.()).not.toThrow();
+    await Promise.resolve();
   });
 
   test("skips follow-up when trailing prompt is empty", async () => {

--- a/tests/pi-vcc-command.test.ts
+++ b/tests/pi-vcc-command.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { registerPiVccCommand } from "../src/commands/pi-vcc";
+import { PI_VCC_COMPACT_INSTRUCTION } from "../src/hooks/before-compact";
+
+type CompactOptions = {
+  customInstructions?: string;
+  onComplete?: () => void;
+  onError?: (err: Error) => void;
+};
+
+function createHarness() {
+  let handler: ((args: string, ctx: any) => Promise<void>) | undefined;
+  const compactCalls: CompactOptions[] = [];
+  const notifyCalls: Array<{ msg: string; level: string }> = [];
+  const userMessages: Array<string | unknown[]> = [];
+
+  const pi = {
+    registerCommand: (name: string, command: { handler: typeof handler }) => {
+      expect(name).toBe("pi-vcc");
+      handler = command.handler;
+    },
+    sendUserMessage: (content: string | unknown[]) => {
+      userMessages.push(content);
+    },
+  } as any;
+
+  const ctx = {
+    compact: (options: CompactOptions) => {
+      compactCalls.push(options);
+    },
+    ui: {
+      notify: (msg: string, level: string) => {
+        notifyCalls.push({ msg, level });
+      },
+    },
+  };
+
+  registerPiVccCommand(pi);
+
+  return {
+    invoke: async (args = "") => handler!(args, ctx),
+    compactCalls,
+    notifyCalls,
+    userMessages,
+  };
+}
+
+describe("registerPiVccCommand", () => {
+  test("uses the pi-vcc compaction marker", async () => {
+    const { invoke, compactCalls } = createHarness();
+
+    await invoke();
+
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0].customInstructions).toBe(PI_VCC_COMPACT_INSTRUCTION);
+  });
+
+  test("sends trailing prompt as a user message after successful compaction", async () => {
+    const { invoke, compactCalls, userMessages } = createHarness();
+
+    await invoke("  continue  ");
+
+    expect(userMessages).toHaveLength(0);
+    compactCalls[0].onComplete?.();
+
+    expect(userMessages).toEqual(["continue"]);
+  });
+
+  test("skips follow-up when trailing prompt is empty", async () => {
+    const { invoke, compactCalls, userMessages } = createHarness();
+
+    await invoke("   ");
+    compactCalls[0].onComplete?.();
+
+    expect(userMessages).toHaveLength(0);
+  });
+
+  test("does not send trailing prompt on compaction error", async () => {
+    const { invoke, compactCalls, userMessages, notifyCalls } = createHarness();
+
+    await invoke("continue");
+    compactCalls[0].onError?.(new Error("Already compacted"));
+
+    expect(userMessages).toHaveLength(0);
+    expect(notifyCalls).toEqual([{ msg: "Nothing to compact", level: "warning" }]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add follow-up prompt support for `/pi-vcc <prompt>` so the prompt is sent after compaction completes.
- Add follow-up prompt support for `/compact <prompt>` when `overrideDefaultCompaction` is enabled.
- Bump package version to `0.3.16`.

## Testing
- `bun test tests/before-compact-hook.test.ts tests/before-compact.test.ts tests/pi-vcc-command.test.ts`
