### PR TITLE
Support Pi compaction retry context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sting8k/pi-vcc",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Algorithmic conversation compactor for pi - transcript-preserving structured summaries, no LLM calls",
   "main": "index.ts",
   "keywords": [

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -1,49 +1,14 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { formatCompactionStats, getLastCompactionStats, PI_VCC_COMPACT_INSTRUCTION } from "../hooks/before-compact";
-
-const KEEP_TOKEN_RE = /^keep:(\d+)$/;
-
-const parseKeepUserTurns = (raw: string): number => {
-  const value = Number(raw);
-  return Number.isSafeInteger(value) ? value : Number.MAX_SAFE_INTEGER;
-};
-
-const parsePiVccArgs = (args: string): { followUpPrompt: string; keepUserTurns: number | null } => {
-  const trimmed = args.trim();
-  if (!trimmed) return { followUpPrompt: "", keepUserTurns: null };
-
-  const startMatch = trimmed.match(/^keep:(\d+)(?:\s+|$)([\s\S]*)$/);
-  if (startMatch) {
-    return {
-      followUpPrompt: startMatch[2].trim(),
-      keepUserTurns: parseKeepUserTurns(startMatch[1]),
-    };
-  }
-
-  const parts = trimmed.split(/\s+/);
-  const endMatch = parts[parts.length - 1].match(KEEP_TOKEN_RE);
-  if (endMatch) {
-    return {
-      followUpPrompt: trimmed.slice(0, trimmed.length - parts[parts.length - 1].length).trim(),
-      keepUserTurns: parseKeepUserTurns(endMatch[1]),
-    };
-  }
-
-  return { followUpPrompt: trimmed, keepUserTurns: null };
-};
-
-const buildCustomInstructions = (keepUserTurns: number | null): string => {
-  if (keepUserTurns == null) return PI_VCC_COMPACT_INSTRUCTION;
-  return `${PI_VCC_COMPACT_INSTRUCTION} keep:${keepUserTurns}`;
-};
+import { formatCompactionStats, getLastCompactionStats } from "../hooks/before-compact";
+import { buildPiVccCustomInstructions, parseKeepAndPrompt } from "../core/compact-args";
 
 export const registerPiVccCommand = (pi: ExtensionAPI) => {
   pi.registerCommand("pi-vcc", {
     description: "Compact conversation with pi-vcc structured summary",
     handler: async (args: string, ctx) => {
-      const { followUpPrompt, keepUserTurns } = parsePiVccArgs(args);
+      const { followUpPrompt, keepUserTurns } = parseKeepAndPrompt(args);
       ctx.compact({
-        customInstructions: buildCustomInstructions(keepUserTurns),
+        customInstructions: buildPiVccCustomInstructions(keepUserTurns),
         onComplete: () => {
           const stats = getLastCompactionStats();
           if (stats) {

--- a/src/core/compact-args.ts
+++ b/src/core/compact-args.ts
@@ -1,0 +1,45 @@
+export const PI_VCC_COMPACT_INSTRUCTION = "__pi_vcc__";
+
+const KEEP_TOKEN_RE = /^keep:(\d+)$/;
+
+export interface ParsedCompactionArgs {
+  followUpPrompt: string;
+  keepUserTurns: number | null;
+  keepUserTurnsExplicit: boolean;
+}
+
+const parseKeepUserTurns = (raw: string): number => {
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : Number.MAX_SAFE_INTEGER;
+};
+
+export const parseKeepAndPrompt = (args?: string): ParsedCompactionArgs => {
+  const trimmed = args?.trim() ?? "";
+  if (!trimmed) return { followUpPrompt: "", keepUserTurns: null, keepUserTurnsExplicit: false };
+
+  const startMatch = trimmed.match(/^keep:(\d+)(?:\s+|$)([\s\S]*)$/);
+  if (startMatch) {
+    return {
+      followUpPrompt: startMatch[2].trim(),
+      keepUserTurns: parseKeepUserTurns(startMatch[1]),
+      keepUserTurnsExplicit: true,
+    };
+  }
+
+  const parts = trimmed.split(/\s+/);
+  const endMatch = parts[parts.length - 1].match(KEEP_TOKEN_RE);
+  if (endMatch) {
+    return {
+      followUpPrompt: trimmed.slice(0, trimmed.length - parts[parts.length - 1].length).trim(),
+      keepUserTurns: parseKeepUserTurns(endMatch[1]),
+      keepUserTurnsExplicit: true,
+    };
+  }
+
+  return { followUpPrompt: trimmed, keepUserTurns: null, keepUserTurnsExplicit: false };
+};
+
+export const buildPiVccCustomInstructions = (keepUserTurns: number | null): string => {
+  if (keepUserTurns == null) return PI_VCC_COMPACT_INSTRUCTION;
+  return `${PI_VCC_COMPACT_INSTRUCTION} keep:${keepUserTurns}`;
+};

--- a/src/details.ts
+++ b/src/details.ts
@@ -1,7 +1,11 @@
+import type { CompactionReason } from "./types";
+
 export interface PiVccCompactionDetails {
   compactor: "pi-vcc";
   version: number;
   sections: string[];
   sourceMessageCount: number;
   previousSummaryUsed: boolean;
+  reason?: CompactionReason;
+  willRetry?: boolean;
 }

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -2,11 +2,12 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { writeFileSync } from "fs";
 import { compile } from "../core/summarize";
+import { parseKeepAndPrompt, PI_VCC_COMPACT_INSTRUCTION } from "../core/compact-args";
 import { loadSettings, type PiVccSettings } from "../core/settings";
 import type { PiVccCompactionDetails } from "../details";
 import type { CompactionReason } from "../types";
 
-export const PI_VCC_COMPACT_INSTRUCTION = "__pi_vcc__";
+export { PI_VCC_COMPACT_INSTRUCTION } from "../core/compact-args";
 
 export interface CompactionStats {
   summarized: number;
@@ -48,25 +49,36 @@ const readCompactionEventContext = (event: unknown): { reason?: CompactionReason
   return { reason, willRetry: raw.willRetry === true };
 };
 
-const normalizeCustomInstructions = (customInstructions?: string): string | null => {
+const parseCompactionInstructions = (customInstructions?: string): {
+  isPiVcc: boolean;
+  keepUserTurns: number;
+  keepUserTurnsExplicit: boolean;
+  followUpPrompt: string | null;
+} => {
   const trimmed = customInstructions?.trim();
-  return trimmed ? trimmed : null;
-};
-
-const parsePiVccInstructions = (customInstructions?: string): { isPiVcc: boolean; keepUserTurns: number; keepUserTurnsExplicit: boolean } => {
-  const trimmed = customInstructions?.trim();
-  if (trimmed === PI_VCC_COMPACT_INSTRUCTION) return { isPiVcc: true, keepUserTurns: 1, keepUserTurnsExplicit: false };
+  if (trimmed === PI_VCC_COMPACT_INSTRUCTION) {
+    return { isPiVcc: true, keepUserTurns: 1, keepUserTurnsExplicit: false, followUpPrompt: null };
+  }
 
   const keepPrefix = `${PI_VCC_COMPACT_INSTRUCTION} `;
-  if (!trimmed?.startsWith(keepPrefix)) return { isPiVcc: false, keepUserTurns: 1, keepUserTurnsExplicit: false };
+  if (trimmed?.startsWith(keepPrefix)) {
+    const parsed = parseKeepAndPrompt(trimmed.slice(keepPrefix.length));
+    if (parsed.keepUserTurnsExplicit && !parsed.followUpPrompt) {
+      return {
+        isPiVcc: true,
+        keepUserTurns: parsed.keepUserTurns ?? 1,
+        keepUserTurnsExplicit: true,
+        followUpPrompt: null,
+      };
+    }
+  }
 
-  const match = trimmed.slice(keepPrefix.length).match(/^keep:(\d+)$/);
-  if (!match) return { isPiVcc: false, keepUserTurns: 1, keepUserTurnsExplicit: false };
-  const parsed = Number(match[1]);
+  const parsed = parseKeepAndPrompt(customInstructions);
   return {
-    isPiVcc: true,
-    keepUserTurns: Number.isSafeInteger(parsed) ? parsed : Number.MAX_SAFE_INTEGER,
-    keepUserTurnsExplicit: true,
+    isPiVcc: false,
+    keepUserTurns: parsed.keepUserTurns ?? 1,
+    keepUserTurnsExplicit: parsed.keepUserTurnsExplicit,
+    followUpPrompt: parsed.followUpPrompt || null,
   };
 };
 
@@ -218,8 +230,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
 
     // Always handle explicit /pi-vcc marker.
     // Otherwise, only handle when user opted in via settings.
-    const { isPiVcc, keepUserTurns, keepUserTurnsExplicit } = parsePiVccInstructions(customInstructions);
-    const followUpPrompt = isPiVcc ? null : normalizeCustomInstructions(customInstructions);
+    const { isPiVcc, keepUserTurns, keepUserTurnsExplicit, followUpPrompt } = parseCompactionInstructions(customInstructions);
     pendingFollowUpPrompt = null;
     if (!isPiVcc && !settings.overrideDefaultCompaction) return;
 

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -4,6 +4,7 @@ import { writeFileSync } from "fs";
 import { compile } from "../core/summarize";
 import { loadSettings, type PiVccSettings } from "../core/settings";
 import type { PiVccCompactionDetails } from "../details";
+import type { CompactionReason } from "../types";
 
 export const PI_VCC_COMPACT_INSTRUCTION = "__pi_vcc__";
 
@@ -16,6 +17,8 @@ export interface CompactionStats {
   keepUserTurnsExplicit: boolean;
   keepFallbackToCompactAll: boolean;
   keptTokensEst: number;
+  reason?: CompactionReason;
+  willRetry?: boolean;
 }
 
 let lastStats: CompactionStats | null = null;
@@ -35,6 +38,14 @@ export const formatCompactionStats = (stats: CompactionStats): string => {
       : "; compact-all fallback"
     : "";
   return `pi-vcc: ${stats.summarized} source entries processed; tail kept ${stats.keptUserTurns}/${stats.totalUserTurns} user turns${fallbackNote} (${stats.kept} messages, ~${formatTokens(stats.keptTokensEst)} tok).`;
+};
+
+const readCompactionEventContext = (event: unknown): { reason?: CompactionReason; willRetry: boolean } => {
+  const raw = event as { reason?: unknown; willRetry?: unknown };
+  const reason = raw.reason === "manual" || raw.reason === "threshold" || raw.reason === "overflow"
+    ? raw.reason
+    : undefined;
+  return { reason, willRetry: raw.willRetry === true };
 };
 
 const normalizeCustomInstructions = (customInstructions?: string): string | null => {
@@ -202,6 +213,7 @@ const REASON_MESSAGES: Record<OwnCutCancelReason, string> = {
 export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
   pi.on("session_before_compact", (event, ctx) => {
     const { preparation, branchEntries, customInstructions } = event;
+    const { reason, willRetry } = readCompactionEventContext(event);
     const settings = loadSettings();
 
     // Always handle explicit /pi-vcc marker.
@@ -240,9 +252,12 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       const userIndices = liveRoles.reduce<number[]>((acc, r, i) => (r === "user" ? (acc.push(i), acc) : acc), []);
 
       pendingFollowUpPrompt = null;
+      const fallbackToCore = !isPiVcc && (reason === "overflow" || willRetry);
       dbg(settings, {
-        cancelled: true,
+        cancelled: !fallbackToCore,
+        fallbackToCore,
         reason: ownCut.reason,
+        compaction: { reason, willRetry },
         isPiVcc,
         counts: {
           total: branchEntries.length,
@@ -271,6 +286,8 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
           hasContent: e.type === "message" ? e.message?.content != null : undefined,
         })),
       });
+
+      if (fallbackToCore) return;
 
       try {
         ctx?.ui?.notify?.(REASON_MESSAGES[ownCut.reason], "warning");
@@ -308,6 +325,8 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       keepUserTurnsExplicit,
       keepFallbackToCompactAll: ownCut.keepFallbackToCompactAll,
       keptTokensEst: Math.round(keptChars / 4),
+      reason,
+      willRetry,
     };
 
     const config = settings;
@@ -334,6 +353,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
 
     dbg(config, {
       usedOwnCut: true,
+      compaction: { reason, willRetry },
       messagesToSummarize: agentMessages.length,
       messagesPreviewHead: agentMessages.slice(0, 3).map((m: any) => ({ role: m.role, preview: previewContent(m.content) })),
       messagesPreviewTail: agentMessages.slice(-3).map((m: any) => ({ role: m.role, preview: previewContent(m.content) })),
@@ -352,6 +372,8 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       sections: [...summary.matchAll(/^\[(.+?)\]/gm)].map((m) => m[1]),
       sourceMessageCount: agentMessages.length,
       previousSummaryUsed: Boolean(preparation.previousSummary),
+      reason,
+      willRetry,
     };
 
     lastCompactWasPiVcc = isPiVcc;
@@ -369,13 +391,14 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
   // Fire success toast for /compact path only (delayed to let UI settle).
   // /pi-vcc path uses its own onComplete callback in the command handler.
   pi.on("session_compact", async (event, ctx) => {
+    const { reason, willRetry } = readCompactionEventContext(event);
     if (!event.fromExtension) return;
     const followUpPrompt = pendingFollowUpPrompt;
     pendingFollowUpPrompt = null;
     if (lastCompactWasPiVcc) return; // /pi-vcc handles its own toast via onComplete
     const stats = lastStats;
     if (!stats) return;
-    if (followUpPrompt) {
+    if (followUpPrompt && reason !== "overflow" && !willRetry) {
       try {
         await pi.sendUserMessage(followUpPrompt);
       } catch {}

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -63,14 +63,12 @@ const parseCompactionInstructions = (customInstructions?: string): {
   const keepPrefix = `${PI_VCC_COMPACT_INSTRUCTION} `;
   if (trimmed?.startsWith(keepPrefix)) {
     const parsed = parseKeepAndPrompt(trimmed.slice(keepPrefix.length));
-    if (parsed.keepUserTurnsExplicit && !parsed.followUpPrompt) {
-      return {
-        isPiVcc: true,
-        keepUserTurns: parsed.keepUserTurns ?? 1,
-        keepUserTurnsExplicit: true,
-        followUpPrompt: null,
-      };
-    }
+    return {
+      isPiVcc: true,
+      keepUserTurns: parsed.keepUserTurns ?? 1,
+      keepUserTurnsExplicit: parsed.keepUserTurnsExplicit,
+      followUpPrompt: null,
+    };
   }
 
   const parsed = parseKeepAndPrompt(customInstructions);
@@ -407,9 +405,10 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     const followUpPrompt = pendingFollowUpPrompt;
     pendingFollowUpPrompt = null;
     if (lastCompactWasPiVcc) return; // /pi-vcc handles its own toast via onComplete
+    if (reason === "overflow" || willRetry) return;
     const stats = lastStats;
     if (!stats) return;
-    if (followUpPrompt && reason !== "overflow" && !willRetry) {
+    if (followUpPrompt) {
       try {
         await pi.sendUserMessage(followUpPrompt);
       } catch {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import type { Message } from "@earendil-works/pi-ai";
 
+export type CompactionReason = "manual" | "threshold" | "overflow";
+
 export interface FileOps {
   readFiles?: string[];
   modifiedFiles?: string[];

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -299,7 +299,7 @@ describe("registerBeforeCompactHook: compact-all path", () => {
 
   test("session_compact overflow retry does not send follow-up prompt", async () => {
     setConfig({ debug: false, overrideDefaultCompaction: true });
-    const { pi, invokeBefore, invokeCompact, userMessages } = createMockPi();
+    const { pi, invokeBefore, invokeCompact, userMessages, notifyCalls } = createMockPi();
     registerBeforeCompactHook(pi);
 
     const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
@@ -308,6 +308,7 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     await new Promise((resolve) => setTimeout(resolve, 550));
 
     expect(userMessages).toEqual([]);
+    expect(notifyCalls).toEqual([]);
   });
 
   test("formatCompactionStats surfaces compact-all fallback when keep cannot be honored", () => {
@@ -359,6 +360,31 @@ describe("registerBeforeCompactHook: compact-all path", () => {
       keptUserTurns: 2,
       totalUserTurns: 3,
     });
+  });
+
+  test("/pi-vcc marker with trailing prompt does not leak marker as follow-up", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true });
+    const { pi, invokeBefore, invokeCompact, userMessages } = createMockPi();
+    registerBeforeCompactHook(pi);
+    const entries = [
+      msg("u1", "user", "one"),
+      msg("a1", "assistant", "reply one"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", "reply two"),
+      msg("u3", "user", "three"),
+      msg("a3", "assistant", "reply three"),
+    ];
+
+    const result = invokeBefore(makeEvent(entries, `${PI_VCC_COMPACT_INSTRUCTION} keep:2 continue`));
+    await invokeCompact({ type: "session_compact", fromExtension: true, reason: "manual", willRetry: false });
+    await new Promise((resolve) => setTimeout(resolve, 550));
+
+    expect(result.compaction.firstKeptEntryId).toBe("u2");
+    expect(getLastCompactionStats()).toMatchObject({
+      keptUserTurns: 2,
+      keepUserTurnsExplicit: true,
+    });
+    expect(userMessages).toEqual([]);
   });
 
   test("huge keep instruction compacts all safely", () => {

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -54,7 +54,7 @@ function setConfig(cfg: Record<string, unknown>) {
   writeFileSync(CONFIG_PATH, JSON.stringify(cfg));
 }
  
-function makeEvent(branchEntries: any[], customInstructions?: string) {
+function makeEvent(branchEntries: any[], customInstructions?: string, eventContext: Record<string, unknown> = {}) {
   return {
     type: "session_before_compact",
     customInstructions,
@@ -65,6 +65,7 @@ function makeEvent(branchEntries: any[], customInstructions?: string) {
       tokensBefore: 1000,
     },
     signal: new AbortController().signal,
+    ...eventContext,
   };
 }
  
@@ -130,6 +131,24 @@ describe("registerBeforeCompactHook: cancel paths", () => {
     expect(notifyCalls).toHaveLength(0);
   });
  
+  test("overflow retry ownCut failure falls back to Pi core instead of cancelling", () => {
+    setConfig({ debug: true, overrideDefaultCompaction: true });
+    const { pi, invokeBefore, notifyCalls } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant")];
+    const result = invokeBefore(makeEvent(entries, undefined, { reason: "overflow", willRetry: true }));
+
+    expect(result).toBeUndefined();
+    expect(notifyCalls).toHaveLength(0);
+    expect(existsSync(DEBUG_PATH)).toBe(true);
+    const snapshot = JSON.parse(readFileSync(DEBUG_PATH, "utf-8"));
+    expect(snapshot.cancelled).toBe(false);
+    expect(snapshot.fallbackToCore).toBe(true);
+    expect(snapshot.reason).toBe("too_few_live_messages");
+    expect(snapshot.compaction).toEqual({ reason: "overflow", willRetry: true });
+  });
+
   test("debug:true writes metrics-only snapshot on cancel with no content leakage", () => {
     setConfig({ debug: true, overrideDefaultCompaction: false });
     const { pi, invokeBefore } = createMockPi();
@@ -189,6 +208,34 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     expect(notifyCalls).toHaveLength(0); // no cancel notify on success
   });
  
+  test("manual /pi-vcc marker still compacts and records reason metadata", () => {
+    setConfig({ debug: false, overrideDefaultCompaction: false });
+    const { pi, invokeBefore } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+    const result = invokeBefore(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION, { reason: "manual", willRetry: false }));
+
+    expect(result.compaction).toBeDefined();
+    expect(result.compaction.firstKeptEntryId).toBe("m3");
+    expect(result.compaction.details).toMatchObject({ reason: "manual", willRetry: false });
+    expect(getLastCompactionStats()).toMatchObject({ reason: "manual", willRetry: false });
+  });
+
+  test("threshold override still compacts and records reason metadata", () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true });
+    const { pi, invokeBefore } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+    const result = invokeBefore(makeEvent(entries, undefined, { reason: "threshold", willRetry: false }));
+
+    expect(result.compaction).toBeDefined();
+    expect(result.compaction.firstKeptEntryId).toBe("m3");
+    expect(result.compaction.details).toMatchObject({ reason: "threshold", willRetry: false });
+    expect(getLastCompactionStats()).toMatchObject({ reason: "threshold", willRetry: false });
+  });
+
   test("override=true + customInstructions sends follow-up user message after compact", async () => {
     setConfig({ debug: false, overrideDefaultCompaction: true });
     const { pi, invokeBefore, invokeCompact, userMessages, notifyCalls } = createMockPi();
@@ -199,6 +246,19 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     await new Promise((resolve) => setTimeout(resolve, 550));
     expect(userMessages).toEqual(["continue"]);
     expect(notifyCalls.some((call) => call.msg.includes("tail kept 1/2 user turns (2 messages,"))).toBe(true);
+  });
+
+  test("session_compact overflow retry does not send follow-up prompt", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true });
+    const { pi, invokeBefore, invokeCompact, userMessages } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+    invokeBefore(makeEvent(entries, "continue", { reason: "overflow", willRetry: true }));
+    await invokeCompact({ type: "session_compact", fromExtension: true, reason: "overflow", willRetry: true });
+    await new Promise((resolve) => setTimeout(resolve, 550));
+
+    expect(userMessages).toEqual([]);
   });
 
   test("formatCompactionStats surfaces compact-all fallback when keep cannot be honored", () => {

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -248,6 +248,55 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     expect(notifyCalls.some((call) => call.msg.includes("tail kept 1/2 user turns (2 messages,"))).toBe(true);
   });
 
+  test("override=true + /compact keep prefix keeps requested turns and strips follow-up", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true });
+    const { pi, invokeBefore, invokeCompact, userMessages } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [
+      msg("m1", "user"), msg("m2", "assistant"),
+      msg("m3", "user"), msg("m4", "assistant"),
+      msg("m5", "user"), msg("m6", "assistant"),
+      msg("m7", "user"), msg("m8", "assistant"),
+    ];
+    const result = invokeBefore(makeEvent(entries, "keep:3 continue"));
+    await invokeCompact({ type: "session_compact", fromExtension: true });
+    await new Promise((resolve) => setTimeout(resolve, 550));
+
+    expect(result.compaction.firstKeptEntryId).toBe("m3");
+    expect(getLastCompactionStats()).toMatchObject({
+      keptUserTurns: 3,
+      totalUserTurns: 4,
+      requestedKeepUserTurns: 3,
+      keepUserTurnsExplicit: true,
+    });
+    expect(userMessages).toEqual(["continue"]);
+  });
+
+  test("override=true + /compact keep suffix keeps requested turns and strips follow-up", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true });
+    const { pi, invokeBefore, invokeCompact, userMessages } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [
+      msg("m1", "user"), msg("m2", "assistant"),
+      msg("m3", "user"), msg("m4", "assistant"),
+      msg("m5", "user"), msg("m6", "assistant"),
+    ];
+    const result = invokeBefore(makeEvent(entries, "continue keep:2"));
+    await invokeCompact({ type: "session_compact", fromExtension: true });
+    await new Promise((resolve) => setTimeout(resolve, 550));
+
+    expect(result.compaction.firstKeptEntryId).toBe("m3");
+    expect(getLastCompactionStats()).toMatchObject({
+      keptUserTurns: 2,
+      totalUserTurns: 3,
+      requestedKeepUserTurns: 2,
+      keepUserTurnsExplicit: true,
+    });
+    expect(userMessages).toEqual(["continue"]);
+  });
+
   test("session_compact overflow retry does not send follow-up prompt", async () => {
     setConfig({ debug: false, overrideDefaultCompaction: true });
     const { pi, invokeBefore, invokeCompact, userMessages } = createMockPi();


### PR DESCRIPTION
## Summary
- support optional Pi compaction event `reason` / `willRetry` context
- let overflow retry compactions fall back to Pi core instead of cancelling recovery
- share keep:N parsing so `/compact keep:N <prompt>` matches `/pi-vcc keep:N <prompt>` when overrideDefaultCompaction is enabled
- bump package version to 0.3.18

## Tests
- `git diff --check`
- `bun test` (158 passed)
- reviewer: no blockers found