### PR TITLE
Add keep arg to /pi-vcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ pi -e https://github.com/sting8k/pi-vcc
 Once installed, pi-vcc registers a `session_before_compact` hook.
 
 - Run `/pi-vcc` to trigger pi-vcc compaction manually.
+- Optional keep syntax: `/pi-vcc keep:3 <prompt>` or `/pi-vcc <prompt> keep:3`.
+  - `keep:1` matches the default behavior.
+  - `keep:0` compacts everything and keeps no tail.
 - By default, `/compact` and auto-threshold compactions still go through pi core (LLM-based). Set `overrideDefaultCompaction: true` in the config to let pi-vcc handle all compaction paths.
 - To search older active-lineage history after compaction, use `vcc_recall`.
 - To intentionally search across all lineages, pass `scope:"all"` to `vcc_recall` or run `/pi-vcc-recall <query> scope:all`.
@@ -82,7 +85,7 @@ Once installed, pi-vcc registers a `session_before_compact` hook.
 
 ### How compaction works
 
-Pi splits the conversation at the **last user message**. Everything after — the **kept tail** — stays intact and untouched. pi-vcc only summarizes the older portion before that cut point.
+Pi splits the conversation at the **last user message** by default. Everything after — the **kept tail** — stays intact and untouched. With `keep:N`, pi-vcc keeps the last `N` user turns in that tail and summarizes everything before the cut point. If `keep:0` is requested, it compacts everything and keeps no tail.
 
 ### Compacted message structure
 
@@ -186,10 +189,11 @@ Typical workflow: **search → find relevant entry indices → expand those indi
 
 1. **Normalize** — raw Pi messages → uniform blocks (user, assistant, tool_call, tool_result, thinking)
 2. **Filter noise** — strip system messages, empty blocks
-3. **Build sections** — extract goal, file paths, blockers, preferences
-4. **Brief transcript** — chronological conversation flow, tool calls collapsed to one-liners, text truncated
-5. **Format** — render into bracketed sections + transcript
-6. **Merge** — if previous summary exists: sticky sections merge, volatile sections replace, transcript rolls
+3. **Build cut** — keep the requested tail of user turns; compact-all uses the `firstKeptEntryId: ""` sentinel
+4. **Build sections** — extract goal, file paths, blockers, preferences
+5. **Brief transcript** — chronological conversation flow, tool calls collapsed to one-liners, text truncated
+6. **Format** — render into bracketed sections + transcript
+7. **Merge** — if previous summary exists: sticky sections merge, volatile sections replace, transcript rolls
 
 ## Config
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sting8k/pi-vcc",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Algorithmic conversation compactor for pi - transcript-preserving structured summaries, no LLM calls",
   "main": "index.ts",
   "keywords": [

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -21,7 +21,7 @@ const parsePiVccArgs = (args: string): { followUpPrompt: string; keepUserTurns: 
   }
 
   const parts = trimmed.split(/\s+/);
-  const endMatch = parts.length > 1 ? parts[parts.length - 1].match(KEEP_TOKEN_RE) : null;
+  const endMatch = parts[parts.length - 1].match(KEEP_TOKEN_RE);
   if (endMatch) {
     return {
       followUpPrompt: trimmed.slice(0, trimmed.length - parts[parts.length - 1].length).trim(),

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -1,25 +1,53 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { getLastCompactionStats, PI_VCC_COMPACT_INSTRUCTION } from "../hooks/before-compact";
+import { formatCompactionStats, getLastCompactionStats, PI_VCC_COMPACT_INSTRUCTION } from "../hooks/before-compact";
 
-const formatTokens = (n: number): string => {
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
-  return String(n);
+const KEEP_TOKEN_RE = /^keep:(\d+)$/;
+
+const parseKeepUserTurns = (raw: string): number => {
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : Number.MAX_SAFE_INTEGER;
+};
+
+const parsePiVccArgs = (args: string): { followUpPrompt: string; keepUserTurns: number | null } => {
+  const trimmed = args.trim();
+  if (!trimmed) return { followUpPrompt: "", keepUserTurns: null };
+
+  const startMatch = trimmed.match(/^keep:(\d+)(?:\s+|$)([\s\S]*)$/);
+  if (startMatch) {
+    return {
+      followUpPrompt: startMatch[2].trim(),
+      keepUserTurns: parseKeepUserTurns(startMatch[1]),
+    };
+  }
+
+  const parts = trimmed.split(/\s+/);
+  const endMatch = parts.length > 1 ? parts[parts.length - 1].match(KEEP_TOKEN_RE) : null;
+  if (endMatch) {
+    return {
+      followUpPrompt: trimmed.slice(0, trimmed.length - parts[parts.length - 1].length).trim(),
+      keepUserTurns: parseKeepUserTurns(endMatch[1]),
+    };
+  }
+
+  return { followUpPrompt: trimmed, keepUserTurns: null };
+};
+
+const buildCustomInstructions = (keepUserTurns: number | null): string => {
+  if (keepUserTurns == null) return PI_VCC_COMPACT_INSTRUCTION;
+  return `${PI_VCC_COMPACT_INSTRUCTION} keep:${keepUserTurns}`;
 };
 
 export const registerPiVccCommand = (pi: ExtensionAPI) => {
   pi.registerCommand("pi-vcc", {
     description: "Compact conversation with pi-vcc structured summary",
     handler: async (args: string, ctx) => {
-      const followUpPrompt = args.trim();
+      const { followUpPrompt, keepUserTurns } = parsePiVccArgs(args);
       ctx.compact({
-        customInstructions: PI_VCC_COMPACT_INSTRUCTION,
+        customInstructions: buildCustomInstructions(keepUserTurns),
         onComplete: () => {
           const stats = getLastCompactionStats();
           if (stats) {
-            ctx.ui.notify(
-              `pi-vcc: ${stats.summarized} source entries processed; tail kept ${stats.kept} (~${formatTokens(stats.keptTokensEst)} tok).`,
-              "info",
-            );
+            ctx.ui.notify(formatCompactionStats(stats), "info");
           } else {
             ctx.ui.notify("Compacted with pi-vcc", "info");
           }

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -12,6 +12,8 @@ export interface CompactionStats {
   kept: number;
   keptUserTurns: number;
   totalUserTurns: number;
+  requestedKeepUserTurns: number;
+  keepFallbackToCompactAll: boolean;
   keptTokensEst: number;
 }
 
@@ -25,8 +27,12 @@ const formatTokens = (n: number): string => {
   return String(n);
 };
 
-export const formatCompactionStats = (stats: CompactionStats): string =>
-  `pi-vcc: ${stats.summarized} source entries processed; tail kept ${stats.keptUserTurns}/${stats.totalUserTurns} user turns (${stats.kept} messages, ~${formatTokens(stats.keptTokensEst)} tok).`;
+export const formatCompactionStats = (stats: CompactionStats): string => {
+  const fallbackNote = stats.keepFallbackToCompactAll && stats.requestedKeepUserTurns > 0
+    ? `; requested keep:${stats.requestedKeepUserTurns}, compact-all fallback`
+    : '';
+  return `pi-vcc: ${stats.summarized} source entries processed; tail kept ${stats.keptUserTurns}/${stats.totalUserTurns} user turns${fallbackNote} (${stats.kept} messages, ~${formatTokens(stats.keptTokensEst)} tok).`;
+};
 
 const normalizeCustomInstructions = (customInstructions?: string): string | null => {
   const trimmed = customInstructions?.trim();
@@ -93,6 +99,8 @@ export type OwnCutResult =
       compactAll: boolean;
       keptUserTurns: number;
       totalUserTurns: number;
+      requestedKeepUserTurns: number;
+      keepFallbackToCompactAll: boolean;
     }
   | { ok: false; reason: OwnCutCancelReason };
 
@@ -145,16 +153,18 @@ export function buildOwnCut(branchEntries: any[], keepUserTurns = 1): OwnCutResu
     if (e.message.role === "user") acc.push(i);
     return acc;
   }, []);
-  const compactAll = () => ({
+  const compactAll = (keepFallbackToCompactAll: boolean) => ({
     ok: true as const,
     messages: liveMessages.map((e) => e.message),
     firstKeptEntryId: "",
     compactAll: true,
     keptUserTurns: 0,
     totalUserTurns: userIndices.length,
+    requestedKeepUserTurns: normalizedKeepUserTurns,
+    keepFallbackToCompactAll,
   });
 
-  if (normalizedKeepUserTurns <= 0) return compactAll();
+  if (normalizedKeepUserTurns <= 0) return compactAll(false);
 
   // Summarize all messages before the requested kept user-turn tail.
   const targetUserIdx = userIndices.length - normalizedKeepUserTurns;
@@ -165,7 +175,7 @@ export function buildOwnCut(branchEntries: any[], keepUserTurns = 1): OwnCutResu
     // or keep larger than available user turns), so compact EVERYTHING and keep no tail.
     // firstKeptEntryId="" is a sentinel: pi-core's buildSessionContext won't match it
     // (so 0 kept from pre-compaction), and next buildOwnCut triggers orphan recovery.
-    return compactAll();
+    return compactAll(true);
   }
 
   return {
@@ -175,6 +185,8 @@ export function buildOwnCut(branchEntries: any[], keepUserTurns = 1): OwnCutResu
     compactAll: false,
     keptUserTurns: userIndices.length - targetUserIdx,
     totalUserTurns: userIndices.length,
+    requestedKeepUserTurns: normalizedKeepUserTurns,
+    keepFallbackToCompactAll: false,
   };
 }
 
@@ -288,6 +300,8 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       kept: keptEntries.length,
       keptUserTurns: ownCut.keptUserTurns,
       totalUserTurns: ownCut.totalUserTurns,
+      requestedKeepUserTurns: ownCut.requestedKeepUserTurns,
+      keepFallbackToCompactAll: ownCut.keepFallbackToCompactAll,
       keptTokensEst: Math.round(keptChars / 4),
     };
 

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -13,6 +13,7 @@ export interface CompactionStats {
   keptUserTurns: number;
   totalUserTurns: number;
   requestedKeepUserTurns: number;
+  keepUserTurnsExplicit: boolean;
   keepFallbackToCompactAll: boolean;
   keptTokensEst: number;
 }
@@ -28,9 +29,11 @@ const formatTokens = (n: number): string => {
 };
 
 export const formatCompactionStats = (stats: CompactionStats): string => {
-  const fallbackNote = stats.keepFallbackToCompactAll && stats.requestedKeepUserTurns > 0
-    ? `; requested keep:${stats.requestedKeepUserTurns}, compact-all fallback`
-    : '';
+  const fallbackNote = stats.keepFallbackToCompactAll
+    ? stats.keepUserTurnsExplicit
+      ? `; requested keep:${stats.requestedKeepUserTurns}, compact-all fallback`
+      : "; compact-all fallback"
+    : "";
   return `pi-vcc: ${stats.summarized} source entries processed; tail kept ${stats.keptUserTurns}/${stats.totalUserTurns} user turns${fallbackNote} (${stats.kept} messages, ~${formatTokens(stats.keptTokensEst)} tok).`;
 };
 
@@ -39,19 +42,20 @@ const normalizeCustomInstructions = (customInstructions?: string): string | null
   return trimmed ? trimmed : null;
 };
 
-const parsePiVccInstructions = (customInstructions?: string): { isPiVcc: boolean; keepUserTurns: number } => {
+const parsePiVccInstructions = (customInstructions?: string): { isPiVcc: boolean; keepUserTurns: number; keepUserTurnsExplicit: boolean } => {
   const trimmed = customInstructions?.trim();
-  if (trimmed === PI_VCC_COMPACT_INSTRUCTION) return { isPiVcc: true, keepUserTurns: 1 };
+  if (trimmed === PI_VCC_COMPACT_INSTRUCTION) return { isPiVcc: true, keepUserTurns: 1, keepUserTurnsExplicit: false };
 
   const keepPrefix = `${PI_VCC_COMPACT_INSTRUCTION} `;
-  if (!trimmed?.startsWith(keepPrefix)) return { isPiVcc: false, keepUserTurns: 1 };
+  if (!trimmed?.startsWith(keepPrefix)) return { isPiVcc: false, keepUserTurns: 1, keepUserTurnsExplicit: false };
 
   const match = trimmed.slice(keepPrefix.length).match(/^keep:(\d+)$/);
-  if (!match) return { isPiVcc: false, keepUserTurns: 1 };
+  if (!match) return { isPiVcc: false, keepUserTurns: 1, keepUserTurnsExplicit: false };
   const parsed = Number(match[1]);
   return {
     isPiVcc: true,
     keepUserTurns: Number.isSafeInteger(parsed) ? parsed : Number.MAX_SAFE_INTEGER,
+    keepUserTurnsExplicit: true,
   };
 };
 
@@ -202,7 +206,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
 
     // Always handle explicit /pi-vcc marker.
     // Otherwise, only handle when user opted in via settings.
-    const { isPiVcc, keepUserTurns } = parsePiVccInstructions(customInstructions);
+    const { isPiVcc, keepUserTurns, keepUserTurnsExplicit } = parsePiVccInstructions(customInstructions);
     const followUpPrompt = isPiVcc ? null : normalizeCustomInstructions(customInstructions);
     pendingFollowUpPrompt = null;
     if (!isPiVcc && !settings.overrideDefaultCompaction) return;
@@ -301,6 +305,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       keptUserTurns: ownCut.keptUserTurns,
       totalUserTurns: ownCut.totalUserTurns,
       requestedKeepUserTurns: ownCut.requestedKeepUserTurns,
+      keepUserTurnsExplicit,
       keepFallbackToCompactAll: ownCut.keepFallbackToCompactAll,
       keptTokensEst: Math.round(keptChars / 4),
     };

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -10,6 +10,8 @@ export const PI_VCC_COMPACT_INSTRUCTION = "__pi_vcc__";
 export interface CompactionStats {
   summarized: number;
   kept: number;
+  keptUserTurns: number;
+  totalUserTurns: number;
   keptTokensEst: number;
 }
 
@@ -23,9 +25,33 @@ const formatTokens = (n: number): string => {
   return String(n);
 };
 
+export const formatCompactionStats = (stats: CompactionStats): string =>
+  `pi-vcc: ${stats.summarized} source entries processed; tail kept ${stats.keptUserTurns}/${stats.totalUserTurns} user turns (${stats.kept} messages, ~${formatTokens(stats.keptTokensEst)} tok).`;
+
 const normalizeCustomInstructions = (customInstructions?: string): string | null => {
   const trimmed = customInstructions?.trim();
   return trimmed ? trimmed : null;
+};
+
+const parsePiVccInstructions = (customInstructions?: string): { isPiVcc: boolean; keepUserTurns: number } => {
+  const trimmed = customInstructions?.trim();
+  if (trimmed === PI_VCC_COMPACT_INSTRUCTION) return { isPiVcc: true, keepUserTurns: 1 };
+
+  const keepPrefix = `${PI_VCC_COMPACT_INSTRUCTION} `;
+  if (!trimmed?.startsWith(keepPrefix)) return { isPiVcc: false, keepUserTurns: 1 };
+
+  const match = trimmed.slice(keepPrefix.length).match(/^keep:(\d+)$/);
+  if (!match) return { isPiVcc: false, keepUserTurns: 1 };
+  const parsed = Number(match[1]);
+  return {
+    isPiVcc: true,
+    keepUserTurns: Number.isSafeInteger(parsed) ? parsed : Number.MAX_SAFE_INTEGER,
+  };
+};
+
+const normalizeKeepUserTurns = (keepUserTurns: number): number => {
+  if (!Number.isFinite(keepUserTurns)) return 0;
+  return Math.max(0, Math.floor(keepUserTurns));
 };
 
 const dbg = (settings: PiVccSettings, data: Record<string, unknown>) => {
@@ -60,10 +86,18 @@ export type OwnCutCancelReason =
   | "too_few_live_messages";
 
 export type OwnCutResult =
-  | { ok: true; messages: any[]; firstKeptEntryId: string; compactAll: boolean }
+  | {
+      ok: true;
+      messages: any[];
+      firstKeptEntryId: string;
+      compactAll: boolean;
+      keptUserTurns: number;
+      totalUserTurns: number;
+    }
   | { ok: false; reason: OwnCutCancelReason };
 
-export function buildOwnCut(branchEntries: any[]): OwnCutResult {
+export function buildOwnCut(branchEntries: any[], keepUserTurns = 1): OwnCutResult {
+  const normalizedKeepUserTurns = normalizeKeepUserTurns(keepUserTurns);
   // Find the last compaction entry and its firstKeptEntryId
   let lastCompactionIdx = -1;
   let lastKeptId: string | undefined;
@@ -107,27 +141,31 @@ export function buildOwnCut(branchEntries: any[]): OwnCutResult {
   if (liveMessages.length === 0) return { ok: false, reason: "no_live_messages" };
   if (liveMessages.length <= 2) return { ok: false, reason: "too_few_live_messages" };
 
-  // Summarize all messages, keep only the last user message as context
-  let cutIdx = liveMessages.length - 1;
-  while (cutIdx > 0 && liveMessages[cutIdx].message.role !== "user") {
-    cutIdx--;
-  }
+  const userIndices = liveMessages.reduce<number[]>((acc, e, i) => {
+    if (e.message.role === "user") acc.push(i);
+    return acc;
+  }, []);
+  const compactAll = () => ({
+    ok: true as const,
+    messages: liveMessages.map((e) => e.message),
+    firstKeptEntryId: "",
+    compactAll: true,
+    keptUserTurns: 0,
+    totalUserTurns: userIndices.length,
+  });
+
+  if (normalizedKeepUserTurns <= 0) return compactAll();
+
+  // Summarize all messages before the requested kept user-turn tail.
+  const targetUserIdx = userIndices.length - normalizedKeepUserTurns;
+  const cutIdx = targetUserIdx >= 0 ? userIndices[targetUserIdx] : -1;
 
   if (cutIdx <= 0) {
-    // Single user prompt scenario (or no user at all).
-    // Compact EVERYTHING and keep no tail. This handles both:
-    //  - Single user prompt at index 0: compact all, fresh start after summary
-    //  - No user message at all (e.g., long assistant/tool chain): still compact
-    //    to recover from context overflow rather than cancelling and leaving
-    //    the session unrecoverable.
+    // Keep request cannot form a safe boundary (single user prompt, no user prompt,
+    // or keep larger than available user turns), so compact EVERYTHING and keep no tail.
     // firstKeptEntryId="" is a sentinel: pi-core's buildSessionContext won't match it
     // (so 0 kept from pre-compaction), and next buildOwnCut triggers orphan recovery.
-    return {
-      ok: true,
-      messages: liveMessages.map((e) => e.message),
-      firstKeptEntryId: "",
-      compactAll: true,
-    };
+    return compactAll();
   }
 
   return {
@@ -135,6 +173,8 @@ export function buildOwnCut(branchEntries: any[]): OwnCutResult {
     messages: liveMessages.slice(0, cutIdx).map((e) => e.message),
     firstKeptEntryId: liveMessages[cutIdx].entry.id,
     compactAll: false,
+    keptUserTurns: userIndices.length - targetUserIdx,
+    totalUserTurns: userIndices.length,
   };
 }
 
@@ -150,12 +190,12 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
 
     // Always handle explicit /pi-vcc marker.
     // Otherwise, only handle when user opted in via settings.
-    const isPiVcc = customInstructions === PI_VCC_COMPACT_INSTRUCTION;
+    const { isPiVcc, keepUserTurns } = parsePiVccInstructions(customInstructions);
     const followUpPrompt = isPiVcc ? null : normalizeCustomInstructions(customInstructions);
     pendingFollowUpPrompt = null;
     if (!isPiVcc && !settings.overrideDefaultCompaction) return;
 
-    const ownCut = buildOwnCut(branchEntries as any[]);
+    const ownCut = buildOwnCut(branchEntries as any[], keepUserTurns);
     if (!ownCut.ok) {
       const lastComp = [...branchEntries].reverse().find((e: any) => e.type === "compaction");
       const lastCompIdx = lastComp ? (branchEntries as any[]).indexOf(lastComp) : -1;
@@ -246,6 +286,8 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     lastStats = {
       summarized: agentMessages.length,
       kept: keptEntries.length,
+      keptUserTurns: ownCut.keptUserTurns,
+      totalUserTurns: ownCut.totalUserTurns,
       keptTokensEst: Math.round(keptChars / 4),
     };
 
@@ -322,7 +364,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     setTimeout(() => {
       try {
         ctx?.ui?.notify?.(
-          `pi-vcc: ${stats.summarized} source entries processed; tail kept ${stats.kept} (~${formatTokens(stats.keptTokensEst)} tok).`,
+          formatCompactionStats(stats),
           "info",
         );
       } catch {}

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -208,9 +208,23 @@ describe("registerBeforeCompactHook: compact-all path", () => {
       keptUserTurns: 0,
       totalUserTurns: 2,
       requestedKeepUserTurns: 2,
+      keepUserTurnsExplicit: true,
       keepFallbackToCompactAll: true,
       keptTokensEst: 10,
     })).toContain("tail kept 0/2 user turns; requested keep:2, compact-all fallback");
+  });
+
+  test("formatCompactionStats avoids requested keep wording for default compact-all fallback", () => {
+    expect(formatCompactionStats({
+      summarized: 2,
+      kept: 4,
+      keptUserTurns: 0,
+      totalUserTurns: 1,
+      requestedKeepUserTurns: 1,
+      keepUserTurnsExplicit: false,
+      keepFallbackToCompactAll: true,
+      keptTokensEst: 10,
+    })).toContain("tail kept 0/1 user turns; compact-all fallback");
   });
 
   test("/pi-vcc keep instruction changes firstKeptEntryId and stats", () => {

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } fr
 import { existsSync, unlinkSync, writeFileSync, readFileSync, mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { registerBeforeCompactHook, PI_VCC_COMPACT_INSTRUCTION } from "../src/hooks/before-compact";
+import { registerBeforeCompactHook, PI_VCC_COMPACT_INSTRUCTION, getLastCompactionStats } from "../src/hooks/before-compact";
 
 let tmpDir: string;
 let CONFIG_PATH: string;
@@ -191,11 +191,53 @@ describe("registerBeforeCompactHook: compact-all path", () => {
  
   test("override=true + customInstructions sends follow-up user message after compact", async () => {
     setConfig({ debug: false, overrideDefaultCompaction: true });
-    const { pi, invokeBefore, invokeCompact, userMessages } = createMockPi();
+    const { pi, invokeBefore, invokeCompact, userMessages, notifyCalls } = createMockPi();
     registerBeforeCompactHook(pi);
     const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
     invokeBefore(makeEvent(entries, "continue"));
     await invokeCompact({ type: "session_compact", fromExtension: true });
+    await new Promise((resolve) => setTimeout(resolve, 550));
     expect(userMessages).toEqual(["continue"]);
+    expect(notifyCalls.some((call) => call.msg.includes("tail kept 1/2 user turns (2 messages,"))).toBe(true);
+  });
+
+  test("/pi-vcc keep instruction changes firstKeptEntryId and stats", () => {
+    setConfig({ debug: false, overrideDefaultCompaction: false });
+    const { pi, invokeBefore } = createMockPi();
+    registerBeforeCompactHook(pi);
+    const entries = [
+      msg("u1", "user", "one"),
+      msg("a1", "assistant", "reply one"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", "reply two"),
+      msg("u3", "user", "three"),
+      msg("a3", "assistant", "reply three"),
+    ];
+
+    const result = invokeBefore(makeEvent(entries, `${PI_VCC_COMPACT_INSTRUCTION} keep:2`));
+
+    expect(result.compaction.firstKeptEntryId).toBe("u2");
+    expect(result.compaction.details.sourceMessageCount).toBe(2);
+    expect(getLastCompactionStats()).toMatchObject({
+      summarized: 2,
+      kept: 4,
+      keptUserTurns: 2,
+      totalUserTurns: 3,
+    });
+  });
+
+  test("huge keep instruction compacts all safely", () => {
+    setConfig({ debug: false, overrideDefaultCompaction: false });
+    const { pi, invokeBefore } = createMockPi();
+    registerBeforeCompactHook(pi);
+    const entries = [msg("u1", "user", "one"), msg("a1", "assistant", "reply one"), msg("u2", "user", "two"), msg("a2", "assistant", "reply two")];
+
+    const result = invokeBefore(makeEvent(entries, `${PI_VCC_COMPACT_INSTRUCTION} keep:999999999999999999999`));
+
+    expect(result.compaction.firstKeptEntryId).toBe("");
+    expect(getLastCompactionStats()).toMatchObject({
+      keptUserTurns: 0,
+      totalUserTurns: 2,
+    });
   });
 });

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } fr
 import { existsSync, unlinkSync, writeFileSync, readFileSync, mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { registerBeforeCompactHook, PI_VCC_COMPACT_INSTRUCTION, getLastCompactionStats } from "../src/hooks/before-compact";
+import { registerBeforeCompactHook, PI_VCC_COMPACT_INSTRUCTION, getLastCompactionStats, formatCompactionStats } from "../src/hooks/before-compact";
 
 let tmpDir: string;
 let CONFIG_PATH: string;
@@ -199,6 +199,18 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     await new Promise((resolve) => setTimeout(resolve, 550));
     expect(userMessages).toEqual(["continue"]);
     expect(notifyCalls.some((call) => call.msg.includes("tail kept 1/2 user turns (2 messages,"))).toBe(true);
+  });
+
+  test("formatCompactionStats surfaces compact-all fallback when keep cannot be honored", () => {
+    expect(formatCompactionStats({
+      summarized: 2,
+      kept: 4,
+      keptUserTurns: 0,
+      totalUserTurns: 2,
+      requestedKeepUserTurns: 2,
+      keepFallbackToCompactAll: true,
+      keptTokensEst: 10,
+    })).toContain("tail kept 0/2 user turns; requested keep:2, compact-all fallback");
   });
 
   test("/pi-vcc keep instruction changes firstKeptEntryId and stats", () => {

--- a/tests/before-compact.test.ts
+++ b/tests/before-compact.test.ts
@@ -161,6 +161,24 @@ describe("buildOwnCut", () => {
     expect(r.totalUserTurns).toBe(3);
   });
 
+  test("keep:2 falls back to compact-all when the boundary would start at the first user", () => {
+    const r = buildOwnCut([
+      msg("u1", "user", "one"),
+      msg("a1", "assistant", "reply one"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", "reply two"),
+    ], 2);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.compactAll).toBe(true);
+    expect(r.firstKeptEntryId).toBe("");
+    expect(r.messages).toHaveLength(4);
+    expect(r.keptUserTurns).toBe(0);
+    expect(r.totalUserTurns).toBe(2);
+    expect(r.requestedKeepUserTurns).toBe(2);
+    expect(r.keepFallbackToCompactAll).toBe(true);
+  });
+
   test("keep:0 compacts all and keeps no tail", () => {
     const r = buildOwnCut([
       msg("u1", "user", "one"),

--- a/tests/before-compact.test.ts
+++ b/tests/before-compact.test.ts
@@ -142,4 +142,74 @@ describe("buildOwnCut", () => {
     expect(r.compactAll).toBe(true);
     expect(r.firstKeptEntryId).toBe("");
   });
+
+  test("keep:2 keeps the last two user turns", () => {
+    const r = buildOwnCut([
+      msg("u1", "user", "one"),
+      msg("a1", "assistant", "reply one"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", "reply two"),
+      msg("u3", "user", "three"),
+      msg("a3", "assistant", "reply three"),
+    ], 2);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.compactAll).toBe(false);
+    expect(r.firstKeptEntryId).toBe("u2");
+    expect(r.messages).toHaveLength(2);
+    expect(r.keptUserTurns).toBe(2);
+    expect(r.totalUserTurns).toBe(3);
+  });
+
+  test("keep:0 compacts all and keeps no tail", () => {
+    const r = buildOwnCut([
+      msg("u1", "user", "one"),
+      msg("a1", "assistant", "reply one"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", "reply two"),
+    ], 0);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.compactAll).toBe(true);
+    expect(r.firstKeptEntryId).toBe("");
+    expect(r.messages).toHaveLength(4);
+    expect(r.keptUserTurns).toBe(0);
+    expect(r.totalUserTurns).toBe(2);
+  });
+
+  test("keep larger than available user turns compacts all", () => {
+    const r = buildOwnCut([
+      msg("u1", "user", "one"),
+      msg("a1", "assistant", "reply one"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", "reply two"),
+    ], 3);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.compactAll).toBe(true);
+    expect(r.firstKeptEntryId).toBe("");
+    expect(r.messages).toHaveLength(4);
+    expect(r.keptUserTurns).toBe(0);
+    expect(r.totalUserTurns).toBe(2);
+  });
+
+  test("orphan recovery respects keep user turns", () => {
+    const r = buildOwnCut([
+      msg("old1", "user", "old"),
+      comp("c1", ""),
+      msg("u1", "user", "new1"),
+      msg("a1", "assistant", "reply1"),
+      msg("u2", "user", "new2"),
+      msg("a2", "assistant", "reply2"),
+      msg("u3", "user", "new3"),
+      msg("a3", "assistant", "reply3"),
+    ], 2);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.compactAll).toBe(false);
+    expect(r.firstKeptEntryId).toBe("u2");
+    expect(r.messages).toHaveLength(2);
+    expect(r.keptUserTurns).toBe(2);
+    expect(r.totalUserTurns).toBe(3);
+  });
 });

--- a/tests/pi-vcc-command.test.ts
+++ b/tests/pi-vcc-command.test.ts
@@ -75,6 +75,16 @@ describe("registerPiVccCommand", () => {
     expect(userMessages).toEqual(["continue"]);
   });
 
+  test("parses a lone keep token without sending a follow-up prompt", async () => {
+    const { invoke, compactCalls, userMessages } = createHarness();
+
+    await invoke("keep:4");
+
+    expect(compactCalls[0].customInstructions).toBe(`${PI_VCC_COMPACT_INSTRUCTION} keep:4`);
+    compactCalls[0].onComplete?.();
+    expect(userMessages).toHaveLength(0);
+  });
+
   test("sends trailing prompt as a user message after successful compaction", async () => {
     const { invoke, compactCalls, userMessages } = createHarness();
 

--- a/tests/pi-vcc-command.test.ts
+++ b/tests/pi-vcc-command.test.ts
@@ -55,6 +55,26 @@ describe("registerPiVccCommand", () => {
     expect(compactCalls[0].customInstructions).toBe(PI_VCC_COMPACT_INSTRUCTION);
   });
 
+  test("parses keep token at the start of args and strips it from the prompt", async () => {
+    const { invoke, compactCalls, userMessages } = createHarness();
+
+    await invoke("keep:3   continue  ");
+
+    expect(compactCalls[0].customInstructions).toBe(`${PI_VCC_COMPACT_INSTRUCTION} keep:3`);
+    compactCalls[0].onComplete?.();
+    expect(userMessages).toEqual(["continue"]);
+  });
+
+  test("parses keep token at the end of args and strips it from the prompt", async () => {
+    const { invoke, compactCalls, userMessages } = createHarness();
+
+    await invoke("  continue   keep:2");
+
+    expect(compactCalls[0].customInstructions).toBe(`${PI_VCC_COMPACT_INSTRUCTION} keep:2`);
+    compactCalls[0].onComplete?.();
+    expect(userMessages).toEqual(["continue"]);
+  });
+
   test("sends trailing prompt as a user message after successful compaction", async () => {
     const { invoke, compactCalls, userMessages } = createHarness();
 
@@ -92,5 +112,13 @@ describe("registerPiVccCommand", () => {
 
     expect(userMessages).toHaveLength(0);
     expect(notifyCalls).toEqual([{ msg: "Nothing to compact", level: "warning" }]);
+  });
+
+  test("normalizes huge keep tokens to a safe integer instruction", async () => {
+    const { invoke, compactCalls } = createHarness();
+
+    await invoke("keep:999999999999999999999 continue");
+
+    expect(compactCalls[0].customInstructions).toBe(`${PI_VCC_COMPACT_INSTRUCTION} keep:${Number.MAX_SAFE_INTEGER}`);
   });
 });


### PR DESCRIPTION
## Summary
- add /pi-vcc keep:N parsing at the start or end of slash args
- pass keep count through pi-vcc compaction instructions and keep the requested last user turns
- update compact notifications to report kept user turns plus messages/tokens
- document keep:N usage and add guardrail tests

## Verification
- bun test