### PR TITLE
Improve ranked compaction keep-tail and auto-continue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ docs/
 run_compare.ts
 .pi-mux-state.json
 research/
+benchmarks/out/
 demo.cast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to `@sting8k/pi-vcc` are documented in this file.
+
+## [0.4.0]
+
+### Features
+
+- **Ranked compaction brief** — replace the fixed 120-line summary cap with signal-density-based block selection under a size-relative token budget (floor/ceiling/per-block clamp). On 794 real sessions: size parity with the old cap, recall +2.4pp, gh-recall +7pp, higher fact density.
+- **Size-relative brief budget** — `maxBriefChars` now scales with transcript length between a floor (~1100 tok) and ceiling (~2000 tok) at ~15 tok/block, so large sessions are no longer starved of high-value long-tail blocks while small sessions stay tight.
+- **Heredoc previews in brief** — multi-line bash (set -euo pipefail + real work) and interpreter heredocs (python3/node/ssh/sqlite3/...) now render a one-line body preview instead of a content-free opener. File-writer heredocs (cat/tee/dd) stay opener-only.
+- **Hardened heredoc parsing** — tighten opener regex to reject shift ops (`8<<20`) and numeric heredocs; only treat as heredoc when a closing terminator exists downstream. Misparse rate ≤0.17% across ~105k bash blocks, fail-safe.
+- **Trivial-bash penalty** — scaffolding-only bash blocks (set -e, cd, ls, echo) no longer compete with real edits for the brief budget. Failed commands (nonzero exit) are exempt since the failure is itself a state fact.
+- **Segment-closing assistant boost** — assistant turns that close a segment (next renderable block is user or EOF) get a +14 score boost and 120+120 head/tail truncation instead of the old head-only budget.
+- **Smart keep-tail** — when `smartKeepTail` is enabled (default true), pi-vcc estimates the keep:1 tail token count and, if ≤5k, grows keep to the largest N whose tail stays ≤25k. Explicit `keep:N` from the user is always respected.
+- **Auto-continue after compaction** — continue the agent after a successful threshold compaction or overflow compaction, deferred until idle so it doesn't interrupt in-flight tool calls.
+- **Token calibration from context usage** — calibrate chars/token from the real `tokensBefore` reported by the harness instead of a hardcoded heuristic, so estimates adapt to each session's content mix.
+
+### Fixes
+
+- **Token estimate: count all token-bearing parts** — `estimateMessageContentChars` now counts `thinking`, `toolCall.arguments` (not just `.input`), and `image` (4800 chars). Previously these were missed, deflating calibrated chars/token (mean 2.35→2.50) and over-estimating tail tokens. Fixes smart-keep engagement and brief budget sizing.
+- **Brief budget: charge preserve-recent blocks** — the newest `preserveRecentBlocks` are now charged against `maxBriefChars` instead of being added unconditionally. On the largest real session (~27.9k blocks) the ranked brief was 31% larger than baseline with zero recall gain; `maxBriefChars` is now a true ceiling.
+- **Notify format tightened** — compaction notify now shows `kept N/M turns, ~Xk tok (summarized Y)` instead of verbose source-entry counts and mechanism wording. Anomalies (compact-all fallback) collapse to `kept 0/N` with no extra clause.
+- **Notify retained with follow-up** — compact metrics notify is no longer swallowed when a pi-vcc follow-up prompt is queued.
+- **Brief: preserve message line breaks** — assistant text line breaks are no longer collapsed in the brief render.
+- **Exclude tool_result from selection** — `tool_result` blocks no longer consume brief selection budget since they render to nothing.
+- **gh pr poll penalty/dedup** — `gh pr view/checks <num>` polling commands get -10 penalty and are deduplicated by PR number; `gh pr merge/create/comment` are not penalized.
+- **Continuation timing** — threshold continuation deferred until idle; overflow compaction continuation fixed.
+- **Misc** — greptile review nits addressed; smart-keep tests aligned with compact-all boundary.
+
+### Documentation
+
+- Add runnable benchmark template (`benchmarks/benchmark.ts`) with fact model, category weights, and paired recall scoring vs 0.3.18 baseline.
+- Add benchmarks writeup (`benchmarks/README.md`) documenting the scoring model, size-relative budget params, and results on a public HF session dataset plus held-out local sessions.
+- Restructure usage and recall sections in README; add config field documentation.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Config lives at `~/.pi/agent/pi-vcc-config.json` (auto-scaffolded on first load 
 - **`continueAfterThresholdCompact`** *(default `true`)*: when `true`, pi-vcc asks the agent to continue after a successful automatic compaction (threshold or overflow), avoiding a UX cliff where the agent stops after compaction instead of continuing the task.
 - **`debug`** *(default `false`)*: when `true`, each compaction writes detailed info to `/tmp/pi-vcc-debug.json` — message counts, cut boundary, summary preview, sections, token estimate calibration.
 
+## Benchmarks
+
+Local benchmarks / research comparing the ranked brief against the shipped pi-vcc 0.3.18 baseline (recall, fact-density, precision, size) live in [`benchmarks/README.md`](./benchmarks/README.md).
+
 ## Related Work
 
 - [VCC](https://github.com/lllyasviel/VCC) — the original transcript-preserving conversation compiler

--- a/README.md
+++ b/README.md
@@ -23,20 +23,6 @@ Inspired by [VCC](https://github.com/lllyasviel/VCC) **(View-oriented Conversati
 | **Cost** | Burns tokens on summarization call | Zero — no API calls |
 | **Structure** | Free-form prose | Brief transcript + 4 semantic sections |
 
-### Real session metrics
-
-Measured on real session JSONLs under `~/.pi/agent/sessions` (chars = rendered message text).
-
-| Session | Messages | Before | After | Reduction | Time |
-|---|---|---|---|---|---|
-| Session A | 2,943 | 997,162 | 7,959 | 99.2% | 64ms |
-| Session B | 1,703 | 428,334 | 7,762 | 98.2% | 29ms |
-| Session C | 1,657 | 424,183 | 9,577 | 97.7% | 54ms |
-| Session D | 1,004 | 2,258,477 | 4,439 | 99.8% | 30ms |
-| Session E | 486 | 295,006 | 11,163 | 96.2% | 30ms |
-| Session F | 46 | 5,234 | 3,364 | 35.7% | 5ms |
-| Session G | 27 | 8,595 | 2,489 | 71.0% | 2ms |
-
 ## Features
 
 - **No LLM** — purely algorithmic, zero extra API cost
@@ -133,28 +119,19 @@ Sections appear only when relevant — a session with no git commits won't have 
 | `[User Preferences]` | Regex-extracted from user messages (`always`, `never`, `prefer`...) |
 | Brief transcript | Chronological conversation flow — rolling window of ~120 recent lines, tool calls collapsed to one-liners with `(#N)` refs |
 
-**Merge policy:**
-- `Session Goal`, `User Preferences`: concise sticky sections
-- `Outstanding Context`: fresh-only (replaced each compaction)
-- `Files And Changes`, `Commits`: unique union across compactions
-- Brief transcript: rolling window, older lines drop off
-
 ## Recall (Lossless History)
 
 Pi's default compaction discards old messages permanently. After compaction, the agent only sees the summary.
 
 `vcc_recall` bypasses this by reading the raw session JSONL file directly. By default it searches only the active conversation lineage, regardless of how many compactions have happened. Use `scope:"all"` only when you intentionally want to include off-lineage branches.
 
-### Search
-
 Queries support **regex** and **multi-word OR logic** ranked by relevance:
 
 ```
-vcc_recall({ query: "auth token" })                         // active-lineage OR search, ranked
-vcc_recall({ query: "auth token", page: 2 })                // paginated (5 results/page)
-vcc_recall({ query: "hook|inject" })                         // regex pattern
-vcc_recall({ query: "fail.*build" })                         // regex pattern
-vcc_recall({ query: "auth token", scope: "all" })           // search all lineages
+vcc_recall({ query: "auth token" })                  // active-lineage OR search, ranked
+vcc_recall({ query: "auth token", page: 2 })           // paginated (5 results/page)
+vcc_recall({ query: "hook|inject" })                  // regex pattern
+vcc_recall({ query: "auth token", scope: "all" })    // search all lineages
 ```
 
 Manual slash command:
@@ -163,37 +140,17 @@ Manual slash command:
 /pi-vcc-recall auth token scope:all
 ```
 
-### Browse
-
-Without a query, returns the last 25 entries as brief summaries:
-
-```
-vcc_recall()
-vcc_recall({ scope: "all" })  // browse recent entries across all lineages
-```
-
-### Expand
-
-Returns full untruncated content for specific indices found via search:
-
-```
-vcc_recall({ expand: [41, 42] })                 // active-lineage expand
-vcc_recall({ expand: [41, 42], scope: "all" })   // expand across all lineages
-```
-
-Typical workflow: **search → find relevant entry indices → expand those indices for full content**.
-
-> Some tool results are truncated by Pi core at save time. `expand` returns everything in the JSONL but can't recover what Pi already cut.
-
 ## Pipeline
 
-1. **Normalize** — raw Pi messages → uniform blocks (user, assistant, tool_call, tool_result, thinking)
-2. **Filter noise** — strip system messages, empty blocks
-3. **Build cut** — keep the requested tail of user turns; compact-all uses the `firstKeptEntryId: ""` sentinel
-4. **Build sections** — extract goal, file paths, blockers, preferences
-5. **Brief transcript** — chronological conversation flow, tool calls collapsed to one-liners, text truncated
-6. **Format** — render into bracketed sections + transcript
-7. **Merge** — if previous summary exists: sticky sections merge, volatile sections replace, transcript rolls
+1. **Calibrate** — estimate `charsPerToken` from `preparation.tokensBefore` vs actual message chars (falls back to heuristic `4 chars/token`)
+2. **Smart keep** — if `keep:1` tail is small (< 5k tokens), boost keep to the largest N whose tail stays ≤ 20k tokens; explicit `keep:N` is always respected
+3. **Build cut** — split at the keep boundary; everything before is summarized, the tail stays intact
+4. **Normalize** — raw Pi messages → uniform blocks (user, assistant, tool_call, tool_result, thinking)
+5. **Filter noise** — strip system messages, empty blocks
+6. **Build sections** — extract goal, file paths, commits, outstanding context, preferences
+7. **Brief transcript** — chronological conversation flow, tool calls collapsed to one-liners, text truncated
+8. **Format** — render into bracketed sections + transcript
+9. **Merge** — if previous summary exists: sticky sections dedup, volatile sections replace, transcript rolls
 
 ## Config
 
@@ -202,12 +159,16 @@ Config lives at `~/.pi/agent/pi-vcc-config.json` (auto-scaffolded on first load 
 ```json
 {
   "overrideDefaultCompaction": false,
+  "smartKeepTail": true,
+  "continueAfterThresholdCompact": true,
   "debug": false
 }
 ```
 
 - **`overrideDefaultCompaction`** *(default `false`)*: when `false`, pi-vcc only runs for `/pi-vcc`; `/compact` and auto-threshold compactions fall through to pi core. Set `true` to make pi-vcc handle all compaction paths.
-- **`debug`** *(default `false`)*: when `true`, each compaction writes detailed info to `/tmp/pi-vcc-debug.json` — message counts, cut boundary, summary preview, sections.
+- **`smartKeepTail`** *(default `true`)*: when `true`, pi-vcc boosts the default `keep:1` to the largest `N` whose tail stays ≤ 20k tokens, but only when the `keep:1` tail is already small (≤ 5k tokens). Explicit `keep:N` from the user is always respected.
+- **`continueAfterThresholdCompact`** *(default `true`)*: when `true`, pi-vcc asks the agent to continue after a successful automatic compaction (threshold or overflow), avoiding a UX cliff where the agent stops after compaction instead of continuing the task.
+- **`debug`** *(default `false`)*: when `true`, each compaction writes detailed info to `/tmp/pi-vcc-debug.json` — message counts, cut boundary, summary preview, sections, token estimate calibration.
 
 ## Related Work
 

--- a/README.md
+++ b/README.md
@@ -57,21 +57,15 @@ pi -e https://github.com/sting8k/pi-vcc
 
 ## Usage
 
-Once installed, pi-vcc registers a `session_before_compact` hook.
+pi-vcc runs automatically when your context window fills up (if `overrideDefaultCompaction` is enabled), or on-demand via commands.
 
-- Run `/pi-vcc` to trigger pi-vcc compaction manually.
-- Optional keep syntax: `/pi-vcc keep:3 <prompt>` or `/pi-vcc <prompt> keep:3`.
-  - `keep:1` matches the default behavior.
-  - `keep:0` compacts everything and keeps no tail.
-- By default, `/compact` and auto-threshold compactions still go through pi core (LLM-based). Set `overrideDefaultCompaction: true` in the config to let pi-vcc handle all compaction paths.
-- To search older active-lineage history after compaction, use `vcc_recall`.
-- To intentionally search across all lineages, pass `scope:"all"` to `vcc_recall` or run `/pi-vcc-recall <query> scope:all`.
-- To search and feed results to agent yourself, run `/pi-vcc-recall <query> [page:N]`.
-  - Tip: type `/recall` and Pi will autocomplete to `/pi-vcc-recall`.
+### Compaction
 
-### How compaction works
-
-Pi splits the conversation at the **last user message** by default. Everything after — the **kept tail** — stays intact and untouched. With `keep:N`, pi-vcc keeps the last `N` user turns in that tail and summarizes everything before the cut point. If `keep:0` is requested, it compacts everything and keeps no tail.
+- **`/pi-vcc`** — manual compaction, keeps the last 1 user turn by default.
+- **`/pi-vcc keep:N [prompt]`** — keep the last `N` user turns; optional prompt is sent to the agent after compaction.
+  - `keep:1` = default, `keep:0` = compact everything, no tail.
+- By default `/compact` and auto-threshold go through Pi core. Set `overrideDefaultCompaction: true` to let pi-vcc handle all paths.
+- **Smart keep**: when enabled, pi-vcc auto-boosts `keep:1` to a larger N if the tail is small enough (< 5k tokens, capped at 20k).
 
 ### Compacted message structure
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,9 +3,11 @@
 How the ranked brief compaction (`compileRanked`) is measured against the shipped
 baseline compaction (**master 0.3.18**), plus the current results.
 
-> The measurement harness itself currently lives under `research/`. It will be
-> imported into this folder later; this README documents the scoring and results
-> only.
+> [`benchmark.ts`](./benchmark.ts) in this folder is a **self-contained template**
+> you can run on your own sessions (see §8). It is a readable starting frame, not a
+> turnkey tool — the fact weights and command families are meant to be edited to
+> match your workflow. The full research harness that produced the numbers below
+> lives under `research/` (not shipped).
 
 ## 1. What is measured
 
@@ -103,6 +105,11 @@ so it is never used for the headline delta.
 
 hf-dataset, production budget (see §5), 790 non-empty sessions.
 
+**TL;DR vs 0.3.18:** same recall on the typical session (paired median +0.0pp),
+but **smaller** (median −11%, corpus −35%) and **denser** (~1.4× fact-value per
+char, duplicates near-eliminated). The only cost is a small recall dip on the
+large-session tail (mean −2.4pp, §4.2) — the exact place the brief shrinks most.
+
 ### 4.1 Headline
 
 | metric                       | baseline (master) | ranked | delta            |
@@ -197,3 +204,37 @@ tuning).
 - The firm, defensible claim is **no median regression + higher fact-density**,
   not a large recall win.
 
+## 8. Run it on your own sessions
+
+[`benchmark.ts`](./benchmark.ts) is a **template**: a single self-contained file
+(fact model, weights, and metrics inlined) that scores the ranked brief against
+the plain transcript-tail brief on your sessions. Run it from a clone of this
+repo (needs [bun](https://bun.sh) and the repo's installed dependencies):
+
+```
+bun benchmarks/benchmark.ts --sessions=~/.pi/agent/sessions --limit=200
+```
+
+It prints a baseline-vs-ranked table plus the paired recall delta, and writes
+`benchmarks/out/benchmark.{csv,json}` (gitignored) for your own analysis.
+
+| flag          | meaning                                 | default                |
+|---------------|-----------------------------------------|------------------------|
+| `--sessions`  | dir of `*.jsonl` sessions (recursed)    | `~/.pi/agent/sessions` |
+| `--limit`     | max sessions to score                   | all                    |
+| `--floor`     | min brief budget, chars (§5)            | 4400                   |
+| `--ceiling`   | max brief budget, chars (§5)            | 8000                   |
+| `--per-block` | budget slope, chars/block (§5)          | 60                     |
+| `--max-blocks`| ranked selection pool size              | 80                     |
+| `--recent`    | recent blocks always kept               | 16                     |
+| `--out`       | output dir                              | `benchmarks/out`       |
+
+It reads transcripts locally and makes **no network calls**; only aggregate
+metrics and session IDs are written to `--out`.
+
+**Adapt it to your workflow.** The two blocks worth editing are the `WEIGHTS`
+table (§3.2 — what a fact is worth to *you*) and the command-family regexes
+(§3.1 — e.g. add your test runner or task tool). The default baseline is this
+repo's own `compile()`; to reproduce a "vs a released version" number, install
+that version and import its `compile` as the baseline (see the comment at the
+top of the file).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,199 @@
+# Compaction Benchmarks
+
+How the ranked brief compaction (`compileRanked`) is measured against the shipped
+baseline compaction (**master 0.3.18**), plus the current results.
+
+> The measurement harness itself currently lives under `research/`. It will be
+> imported into this folder later; this README documents the scoring and results
+> only.
+
+## 1. What is measured
+
+When a session is compacted, the older transcript is replaced by a **brief**: a
+compressed summary that must preserve the durable facts of the session (files
+edited, commands run, commits, ...) while staying small.
+
+Two things are in tension:
+
+- **Recall** — how many real facts survive into the brief.
+- **Size** — how many characters the brief costs.
+
+The benchmark compares two brief builders on the same sessions:
+
+- **baseline** (master 0.3.18) — one contiguous raw transcript-tail window,
+  line-capped.
+- **ranked** (`compileRanked`) — scores and selects blocks under a size budget.
+
+```
+full transcript ──► extract reference facts  (ground truth, weighted)
+       │                                   │
+       ├──► baseline brief ──►┐            │
+       └──► ranked brief   ──►┤  same extractor parses both  (symmetric)
+                              ▼
+        paired scoring: recall · density · precision · size
+```
+
+## 2. Datasets
+
+| name                | what it is                                  | size             |
+|---------------------|---------------------------------------------|------------------|
+| local tests         | unit + integration suite (`bun test`)       | 214 tests        |
+| hf-dataset          | a public HuggingFace session dataset        | 794 sessions     |
+| local real sessions | held-out real sessions, not in hf-dataset   | large (11–27 MB) |
+
+`hf-dataset` is the primary in-sample corpus. `local real sessions` are the
+out-of-sample (OOS) check against overfitting to hf-dataset.
+
+## 3. Scoring
+
+### 3.1 Fact model
+
+Reference facts are extracted from the **full** transcript (the ground truth).
+Both briefs are then parsed by the **same** extractor and scored by **exact set
+membership** — a fact counts as recalled only if its normalized key appears in
+the brief. Because both sides use the same parser, scoring is symmetric and
+neither builder gets a parsing advantage.
+
+Keys are **normalized**, not embeddings:
+
+- **command family** via regex — `git <verb>`, `gh pr|issue <verb>`,
+  search (`rg`/`grep`/`find`), test/verify (`bun|npm|pytest|cargo|go test|tsc`...)
+- **file path** (read vs modified)
+- **commit**
+- **tool call** (edit-class vs read-class)
+
+### 3.2 Fact weights
+
+Not all facts matter equally. Each recalled fact contributes its category weight,
+so losing a commit hurts far more than losing a generic `ls`:
+
+| fact category            | weight | rationale                          |
+|--------------------------|:------:|------------------------------------|
+| failed command           |   6    | an error state is the most critical to carry forward |
+| commit                   |   5    | durable checkpoint                 |
+| modified file            |   4    | concrete change to the codebase    |
+| test / verify command    |   4    | proves state                       |
+| edit-class tool call     |   4    | concrete change                    |
+| gh pr / issue command    |   2    | workflow milestone                 |
+| file read                |   1    | context, low durability            |
+| search command           |   1    | context, low durability            |
+| read-class tool call     |   1    | context, low durability            |
+| other command (generic)  |  0.5   | the long tail                      |
+
+### 3.3 Metrics
+
+| metric              | formula                                     | meaning                                       |
+|---------------------|---------------------------------------------|-----------------------------------------------|
+| weightedRecall      | Σ weight(ref facts found) / Σ weight(all ref facts) | fraction of *value* kept (empty session → 1) |
+| weightedFactDensity | Σ weight(facts found) / (briefChars / 1000) | value kept per 1k chars (size-normalized)     |
+| precision           | mean fact-weight of the brief's own facts (non-overlapping partition) | is the budget spent on high-value fact types? (~0.5–5) |
+| size                | brief length in chars                       | budget cost                                   |
+
+`weightedFactDensity` is the fairest single quality number because it is
+size-normalized: a builder cannot win it just by writing more.
+
+### 3.4 How comparisons are made
+
+Comparison is **paired**: the per-session delta between ranked and baseline,
+reported as the median + mean (+ IQR) of those deltas. A marginal comparison
+(median of one column minus median of the other) is *not* paired and can mislead,
+so it is never used for the headline delta.
+
+## 4. Results vs master 0.3.18
+
+hf-dataset, production budget (see §5), 790 non-empty sessions.
+
+### 4.1 Headline
+
+| metric                       | baseline (master) | ranked | delta            |
+|------------------------------|:-----------------:|:------:|:-----------------|
+| weightedRecall — paired      |         —         |   —    | **median +0.0pp**, mean −0.7pp |
+| weightedRecall — marginal median | 72.0%         | 69.2%  | (marginal, context only) |
+| weightedFactDensity (median) |       3.69        |  5.10  | **~1.4×**, paired wins 465 / 171 |
+| precision (median)           |       1.68        |  1.84  | +0.20 mean       |
+| duplicate commands / brief   |        0.9        |  0.1   | near-eliminated  |
+| duplicate tool calls / brief |        0.9        |  0.1   | near-eliminated  |
+| recall wins / losses         |         —         |   —    | 253 / 199        |
+
+**Read:** on the median session, ranked matches master's recall (+0.0pp) while
+packing ~1.4× the fact-value per character and near-eliminating duplicates. The
+small negative *mean* comes entirely from a large-session tail (§4.2).
+
+### 4.2 Size and recall by session size
+
+Bucketed by master's brief size. Size reduction is **per-session median**.
+
+| bucket (master brief) |  n  | size reduction | recall Δ (median) | recall Δ (mean) |
+|-----------------------|:---:|:--------------:|:-----------------:|:---------------:|
+| SMALL  (<3.5k)        | 291 |      ~0%       |      +0.0pp       |     +1.2pp      |
+| MED    (3.5–6k)       | 130 |       8%       |      +0.0pp       |     +0.1pp      |
+| LARGE  (≥6k)          | 369 |      38%       |      +0.0pp       |     −2.4pp      |
+
+Overall size reduction depends on how you weight it:
+
+| view                        | reduction |
+|-----------------------------|:---------:|
+| per-session median          |  **11%**  |
+| per-session mean            |    19%    |
+| corpus total bytes          |    35%    |
+
+The oft-quoted "−35%" is the **corpus-byte** figure — dominated by LARGE sessions
+(−38% median). The **typical** session shrinks ~11%.
+
+### 4.3 By fact category
+
+| fact category            | master recall | ranked recall | delta   |
+|--------------------------|:-------------:|:-------------:|:--------|
+| gh pr / issue            |     71.7%     |     77.9%     | +6.2pp  |
+| test / verify            |     84.7%     |     85.4%     | +0.7pp  |
+| generic command (tail)   |     67.1%     |     62.0%     | −5.1pp  |
+
+High-value categories (commits, modified files) sit at parity; the differences
+are confined to the low-weight long tail.
+
+### 4.4 Out-of-sample (local real sessions)
+
+On held-out large/huge real sessions, ranked **ties-or-wins every session**
+(recall mean ≈ +3.1pp, 0 regressions) at ~4× density. Absolute recall there is
+low (~17–20%) simply because an ~8k-char brief can only cover a fraction of the
+thousands of facts in an 11–27 MB transcript; the comparison is fair because both
+builders get the same budget.
+
+## 5. Size-relative budget
+
+The budget is not a flat cap; it scales with session length:
+
+```
+maxBriefChars = clamp(slope × blockCount, floor, ceiling)
+```
+
+| param   | role                                | production value         |
+|---------|-------------------------------------|--------------------------|
+| floor   | minimum budget (small sessions)     | ~4400 chars (1100 tok)   |
+| ceiling | maximum budget (bounds growth)      | ~8000 chars (2000 tok)   |
+| slope   | budget per transcript block         | ~60 chars/block (15 tok) |
+
+A flat cap gives a 50-block and a 3000-block session the same budget, starving the
+long tail on large sessions. The slope gives longer sessions more room; the
+ceiling keeps it bounded. `blockCount` is the length driver because it is
+available in-place (no need to run the baseline builder to size the budget).
+
+## 6. Where ranked leads / trails
+
+- **Leads:** density (~1.4×), precision, near-total dedup, gh-command recall, and
+  small/medium sessions — at recall parity or better.
+- **Trails:** the LARGE-session long tail (mean −2.4pp) and generic long-tail
+  commands (−5.1pp) — which is also exactly where ranked is smallest (−38%).
+
+So the win vs master is **smaller + denser at median-recall parity**, not a raw
+recall win. Closing the LARGE tail without giving back the size advantage is the
+open improvement target (candidate levers: near-duplicate prose compression to
+free budget for markers, a targeted LARGE-session ceiling, and scoring/selection
+tuning).
+
+## 7. Caveats
+
+- The OOS gain is real but modest and workflow-specific.
+- The firm, defensible claim is **no median regression + higher fact-density**,
+  not a large recall win.
+

--- a/benchmarks/benchmark.ts
+++ b/benchmarks/benchmark.ts
@@ -1,0 +1,471 @@
+#!/usr/bin/env bun
+/**
+ * Sample compaction benchmark — TEMPLATE, not a turnkey tool.
+ *
+ * Measures pi-vcc's ranked brief (`compileRanked`) against the plain
+ * contiguous transcript-tail brief (`compile`) on YOUR OWN sessions, using the
+ * scoring documented in benchmarks/README.md: weighted fact recall, weighted
+ * fact-density, precision, and size.
+ *
+ * It is deliberately self-contained (fact model + weights + metrics inlined) so
+ * you can read it top-to-bottom and adapt the parts that matter for your
+ * workflow — especially the fact WEIGHTS (§ "Fact weights") and the command
+ * families, which encode what "an important fact" means for you.
+ *
+ * ── Run (from a clone of this repo, with bun) ────────────────────────────────
+ *   bun benchmarks/benchmark.ts --sessions=~/.pi/agent/sessions --limit=200
+ *
+ * Flags (all optional):
+ *   --sessions=DIR   dir of *.jsonl session files (recursed). default: ~/.pi/agent/sessions
+ *   --limit=N        cap sessions processed. default: all
+ *   --max-blocks=N   ranked selection pool size.        default: 80
+ *   --recent=N       recent blocks always kept.         default: 16
+ *   --floor=N        min brief budget (chars).          default: 4400
+ *   --ceiling=N      max brief budget (chars).          default: 8000
+ *   --per-block=N    budget slope (chars per block).    default: 60
+ *   --out=DIR        where to write csv/json.           default: benchmarks/out
+ *
+ * Requires the Pi runtime packages (already dependencies of this repo):
+ *   @earendil-works/pi-coding-agent, @earendil-works/pi-ai
+ *
+ * NOTE: this reads your real session transcripts locally and writes only
+ * aggregate metrics + session IDs to --out. It makes no network calls.
+ */
+
+import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join, resolve } from "path";
+import { parseSessionEntries, convertToLlm } from "@earendil-works/pi-coding-agent";
+
+// Both brief builders come from THIS repo's src/ — the comparison is
+// "plain tail (compile) vs ranked (compileRanked)", i.e. the value of ranking.
+// To instead reproduce a "vs a previous release" number, install that version
+// and import its compile() here as the baseline.
+import { compile, compileRanked } from "../src/core/summarize";
+import { normalize } from "../src/core/normalize";
+import { filterNoise } from "../src/core/filter-noise";
+import { extractFiles } from "../src/extract/files";
+import { extractCommits, formatCommits } from "../src/extract/commits";
+import { extractPath } from "../src/core/tool-args";
+import type { FileOps, NormalizedBlock } from "../src/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config
+// ─────────────────────────────────────────────────────────────────────────────
+const arg = (name: string): string | undefined => {
+  const p = `--${name}=`;
+  return process.argv.find((a) => a.startsWith(p))?.slice(p.length);
+};
+const argNum = (name: string, fallback: number): number => {
+  const n = Number(arg(name));
+  return Number.isFinite(n) ? n : fallback;
+};
+const expandHome = (p: string): string => (p.startsWith("~") ? join(homedir(), p.slice(1)) : p);
+
+const SESSIONS_DIR = resolve(expandHome(arg("sessions") ?? "~/.pi/agent/sessions"));
+const OUT_DIR = resolve(expandHome(arg("out") ?? join(import.meta.dir, "out")));
+const LIMIT = argNum("limit", Infinity);
+const MAX_BLOCKS = argNum("max-blocks", 80);
+const RECENT = argNum("recent", 16);
+// Size-relative budget: clamp(perBlock * blockCount, floor, ceiling). See README §5.
+const FLOOR = argNum("floor", 4400);
+const CEILING = argNum("ceiling", 8000);
+const PER_BLOCK = argNum("per-block", 60);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fact model  (README §3.1) — command families & tool classes
+// ─────────────────────────────────────────────────────────────────────────────
+const TEST_RE = /(?:\b(?:bun|npm|pnpm|yarn)\s+(?:run\s+)?[\w:-]*(?:test|spec|check|lint|build|typecheck|tsc)\b|\bnode\s+--test\b|\bpytest\b|\bcargo\s+test\b|\bgo\s+test\b|\bmvn\s+test\b|\bgradle\s+test\b|\btsc\b)/i;
+const GH_RE = /(?:^|\s)gh\s+(pr|issue)\s+(\w+)\s+(\d+)/i;
+const GH_ANY_RE = /(?:^|\s)gh\s+(pr|issue)\s+(\w+)\b/i;
+const GIT_RE = /(?:^|\s)git\s+(\w+)/i;
+const SEARCH_RE = /^(?:rg|grep|find)\b/i;
+const EDIT_TOOL_RE = /^(edit|write|multiedit|quick_edit|target_edit|apply_patch)$/i;
+const READ_TOOL_RE = /^(read|glob|grep|ls|find|semantic_query|semantic_grep|semantic_show)$/i;
+
+interface CommandFact { exactKey: string; semanticKey: string; family: string; failed: boolean; }
+interface ToolFact { key: string; family: string; }
+
+const normalizeCommand = (cmd: string): string =>
+  cmd.replace(/^\s*cd\s+\S+\s*&&\s*/, "").replace(/\s+/g, " ").trim();
+
+const commandFamily = (cmd: string): string => {
+  if (GH_ANY_RE.test(cmd)) return "gh";
+  if (GIT_RE.test(cmd)) return "git";
+  if (SEARCH_RE.test(cmd)) return "search";
+  if (TEST_RE.test(cmd)) return "verify";
+  return "other";
+};
+
+const semanticCommandKey = (cmd: string): string => {
+  const n = normalizeCommand(cmd);
+  const gh = n.match(GH_RE);
+  if (gh) return `gh:${gh[1].toLowerCase()}:${gh[2].toLowerCase()}:${gh[3]}`;
+  const ghAny = n.match(GH_ANY_RE);
+  if (ghAny) return `gh:${ghAny[1].toLowerCase()}:${ghAny[2].toLowerCase()}`;
+  const git = n.match(GIT_RE);
+  if (git) {
+    const msg = n.match(/\bgit\s+commit\b[^\n]*?-m\s+(?:"([^"]+)"|'([^']+)'|([^\s]+))/);
+    if (msg) return `git:commit:${msg[1] ?? msg[2] ?? msg[3]}`;
+    return `git:${git[1].toLowerCase()}`;
+  }
+  if (TEST_RE.test(n)) {
+    const runner = n.match(/^\S+/)?.[0] ?? "test";
+    const files = [...n.matchAll(/[\w./-]+(?:test|spec)[\w./-]*\.[\w]+|tests\/[\w./-]+/g)].map((m) => m[0]).sort();
+    return `verify:${runner}:${files.length ? files.join(",") : n.slice(0, 120)}`;
+  }
+  if (SEARCH_RE.test(n)) {
+    const quoted = n.match(/"([^"]+)"|'([^']+)'/)?.slice(1).find(Boolean);
+    const bin = n.match(/^\S+/)?.[0] ?? "search";
+    return `search:${bin}:${quoted ?? n.slice(0, 120)}`;
+  }
+  const [bin = "cmd", sub = ""] = n.split(/\s+/, 2);
+  return `${bin}:${sub || n.slice(0, 80)}`;
+};
+
+const commandFact = (raw: string, failed = false): CommandFact | null => {
+  const n = normalizeCommand(raw);
+  if (!n) return null;
+  return { exactKey: `cmd:${n}`, semanticKey: semanticCommandKey(n), family: commandFamily(n), failed };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fact weights  (README §3.2) — EDIT THESE to reflect what matters to you.
+// ─────────────────────────────────────────────────────────────────────────────
+interface Facts {
+  filesModified: Set<string>;
+  filesRead: Set<string>;
+  commits: Set<string>;
+  commandsSemantic: Set<string>;
+  testCommands: Set<string>;
+  failedCommands: Set<string>;
+  ghCommands: Set<string>;
+  searchCommands: Set<string>;
+  editTools: Set<string>;
+  readTools: Set<string>;
+  commandExactDupes: number;
+  toolDupes: number;
+}
+
+const WEIGHTS = [
+  { ref: "failedCommands", got: "commandsSemantic", weight: 6 }, // error state — most critical
+  { ref: "commits", got: "commits", weight: 5 },
+  { ref: "filesModified", got: "filesModified", weight: 4 },
+  { ref: "testCommands", got: "testCommands", weight: 4 },
+  { ref: "editTools", got: "editTools", weight: 4 },
+  { ref: "ghCommands", got: "ghCommands", weight: 2 },
+  { ref: "filesRead", got: "filesRead", weight: 1 },
+  { ref: "searchCommands", got: "searchCommands", weight: 1 },
+  { ref: "readTools", got: "readTools", weight: 1 },
+  { ref: "commandsSemantic", got: "commandsSemantic", weight: 0.5 }, // generic long tail
+] as const satisfies readonly { ref: keyof Facts; got: keyof Facts; weight: number }[];
+
+const asSet = (f: Facts, k: keyof Facts): Set<string> => (f[k] instanceof Set ? (f[k] as Set<string>) : new Set());
+const weightedTotal = (ref: Facts): number => WEIGHTS.reduce((t, w) => t + asSet(ref, w.ref).size * w.weight, 0);
+const weightedHit = (ref: Facts, got: Facts): number => {
+  let hit = 0;
+  for (const w of WEIGHTS) {
+    const g = asSet(got, w.got);
+    for (const k of asSet(ref, w.ref)) if (g.has(k)) hit += w.weight;
+  }
+  return hit;
+};
+const weightedRecall = (ref: Facts, got: Facts): number => {
+  const total = weightedTotal(ref);
+  return total === 0 ? 1 : weightedHit(ref, got) / total; // empty session → 1
+};
+const weightedFactDensity = (ref: Facts, got: Facts, chars: number): number =>
+  chars > 0 ? weightedHit(ref, got) / (chars / 1000) : 0;
+
+const precision = (got: Facts): number => {
+  const readOnly = new Set([...got.filesRead].filter((p) => !got.filesModified.has(p)));
+  let rest = new Set(got.commandsSemantic);
+  const inter = (a: Set<string>) => new Set([...rest].filter((k) => a.has(k)));
+  const minus = (a: Set<string>) => new Set([...rest].filter((k) => !a.has(k)));
+  const verify = inter(got.testCommands); rest = minus(got.testCommands);
+  const gh = inter(got.ghCommands); rest = minus(got.ghCommands);
+  const search = inter(got.searchCommands); rest = minus(got.searchCommands);
+  const cats = [
+    { c: got.commits.size, w: 5 }, { c: got.filesModified.size, w: 4 }, { c: readOnly.size, w: 1 },
+    { c: verify.size, w: 4 }, { c: gh.size, w: 2 }, { c: search.size, w: 1 }, { c: rest.size, w: 0.5 },
+    { c: got.editTools.size, w: 4 }, { c: got.readTools.size, w: 1 },
+  ];
+  const denom = cats.reduce((s, x) => s + x.c, 0);
+  return denom === 0 ? 0 : cats.reduce((s, x) => s + x.c * x.w, 0) / denom;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Extraction helpers
+// ─────────────────────────────────────────────────────────────────────────────
+const setOf = (items: Iterable<string>): Set<string> => new Set([...items].filter(Boolean));
+const union = (...s: Set<string>[]): Set<string> => setOf(s.flatMap((x) => [...x]));
+const countDupes = (items: string[]): number => items.length - new Set(items).size;
+const stripRenderedRef = (s: string): string =>
+  s.replace(/\s+\(#[\d, #]+\)\s*x\d+$/, "").replace(/\s+\(#\d+\)$/, "").trim();
+
+// Join wrapped continuation lines back into one logical line (mirrors the brief renderer).
+const logicalLines = (text: string): string[] => {
+  const out: string[] = [];
+  for (const raw of text.split("\n")) {
+    const line = raw.trimEnd();
+    if (!line) { out.push(line); continue; }
+    const starts = /^(?:\[[^\]]+\]|[-*]\s+|\$\s+|\.\.\.\()/.test(line);
+    if (starts || out.length === 0) out.push(line);
+    else out[out.length - 1] = `${out[out.length - 1]} ${line.trim()}`.trimEnd();
+  }
+  return out;
+};
+
+const buildFacts = (parts: {
+  filesModified: Set<string>; filesRead: Set<string>; commits: Set<string>;
+  commandFacts: CommandFact[]; toolFacts: ToolFact[];
+}): Facts => ({
+  filesModified: parts.filesModified,
+  filesRead: parts.filesRead,
+  commits: parts.commits,
+  commandsSemantic: setOf(parts.commandFacts.map((c) => c.semanticKey)),
+  testCommands: setOf(parts.commandFacts.filter((c) => c.family === "verify").map((c) => c.semanticKey)),
+  failedCommands: setOf(parts.commandFacts.filter((c) => c.failed).map((c) => c.semanticKey)),
+  ghCommands: setOf(parts.commandFacts.filter((c) => c.family === "gh").map((c) => c.semanticKey)),
+  searchCommands: setOf(parts.commandFacts.filter((c) => c.family === "search").map((c) => c.semanticKey)),
+  editTools: setOf(parts.toolFacts.filter((t) => t.family === "edit").map((t) => t.key)),
+  readTools: setOf(parts.toolFacts.filter((t) => t.family === "read").map((t) => t.key)),
+  commandExactDupes: countDupes(parts.commandFacts.map((c) => c.exactKey)),
+  toolDupes: countDupes(parts.toolFacts.map((t) => t.key)),
+});
+
+// Ground truth: facts from the FULL normalized transcript.
+const factsFromBlocks = (blocks: NormalizedBlock[]): Facts => {
+  const files = extractFiles(blocks);
+  for (const p of files.modified) files.created.delete(p);
+  const commandFacts: CommandFact[] = [];
+  const toolFacts: ToolFact[] = [];
+  for (const b of blocks) {
+    if (b.kind === "bash") {
+      const f = commandFact((b as any).command, (b as any).exitCode != null && (b as any).exitCode !== 0);
+      if (f) commandFacts.push(f);
+      continue;
+    }
+    if (b.kind !== "tool_call" || !b.name) continue;
+    if (/^bash$/i.test(b.name) && typeof (b as any).args?.command === "string") {
+      const f = commandFact((b as any).args.command);
+      if (f) commandFacts.push(f);
+      continue;
+    }
+    const path = extractPath((b as any).args);
+    if (!path) continue;
+    const family = EDIT_TOOL_RE.test(b.name) ? "edit" : READ_TOOL_RE.test(b.name) ? "read" : "tool";
+    toolFacts.push({ key: `tool:${b.name.toLowerCase()}:${path}`, family });
+  }
+  return buildFacts({
+    filesModified: union(files.modified, files.created),
+    filesRead: files.read,
+    commits: setOf(formatCommits(extractCommits(blocks), Number.MAX_SAFE_INTEGER)),
+    commandFacts, toolFacts,
+  });
+};
+
+// Same extractor, applied to a rendered brief (both builders parsed identically → symmetric).
+const briefRegion = (summary: string): string => {
+  const sep = "\n\n---\n\n";
+  const start = summary.indexOf(sep);
+  let brief = start < 0 ? "" : summary.slice(start + sep.length);
+  const note = brief.lastIndexOf("Use `vcc_recall`");
+  if (note >= 0) brief = brief.slice(0, note).replace(/\n\n---\n\n\s*$/, "").trimEnd();
+  return brief;
+};
+
+const parseFilesLine = (line: string, prefix: string): string[] => {
+  if (!line.startsWith(`${prefix}: `)) return [];
+  return line.slice(prefix.length + 2).split(",").map((s) => s.trim()).filter((s) => s && !/^\(\+\d+ more\)$/.test(s));
+};
+
+const factsFromSummary = (summary: string): Facts => {
+  const commandFacts: CommandFact[] = [];
+  const toolFacts: ToolFact[] = [];
+  const modified = new Set<string>();
+  const read = new Set<string>();
+  const commits = new Set<string>();
+
+  let section = "";
+  for (const line of logicalLines(summary)) {
+    const header = line.match(/^\[([^\]]+)\]$/)?.[1];
+    if (header) { section = header; continue; }
+    if (section === "Commits" && line.startsWith("- ")) commits.add(line.slice(2).trim());
+    if (section === "Files And Changes" && line.startsWith("- ")) {
+      const l = line.slice(2).trim();
+      for (const p of [...parseFilesLine(l, "Modified"), ...parseFilesLine(l, "Created")]) modified.add(p);
+      for (const p of parseFilesLine(l, "Read")) read.add(p);
+    }
+  }
+
+  for (const line of logicalLines(briefRegion(summary))) {
+    const clean = stripRenderedRef(line.trim());
+    const shell = clean.match(/^\$\s+(.+)$/)?.[1];
+    if (shell) { const f = commandFact(shell); if (f) commandFacts.push(f); continue; }
+    const tool = clean.match(/^\*\s+([^\s"]+)\s*(?:"([\s\S]*)")?/);
+    if (!tool) continue;
+    const [, name, arg = ""] = tool;
+    if (/^bash$/i.test(name)) { const f = commandFact(arg); if (f) commandFacts.push(f); continue; }
+    if (!arg || name.startsWith("(")) continue;
+    const family = EDIT_TOOL_RE.test(name) ? "edit" : READ_TOOL_RE.test(name) ? "read" : "tool";
+    toolFacts.push({ key: `tool:${name.toLowerCase()}:${arg}`, family });
+  }
+
+  return buildFacts({ filesModified: modified, filesRead: read, commits, commandFacts, toolFacts });
+};
+
+// FileOps feed the ranker the same hook-modified/hook-read signal production has.
+const fileOpsFromBlocks = (blocks: NormalizedBlock[]): FileOps => {
+  const modified = new Set<string>();
+  const read = new Set<string>();
+  for (const b of blocks) {
+    if (b.kind !== "tool_call" || !b.name) continue;
+    const p = extractPath((b as any).args);
+    if (!p) continue;
+    if (EDIT_TOOL_RE.test(b.name)) modified.add(p);
+    else if (READ_TOOL_RE.test(b.name)) read.add(p);
+  }
+  return { modifiedFiles: [...modified], readFiles: [...read] };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stats
+// ─────────────────────────────────────────────────────────────────────────────
+const mean = (a: number[]): number => (a.length ? a.reduce((s, x) => s + x, 0) / a.length : 0);
+const median = (a: number[]): number => {
+  if (!a.length) return 0;
+  const s = [...a].sort((x, y) => x - y);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+const pp = (x: number): string => (x * 100).toFixed(1);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Session loading
+// ─────────────────────────────────────────────────────────────────────────────
+const listJsonl = (dir: string): string[] => {
+  const out: string[] = [];
+  let entries: string[];
+  try { entries = readdirSync(dir); } catch { return out; }
+  for (const name of entries) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...listJsonl(full));
+    else if (name.endsWith(".jsonl")) out.push(full);
+  }
+  return out;
+};
+
+interface Row {
+  sessionId: string;
+  baselineChars: number;
+  rankedChars: number;
+  reductionPct: number;
+  baselineRecall: number;
+  rankedRecall: number;
+  recallDelta: number;
+  baselineDensity: number;
+  rankedDensity: number;
+  baselinePrecision: number;
+  rankedPrecision: number;
+  baselineCmdDupes: number;
+  rankedCmdDupes: number;
+}
+
+const rowFor = (file: string): Row | null => {
+  const raw = readFileSync(file, "utf8");
+  const entries = parseSessionEntries(raw);
+  const sessionId = entries.find((e: any) => e.type === "session")?.id ?? file.split("/").pop()!.replace(/\.jsonl$/, "");
+  const messages = entries.filter((e: any) => e.type === "message" && e.message).map((e: any) => e.message);
+  if (messages.length === 0) return null;
+
+  const llm = convertToLlm(messages);
+  const blocks = filterNoise(normalize(llm));
+  const ref = factsFromBlocks(blocks);
+
+  const baseline = compile({ messages: llm });
+  const ranked = compileRanked({
+    messages: llm,
+    fileOps: fileOpsFromBlocks(blocks),
+    // Production budget path: clamp(perBlock * blockCount, floor, ceiling). See README §5.
+    ranking: {
+      maxBlocks: MAX_BLOCKS,
+      preserveRecentBlocks: RECENT,
+      maxBriefChars: FLOOR,
+      maxBriefCharsCeiling: CEILING,
+      briefCharsPerBlock: PER_BLOCK,
+    },
+  });
+
+  const bf = factsFromSummary(baseline);
+  const rf = factsFromSummary(ranked);
+  const bRecall = weightedRecall(ref, bf);
+  const rRecall = weightedRecall(ref, rf);
+  return {
+    sessionId,
+    baselineChars: baseline.length,
+    rankedChars: ranked.length,
+    reductionPct: baseline.length > 0 ? (baseline.length - ranked.length) / baseline.length : 0,
+    baselineRecall: bRecall,
+    rankedRecall: rRecall,
+    recallDelta: rRecall - bRecall,
+    baselineDensity: weightedFactDensity(ref, bf, baseline.length),
+    rankedDensity: weightedFactDensity(ref, rf, ranked.length),
+    baselinePrecision: precision(bf),
+    rankedPrecision: precision(rf),
+    baselineCmdDupes: bf.commandExactDupes,
+    rankedCmdDupes: rf.commandExactDupes,
+  };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Run
+// ─────────────────────────────────────────────────────────────────────────────
+const files = listJsonl(SESSIONS_DIR);
+if (files.length === 0) {
+  console.error(`No *.jsonl sessions under ${SESSIONS_DIR}. Pass --sessions=DIR.`);
+  process.exit(1);
+}
+
+const rows: Row[] = [];
+for (const file of files) {
+  if (rows.length >= LIMIT) break;
+  try {
+    const row = rowFor(file);
+    if (row) rows.push(row);
+  } catch (e: any) {
+    console.error(`skip ${file}: ${e?.message ?? e}`);
+  }
+}
+
+mkdirSync(OUT_DIR, { recursive: true });
+const cols: (keyof Row)[] = [
+  "sessionId", "baselineChars", "rankedChars", "reductionPct",
+  "baselineRecall", "rankedRecall", "recallDelta",
+  "baselineDensity", "rankedDensity", "baselinePrecision", "rankedPrecision",
+  "baselineCmdDupes", "rankedCmdDupes",
+];
+const esc = (v: unknown): string => {
+  const s = typeof v === "number" ? String(Number(v.toFixed(4))) : String(v ?? "");
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+};
+writeFileSync(join(OUT_DIR, "benchmark.json"), JSON.stringify(rows, null, 2));
+writeFileSync(join(OUT_DIR, "benchmark.csv"), [cols.join(","), ...rows.map((r) => cols.map((c) => esc(r[c])).join(","))].join("\n"));
+
+// Paired deltas (per-session ranked − baseline), the honest headline (README §3.4).
+const recallDeltas = rows.map((r) => r.recallDelta);
+const wins = rows.filter((r) => r.recallDelta > 0.001).length;
+const losses = rows.filter((r) => r.recallDelta < -0.001).length;
+
+console.log(`\nsessions scored: ${rows.length}\n`);
+console.log("metric                     baseline    ranked     ");
+console.log("─────────────────────────  ─────────  ─────────");
+console.log(`weightedRecall   (median)  ${pp(median(rows.map((r) => r.baselineRecall))).padStart(7)}%  ${pp(median(rows.map((r) => r.rankedRecall))).padStart(7)}%`);
+console.log(`factDensity      (median)  ${median(rows.map((r) => r.baselineDensity)).toFixed(2).padStart(8)}  ${median(rows.map((r) => r.rankedDensity)).toFixed(2).padStart(8)}`);
+console.log(`precision        (median)  ${median(rows.map((r) => r.baselinePrecision)).toFixed(2).padStart(8)}  ${median(rows.map((r) => r.rankedPrecision)).toFixed(2).padStart(8)}`);
+console.log(`cmd dupes/brief  (mean)    ${mean(rows.map((r) => r.baselineCmdDupes)).toFixed(2).padStart(8)}  ${mean(rows.map((r) => r.rankedCmdDupes)).toFixed(2).padStart(8)}`);
+console.log(`brief chars      (median)  ${String(Math.round(median(rows.map((r) => r.baselineChars)))).padStart(8)}  ${String(Math.round(median(rows.map((r) => r.rankedChars)))).padStart(8)}`);
+console.log(`\npaired recall delta (ranked − baseline): median ${pp(median(recallDeltas))}pp, mean ${pp(mean(recallDeltas))}pp`);
+console.log(`recall wins/losses: ${wins}/${losses}`);
+console.log(`size reduction: median ${pp(median(rows.map((r) => r.reductionPct)))}%, mean ${pp(mean(rows.map((r) => r.reductionPct)))}%`);
+console.log(`\noutput: ${join(OUT_DIR, "benchmark.csv")}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sting8k/pi-vcc",
-  "version": "0.3.18",
+  "version": "0.4.0",
   "description": "Algorithmic conversation compactor for pi - transcript-preserving structured summaries, no LLM calls",
   "main": "index.ts",
   "keywords": [

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { formatCompactionStats, getLastCompactionStats } from "../hooks/before-compact";
+import { getLastCompactionStats, scheduleCompactionStatsNotify } from "../hooks/before-compact";
 import { buildPiVccCustomInstructions, parseKeepAndPrompt } from "../core/compact-args";
 
 export const registerPiVccCommand = (pi: ExtensionAPI) => {
@@ -12,7 +12,7 @@ export const registerPiVccCommand = (pi: ExtensionAPI) => {
         onComplete: () => {
           const stats = getLastCompactionStats();
           if (stats) {
-            ctx.ui.notify(formatCompactionStats(stats), "info");
+            scheduleCompactionStatsNotify(ctx, stats);
           } else {
             ctx.ui.notify("Compacted with pi-vcc", "info");
           }

--- a/src/core/brief.ts
+++ b/src/core/brief.ts
@@ -4,7 +4,10 @@ import { extractPath } from "./tool-args";
 import { collapseSkillText } from "./skill-collapse";
 
 const TRUNCATE_USER = 256;
-const TRUNCATE_ASSISTANT = 200;
+const SEGMENT_CLOSING_ASSISTANT_HEAD_WORDS = 120;
+const SEGMENT_CLOSING_ASSISTANT_TAIL_WORDS = 120;
+const ASSISTANT_HEAD_WORDS = 80;
+const ASSISTANT_TAIL_WORDS = 120;
 
 // Strip common self-reflective assistant prefixes that carry no semantic info.
 // Conservative list: only removes the leading filler, preserves the actual content.
@@ -59,6 +62,39 @@ const truncateTokens = (text: string, limit: number): string => {
     lastEnd = seg.index + seg.segment.length;
   }
   return flat;
+};
+
+const significantWordSpans = (flat: string): { start: number; end: number }[] => {
+  const words: { start: number; end: number }[] = [];
+  for (const seg of segmenter.segment(flat)) {
+    if (!isWord(seg)) continue;
+    if (STOP_WORDS.has(seg.segment.toLowerCase())) continue;
+    words.push({ start: seg.index, end: seg.index + seg.segment.length });
+  }
+  return words;
+};
+
+
+const truncateTokensHeadTail = (text: string, headLimit: number, tailLimit: number): string => {
+  const flat = text.replace(/\s+/g, " ").trim();
+  const words = significantWordSpans(flat);
+  if (words.length <= headLimit + tailLimit) return flat;
+  const head = flat.slice(0, words[headLimit - 1].end).trimEnd();
+  const tail = flat.slice(words[words.length - tailLimit].start).trimStart();
+  return `${head}...(middle truncated)...${tail}`;
+};
+
+const nextRenderableBlock = (blocks: NormalizedBlock[], index: number): NormalizedBlock | undefined => {
+  for (let i = index + 1; i < blocks.length; i++) {
+    if (blocks[i].kind !== "tool_result") return blocks[i];
+  }
+  return undefined;
+};
+
+const isSegmentClosingAssistant = (blocks: NormalizedBlock[], index: number): boolean => {
+  if (blocks[index]?.kind !== "assistant") return false;
+  const next = nextRenderableBlock(blocks, index);
+  return !next || next.kind === "user";
 };
 
 // ── bash command compression ──
@@ -133,7 +169,8 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
     lastHeader = header;
   };
 
-  for (const b of blocks) {
+  for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
+    const b = blocks[blockIndex];
     switch (b.kind) {
       case "user": {
         if (isNoiseUser(b.text)) break;
@@ -162,7 +199,9 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
           if (stripped === raw) break;
           raw = stripped;
         }
-        const text = truncateTokens(raw, TRUNCATE_ASSISTANT);
+        const text = isSegmentClosingAssistant(blocks, blockIndex)
+          ? truncateTokensHeadTail(raw, SEGMENT_CLOSING_ASSISTANT_HEAD_WORDS, SEGMENT_CLOSING_ASSISTANT_TAIL_WORDS)
+          : truncateTokensHeadTail(raw, ASSISTANT_HEAD_WORDS, ASSISTANT_TAIL_WORDS);
         if (text) {
           const ref = b.sourceIndex != null ? ` (#${b.sourceIndex})` : "";
           push("[assistant]", text + ref);

--- a/src/core/brief.ts
+++ b/src/core/brief.ts
@@ -109,19 +109,92 @@ const isSegmentClosingAssistant = (blocks: NormalizedBlock[], index: number): bo
 
 const BASH_CAP = 240;
 const PIPE_TAIL_RE = /\s*\|\s*(?:head|tail|sort|wc|column|tr|cut|awk|uniq|python3|node|bun)(?:\s[^|]*)?$/;
+// Preamble/boilerplate lines that carry no durable fact on their own. Dropped
+// when a script has more informative lines, so `set -euo pipefail\ngit commit`
+// renders the commit rather than the shell option.
+const TRIVIAL_LINE_RE = /^(?:set\s+[-+]|cd\s+\S+$|export\s+\w+=|(?:source|\.)\s+\S+|pwd$|true$|:$|#)/;
+// A real heredoc opener: `<<` at a command boundary — not preceded by a word
+// char or `)`, so shift ops (`8 << 20`, `Rd<<8`) are not misread — with an
+// identifier terminator starting [A-Za-z_], so numeric `<< 10` is rejected too.
+const HEREDOC_OPEN_RE = /(?<![\w)])<<-?\s*["']?([A-Za-z_]\w*)["']?/;
+// File-writer heredocs (`cat > f <<EOF`, tee, dd) already name their target, so
+// the opener alone is informative → body-only. EVERY other heredoc has a
+// content-free opener (interpreters python3/node, remote shells `ssh host <<CMD`,
+// sqlite3, ...) → we surface a one-line body preview. This denylist replaces an
+// interpreter allowlist that missed ssh/sqlite3/etc. and mis-handled heredocs
+// combined with a `>` redirect.
+const FILEWRITER_HEREDOC_RE = /(?:^|[|&;]\s*)(?:cat|tee|dd)\b/;
+const HEREDOC_BODY_CAP = 80;
+// Body lines that are pure boilerplate and make a poor preview.
+const BODY_NOISE_RE = /^(?:import\s|from\s+\S+\s+import|require\(|const\s+\w+\s*=\s*require|#|\/\/|"""|'''|"use strict"|use\s+strict|<\?php)/;
 
-/** Semantic compression: strip cd prefix, pipe tail formatting, cap length */
-const compressBash = (raw: string): string => {
-  // Flatten multi-line: take first meaningful line
-  let cmd = raw.split("\n").map(l => l.trim()).filter(Boolean)[0] ?? raw;
-  // Strip cd <path> && prefix
-  cmd = cmd.replace(/^cd\s+\S+\s*&&\s*/, "");
-  // Strip pipe tail formatting commands (up to 3 times)
+const stripCdPrefix = (line: string): string => line.replace(/^cd\s+\S+\s*&&\s*/, "").trim();
+const stripPipeTail = (line: string): string => {
+  let c = line;
   for (let i = 0; i < 3; i++) {
-    const stripped = cmd.replace(PIPE_TAIL_RE, "");
-    if (stripped === cmd) break;
-    cmd = stripped;
+    const stripped = c.replace(PIPE_TAIL_RE, "");
+    if (stripped === c) break;
+    c = stripped;
   }
+  return c.trim();
+};
+
+/**
+ * Semantic compression of a (possibly multi-line) bash command.
+ * 1. Drop heredoc BODIES (keep the opener line, e.g. `cat > f <<EOF` or
+ *    `python3 - <<PY`): the body is prose/script content that bloats the brief
+ *    without adding countable facts, while the opener still records what ran.
+ * 2. Drop trivial preamble lines (set -euo pipefail, cd-only, export, source,
+ *    comments) unless they are the ONLY line, so real work below them surfaces.
+ * 3. Strip `cd <path> &&` prefixes and pipe-tail formatting per line.
+ * 4. Join the remaining meaningful lines with `; ` and cap length.
+ */
+const compressBash = (raw: string): string => {
+  // Pass 1: keep heredoc opener lines, skip their bodies + terminators.
+  const rawLines = raw.split("\n");
+  const withoutHeredocBodies: string[] = [];
+  for (let i = 0; i < rawLines.length; i++) {
+    const line = rawLines[i];
+    withoutHeredocBodies.push(line);
+    const hd = line.match(HEREDOC_OPEN_RE);
+    if (!hd) continue;
+    const term = hd[1];
+    // Only treat this as a heredoc if the terminator actually appears on a later
+    // line. Otherwise the `<<` is inside a string/expression, or the body was
+    // truncated — either way leave following lines intact instead of eating them.
+    let close = -1;
+    for (let j = i + 1; j < rawLines.length; j++) {
+      if (rawLines[j].trim() === term) { close = j; break; }
+    }
+    if (close === -1) continue;
+    // File-writer heredocs (`cat > f <<EOF`) name their target → keep opener only.
+    // Every other heredoc has a content-free opener → grab the first meaningful
+    // body line as a preview (`python3 - <<PY`, `ssh host <<CMD`, `sqlite3 <<SQL`).
+    const wantPreview = !FILEWRITER_HEREDOC_RE.test(line);
+    let preview = "";
+    for (let j = i + 1; wantPreview && !preview && j < close; j++) {
+      const t = rawLines[j].trim();
+      if (t && !BODY_NOISE_RE.test(t)) preview = t;
+    }
+    if (preview) {
+      const clipped = preview.length > HEREDOC_BODY_CAP ? preview.slice(0, HEREDOC_BODY_CAP - 1) + "\u2026" : preview;
+      withoutHeredocBodies[withoutHeredocBodies.length - 1] = `${line.trim()} ${clipped}`;
+    }
+    i = close; // for-loop's i++ then skips past the terminator line
+  }
+
+  const lines = withoutHeredocBodies.map(l => l.trim()).filter(Boolean);
+  if (lines.length === 0) return raw.trim();
+
+  const meaningful = lines
+    .filter(l => !TRIVIAL_LINE_RE.test(l))
+    .map(l => stripPipeTail(stripCdPrefix(l)))
+    .filter(Boolean);
+  // If everything was trivial (e.g. a bare `set -e` or `ls`), fall back to the
+  // first line so we never emit an empty marker.
+  const chosen = meaningful.length ? meaningful : [stripPipeTail(stripCdPrefix(lines[0]))].filter(Boolean);
+
+  const cmd = chosen.join("; ");
   if (cmd.length > BASH_CAP) {
     return cmd.slice(0, BASH_CAP - 3) + "...";
   }

--- a/src/core/brief.ts
+++ b/src/core/brief.ts
@@ -84,6 +84,7 @@ const significantWordSpans = (flat: string): { start: number; end: number }[] =>
 
 const truncateTokensHeadTail = (text: string, headLimit: number, tailLimit: number): string => {
   const flat = normalizeForTokenBudget(text);
+  if (headLimit <= 0 || tailLimit <= 0) return flat;
   const words = significantWordSpans(flat);
   if (words.length <= headLimit + tailLimit) return flat;
   const head = flat.slice(0, words[headLimit - 1].end).trimEnd();

--- a/src/core/brief.ts
+++ b/src/core/brief.ts
@@ -46,8 +46,15 @@ const STOP_WORDS = new Set([
   "if", "then", "than", "when", "where", "how", "just", "also",
 ]);
 
+const normalizeForTokenBudget = (text: string): string =>
+  text
+    .replace(/\r\n?/g, "\n")
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
 const truncateTokens = (text: string, limit: number): string => {
-  const flat = text.replace(/\s+/g, " ").trim();
+  const flat = normalizeForTokenBudget(text);
   let count = 0;
   let lastEnd = 0;
   for (const seg of segmenter.segment(flat)) {
@@ -76,12 +83,12 @@ const significantWordSpans = (flat: string): { start: number; end: number }[] =>
 
 
 const truncateTokensHeadTail = (text: string, headLimit: number, tailLimit: number): string => {
-  const flat = text.replace(/\s+/g, " ").trim();
+  const flat = normalizeForTokenBudget(text);
   const words = significantWordSpans(flat);
   if (words.length <= headLimit + tailLimit) return flat;
   const head = flat.slice(0, words[headLimit - 1].end).trimEnd();
   const tail = flat.slice(words[words.length - tailLimit].start).trimStart();
-  return `${head}...(middle truncated)...${tail}`;
+  return `${head}\n...(middle truncated)...\n${tail}`;
 };
 
 const nextRenderableBlock = (blocks: NormalizedBlock[], index: number): NormalizedBlock | undefined => {
@@ -169,6 +176,14 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
     lastHeader = header;
   };
 
+  const pushText = (header: string, text: string, ref = "") => {
+    const lines = text.split("\n");
+    if (ref && lines.length > 0) {
+      lines[lines.length - 1] = `${lines[lines.length - 1]}${ref}`;
+    }
+    for (const line of lines) push(header, line);
+  };
+
   for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
     const b = blocks[blockIndex];
     switch (b.kind) {
@@ -177,7 +192,7 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
         const text = truncateTokens(collapseSkillText(b.text), TRUNCATE_USER);
         if (text) {
           const ref = b.sourceIndex != null ? ` (#${b.sourceIndex})` : "";
-          push("[user]", text + ref);
+          pushText("[user]", text, ref);
         }
         lastHeader = "[user]";
         break;
@@ -204,7 +219,7 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
           : truncateTokensHeadTail(raw, ASSISTANT_HEAD_WORDS, ASSISTANT_TAIL_WORDS);
         if (text) {
           const ref = b.sourceIndex != null ? ` (#${b.sourceIndex})` : "";
-          push("[assistant]", text + ref);
+          pushText("[assistant]", text, ref);
         }
         break;
       }

--- a/src/core/brief.ts
+++ b/src/core/brief.ts
@@ -116,7 +116,7 @@ const TRIVIAL_LINE_RE = /^(?:set\s+[-+]|cd\s+\S+$|export\s+\w+=|(?:source|\.)\s+
 // A real heredoc opener: `<<` at a command boundary — not preceded by a word
 // char or `)`, so shift ops (`8 << 20`, `Rd<<8`) are not misread — with an
 // identifier terminator starting [A-Za-z_], so numeric `<< 10` is rejected too.
-const HEREDOC_OPEN_RE = /(?<![\w)])<<-?\s*["']?([A-Za-z_]\w*)["']?/;
+export const HEREDOC_OPEN_RE = /(?<![\w)])<<-?\s*["']?([A-Za-z_]\w*)["']?/;
 // File-writer heredocs (`cat > f <<EOF`, tee, dd) already name their target, so
 // the opener alone is informative → body-only. EVERY other heredoc has a
 // content-free opener (interpreters python3/node, remote shells `ssh host <<CMD`,
@@ -127,6 +127,22 @@ const FILEWRITER_HEREDOC_RE = /(?:^|[|&;]\s*)(?:cat|tee|dd)\b/;
 const HEREDOC_BODY_CAP = 80;
 // Body lines that are pure boilerplate and make a poor preview.
 const BODY_NOISE_RE = /^(?:import\s|from\s+\S+\s+import|require\(|const\s+\w+\s*=\s*require|#|\/\/|"""|'''|"use strict"|use\s+strict|<\?php)/;
+
+/**
+ * If `lines[i]` opens a heredoc whose terminator actually appears on a later
+ * line, return that terminator's line index; otherwise -1. Callers use -1 to
+ * leave following lines intact instead of treating a stray `<<` (a shift op, a
+ * quoted string, or a truncated body) as a heredoc and skipping real commands.
+ */
+export const heredocCloseIndex = (lines: string[], i: number): number => {
+  const hd = lines[i].match(HEREDOC_OPEN_RE);
+  if (!hd) return -1;
+  const term = hd[1];
+  for (let j = i + 1; j < lines.length; j++) {
+    if (lines[j].trim() === term) return j;
+  }
+  return -1;
+};
 
 const stripCdPrefix = (line: string): string => line.replace(/^cd\s+\S+\s*&&\s*/, "").trim();
 const stripPipeTail = (line: string): string => {
@@ -156,16 +172,9 @@ const compressBash = (raw: string): string => {
   for (let i = 0; i < rawLines.length; i++) {
     const line = rawLines[i];
     withoutHeredocBodies.push(line);
-    const hd = line.match(HEREDOC_OPEN_RE);
-    if (!hd) continue;
-    const term = hd[1];
-    // Only treat this as a heredoc if the terminator actually appears on a later
-    // line. Otherwise the `<<` is inside a string/expression, or the body was
-    // truncated — either way leave following lines intact instead of eating them.
-    let close = -1;
-    for (let j = i + 1; j < rawLines.length; j++) {
-      if (rawLines[j].trim() === term) { close = j; break; }
-    }
+    // Only treat this as a heredoc when its terminator appears downstream; a
+    // stray `<<` (string/expression or truncated body) leaves later lines intact.
+    const close = heredocCloseIndex(rawLines, i);
     if (close === -1) continue;
     // File-writer heredocs (`cat > f <<EOF`) name their target → keep opener only.
     // Every other heredoc has a content-free opener → grab the first meaningful

--- a/src/core/brief.ts
+++ b/src/core/brief.ts
@@ -63,7 +63,7 @@ const truncateTokens = (text: string, limit: number): string => {
 
 // ── bash command compression ──
 
-const BASH_CAP = 120;
+const BASH_CAP = 240;
 const PIPE_TAIL_RE = /\s*\|\s*(?:head|tail|sort|wc|column|tr|cut|awk|uniq|python3|node|bun)(?:\s[^|]*)?$/;
 
 /** Semantic compression: strip cd prefix, pipe tail formatting, cap length */

--- a/src/core/build-sections.ts
+++ b/src/core/build-sections.ts
@@ -9,6 +9,7 @@ import { buildBriefSections, stringifyBrief } from "./brief";
 
 export interface BuildSectionsInput {
   blocks: NormalizedBlock[];
+  briefBlocks?: NormalizedBlock[];
 }
 
 const BLOCKER_RE =
@@ -56,7 +57,7 @@ const formatFileActivity = (blocks: NormalizedBlock[]): string[] => {
 
 export const buildSections = (input: BuildSectionsInput): SectionData => {
   const { blocks } = input;
-  const briefSections = buildBriefSections(blocks);
+  const briefSections = buildBriefSections(input.briefBlocks ?? blocks);
   const sessionGoal = extractGoals(blocks);
   const userPreferences = dedupPreferencesAgainstGoals(
     extractPreferences(blocks),

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -6,7 +6,7 @@ const section = (title: string, items: string[]): string => {
   return `[${title}]\n${body}`;
 };
 
-const BRIEF_MAX_LINES = 120;
+export const BRIEF_MAX_LINES = 120;
 const TUI_SAFE_LINE_CHARS = 120;
 
 const wrapLine = (line: string, maxChars: number): string[] => {
@@ -50,7 +50,12 @@ export const RECALL_NOTE =
   "Use `vcc_recall` to search for prior work, decisions, and context from before this summary. " +
   "Do not redo work already completed.";
 
-export const formatSummary = (data: SectionData): string => {
+export interface FormatSummaryOptions {
+  capBriefTranscript?: boolean;
+}
+
+export const formatSummary = (data: SectionData, options: FormatSummaryOptions = {}): string => {
+  const capBriefTranscript = options.capBriefTranscript ?? true;
   const headerParts = [
     section("Session Goal", data.sessionGoal),
     section("Files And Changes", data.filesAndChanges),
@@ -64,7 +69,7 @@ export const formatSummary = (data: SectionData): string => {
     parts.push(headerParts.join("\n\n"));
   }
   if (data.briefTranscript) {
-    parts.push(capBrief(data.briefTranscript));
+    parts.push(capBriefTranscript ? capBrief(data.briefTranscript) : data.briefTranscript);
   }
 
   if (parts.length === 0) return "";

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -194,11 +194,15 @@ export const selectRankedBriefBlocks = (
     : blocks.map((b) => (b.kind === "tool_result" ? 0 : compileBrief([b]).length + 1));
   let usedChars = 0;
 
-  // Always keep the latest blocks to preserve local continuity. These anchor
-  // the brief and are charged against the budget but never dropped.
-  for (let i = Math.max(0, blocks.length - preserveRecentBlocks); i < blocks.length; i++) {
+  // Keep the latest blocks to preserve local continuity, iterating NEWEST first
+  // so the most recent context is guaranteed. When a char budget is active these
+  // are charged against it too and over-budget blocks are skipped -- otherwise a
+  // run of large recent blocks could blow past maxBriefChars (the old bug on very
+  // long transcripts, where preserve-recent alone exceeded the budget).
+  for (let i = blocks.length - 1; i >= Math.max(0, blocks.length - preserveRecentBlocks); i--) {
     if (blocks[i].kind === "tool_result") continue;
     if (selected.has(i)) continue;
+    if (costs && usedChars + costs[i] > maxBriefChars!) continue;
     selected.add(i);
     if (costs) usedChars += costs[i];
     const key = dedupKey(blocks[i]);

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -1,6 +1,6 @@
 import type { NormalizedBlock, FileOps } from "../types";
 import { extractPath } from "./tool-args";
-import { compileBrief } from "./brief";
+import { compileBrief, heredocCloseIndex } from "./brief";
 
 export interface BriefRankingOptions {
   /** Maximum normalized blocks used to build the brief transcript. */
@@ -58,7 +58,6 @@ const MIN_SEGMENT_CLOSING_ASSISTANT_CHARS = 120;
 // pulls them in ahead of real edits/commands when spare chars appear.
 const TRIVIAL_BASH_LINE_RE =
   /^(?:set\s+[-+]|cd(?:\s+\S+)?$|export\s+\w+=|(?:source|\.)\s+\S+|pwd$|true$|:$|#|ls(?:\s|$)|echo\b|clear$|sleep\b)/;
-const HEREDOC_OPEN_RE = /<<-?\s*["']?(\w+)["']?/;
 const TRIVIAL_BASH_PENALTY = 16;
 
 const isTrivialOnlyBash = (raw: string): boolean => {
@@ -66,12 +65,11 @@ const isTrivialOnlyBash = (raw: string): boolean => {
   const kept: string[] = [];
   for (let i = 0; i < lines.length; i++) {
     kept.push(lines[i]);
-    const hd = lines[i].match(HEREDOC_OPEN_RE);
-    if (hd) {
-      const term = hd[1];
-      i++;
-      while (i < lines.length && lines[i].trim() !== term) i++;
-    }
+    // Skip heredoc bodies (they are content, not scaffolding) using the same
+    // hardened detection as brief.ts: only skip when the terminator exists
+    // downstream, so a stray `<<` never swallows a later real command.
+    const close = heredocCloseIndex(lines, i);
+    if (close !== -1) i = close;
   }
   const meaningful = kept.map((l) => l.trim()).filter(Boolean).filter((l) => !TRIVIAL_BASH_LINE_RE.test(l));
   return meaningful.length === 0;

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -25,9 +25,18 @@ const READ_TOOL_RE = /^(read|glob|grep|ls|find|semantic_query|semantic_grep|sema
 const NOISY_COMMAND_RE = /^(?:ls|pwd|find\b|grep\b|rg\b|cat\b|sed\b|awk\b|head\b|tail\b)/;
 const TEST_COMMAND_RE = /\b(?:bun|npm|pnpm|yarn|node|pytest|cargo|go|mvn|gradle)\b[^\n]*(?:test|spec|check|lint|build|tsc)/i;
 const LIGHT_HINT_RE = /\b(?:fail(?:ed|ing)?|error|exception|crash|broken|blocker|fixed|implemented|resolved|commit|preference|prefer|always|never)\b/i;
+const GH_PR_POLL_RE = /(?:^|\s)gh\s+pr\s+(?:view|checks)\s+(\d+)\b/i;
 const MIN_SEGMENT_CLOSING_ASSISTANT_CHARS = 120;
 
 const asPathSet = (paths?: string[]): Set<string> => new Set((paths ?? []).filter(Boolean));
+
+const bashCommandFromBlock = (block: NormalizedBlock): string | undefined => {
+  if (block.kind === "bash") return block.command;
+  if (block.kind === "tool_call" && /^bash$/i.test(block.name) && typeof block.args.command === "string") {
+    return block.args.command;
+  }
+  return undefined;
+};
 
 const pathFromBlock = (block: NormalizedBlock): string | undefined => {
   if (block.kind === "tool_call") return extractPath(block.args) ?? undefined;
@@ -59,10 +68,12 @@ const scoreBlock = (
   if (block.kind === "tool_result") add(ranked, 1, "tool-result-low-value");
 
   if (block.kind === "tool_call") {
+    const command = bashCommandFromBlock(block);
     if (EDIT_TOOL_RE.test(block.name)) add(ranked, 34, "edit-tool");
-    else if (/^bash$/i.test(block.name) && typeof block.args.command === "string" && TEST_COMMAND_RE.test(block.args.command)) add(ranked, 26, "test-command");
+    else if (command && TEST_COMMAND_RE.test(command)) add(ranked, 26, "test-command");
     else if (READ_TOOL_RE.test(block.name)) add(ranked, 6, "read-tool");
     else add(ranked, 12, "tool-call");
+    if (command && GH_PR_POLL_RE.test(command)) add(ranked, -10, "gh-pr-poll");
   }
 
   if (block.kind === "bash") {
@@ -70,6 +81,7 @@ const scoreBlock = (
     if (block.exitCode != null && block.exitCode !== 0) add(ranked, 24, "nonzero-exit");
     if (TEST_COMMAND_RE.test(block.command)) add(ranked, 22, "test-command");
     if (NOISY_COMMAND_RE.test(block.command.trim())) add(ranked, -8, "exploration-command");
+    if (GH_PR_POLL_RE.test(block.command)) add(ranked, -10, "gh-pr-poll");
   }
 
   const path = pathFromBlock(block);
@@ -136,13 +148,16 @@ const boostSegmentClosingAssistants = (ranked: RankedBlock[]) => {
 };
 
 const dedupKey = (block: NormalizedBlock): string | undefined => {
+  const command = bashCommandFromBlock(block);
+  const ghPrPoll = command?.match(GH_PR_POLL_RE);
+  if (ghPrPoll) return `gh-pr-poll:${ghPrPoll[1]}`;
+  if (command) {
+    const normalized = command.replace(/\s+/g, " ").trim();
+    return normalized ? `bash:${normalized}` : undefined;
+  }
   if (block.kind === "tool_call") {
     const path = pathFromBlock(block);
     return path ? `tool:${block.name.toLowerCase()}:${path}` : undefined;
-  }
-  if (block.kind === "bash") {
-    const normalized = block.command.replace(/\s+/g, " ").trim();
-    return normalized ? `bash:${normalized}` : undefined;
   }
   return undefined;
 };
@@ -169,6 +184,7 @@ export const selectRankedBriefBlocks = (
   const seenKeys = new Set<string>();
 
   for (let i = Math.max(0, blocks.length - preserveRecentBlocks); i < blocks.length; i++) {
+    if (blocks[i].kind === "tool_result") continue;
     selected.add(i);
     const key = dedupKey(blocks[i]);
     if (key) seenKeys.add(key);
@@ -177,6 +193,7 @@ export const selectRankedBriefBlocks = (
   const ordered = [...ranked].sort((a, b) => b.score - a.score || b.index - a.index);
   for (const item of ordered) {
     if (selected.size >= maxBlocks) break;
+    if (item.block.kind === "tool_result") continue;
     const key = dedupKey(item.block);
     if (key && seenKeys.has(key)) continue;
     selected.add(item.index);

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -25,6 +25,7 @@ const READ_TOOL_RE = /^(read|glob|grep|ls|find|semantic_query|semantic_grep|sema
 const NOISY_COMMAND_RE = /^(?:ls|pwd|find\b|grep\b|rg\b|cat\b|sed\b|awk\b|head\b|tail\b)/;
 const TEST_COMMAND_RE = /\b(?:bun|npm|pnpm|yarn|node|pytest|cargo|go|mvn|gradle)\b[^\n]*(?:test|spec|check|lint|build|tsc)/i;
 const LIGHT_HINT_RE = /\b(?:fail(?:ed|ing)?|error|exception|crash|broken|blocker|fixed|implemented|resolved|commit|preference|prefer|always|never)\b/i;
+const MIN_SEGMENT_CLOSING_ASSISTANT_CHARS = 120;
 
 const asPathSet = (paths?: string[]): Set<string> => new Set((paths ?? []).filter(Boolean));
 
@@ -115,6 +116,25 @@ const boostAdjacency = (ranked: RankedBlock[]) => {
   }
 };
 
+const nextNonToolResult = (ranked: RankedBlock[], index: number): NormalizedBlock | undefined => {
+  for (let i = index + 1; i < ranked.length; i++) {
+    if (ranked[i].block.kind !== "tool_result") return ranked[i].block;
+  }
+  return undefined;
+};
+
+const boostSegmentClosingAssistants = (ranked: RankedBlock[]) => {
+  for (let i = 0; i < ranked.length; i++) {
+    const current = ranked[i];
+    if (current.block.kind !== "assistant") continue;
+    if (current.block.text.trim().length < MIN_SEGMENT_CLOSING_ASSISTANT_CHARS) continue;
+    const next = nextNonToolResult(ranked, i);
+    if (!next || next.kind === "user") {
+      add(current, 14, "segment-closing-assistant");
+    }
+  }
+};
+
 const dedupKey = (block: NormalizedBlock): string | undefined => {
   if (block.kind === "tool_call") {
     const path = pathFromBlock(block);
@@ -132,6 +152,7 @@ export const rankBriefBlocks = (blocks: NormalizedBlock[], options: BriefRanking
   const readFiles = asPathSet(options.fileOps?.readFiles);
   const ranked = blocks.map((block, index) => scoreBlock(block, index, blocks.length, modifiedFiles, readFiles));
   boostAdjacency(ranked);
+  boostSegmentClosingAssistants(ranked);
   return ranked;
 };
 

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -1,0 +1,166 @@
+import type { NormalizedBlock, FileOps } from "../types";
+import { extractPath } from "./tool-args";
+
+export interface BriefRankingOptions {
+  /** Maximum normalized blocks used to build the brief transcript. */
+  maxBlocks?: number;
+  /** Always keep this many latest blocks to preserve local continuity. */
+  preserveRecentBlocks?: number;
+  /** Hook-provided file activity, used as structural signal instead of prose guessing. */
+  fileOps?: FileOps;
+}
+
+export interface RankedBlock {
+  block: NormalizedBlock;
+  index: number;
+  score: number;
+  reasons: string[];
+}
+
+const DEFAULT_MAX_BLOCKS = 80;
+const DEFAULT_RECENT_BLOCKS = 16;
+
+const EDIT_TOOL_RE = /^(edit|write|multiedit|quick_edit|target_edit|apply_patch)$/i;
+const READ_TOOL_RE = /^(read|glob|grep|ls|find|semantic_query|semantic_grep|semantic_show)$/i;
+const NOISY_COMMAND_RE = /^(?:ls|pwd|find\b|grep\b|rg\b|cat\b|sed\b|awk\b|head\b|tail\b)/;
+const TEST_COMMAND_RE = /\b(?:bun|npm|pnpm|yarn|node|pytest|cargo|go|mvn|gradle)\b[^\n]*(?:test|spec|check|lint|build|tsc)/i;
+const LIGHT_HINT_RE = /\b(?:fail(?:ed|ing)?|error|exception|crash|broken|blocker|fixed|implemented|resolved|commit|preference|prefer|always|never)\b/i;
+
+const asPathSet = (paths?: string[]): Set<string> => new Set((paths ?? []).filter(Boolean));
+
+const pathFromBlock = (block: NormalizedBlock): string | undefined => {
+  if (block.kind === "tool_call") return extractPath(block.args) ?? undefined;
+  if (block.kind === "bash") {
+    const match = block.command.match(/(?:^|\s)([\w./-]+\.[\w-]+)(?:\s|$)/);
+    return match?.[1];
+  }
+  return undefined;
+};
+
+const add = (ranked: RankedBlock, points: number, reason: string) => {
+  ranked.score += points;
+  ranked.reasons.push(reason);
+};
+
+const scoreBlock = (
+  block: NormalizedBlock,
+  index: number,
+  total: number,
+  modifiedFiles: Set<string>,
+  readFiles: Set<string>,
+): RankedBlock => {
+  const ranked: RankedBlock = { block, index, score: 0, reasons: [] };
+  const recency = total <= 1 ? 0 : Math.round((index / (total - 1)) * 12);
+  add(ranked, recency, "recency");
+
+  if (block.kind === "user") add(ranked, 18, "user-turn");
+  if (block.kind === "assistant") add(ranked, 10, "assistant-context");
+  if (block.kind === "tool_result") add(ranked, 1, "tool-result-low-value");
+
+  if (block.kind === "tool_call") {
+    if (EDIT_TOOL_RE.test(block.name)) add(ranked, 34, "edit-tool");
+    else if (/^bash$/i.test(block.name) && typeof block.args.command === "string" && TEST_COMMAND_RE.test(block.args.command)) add(ranked, 26, "test-command");
+    else if (READ_TOOL_RE.test(block.name)) add(ranked, 6, "read-tool");
+    else add(ranked, 12, "tool-call");
+  }
+
+  if (block.kind === "bash") {
+    add(ranked, 8, "bash");
+    if (block.exitCode != null && block.exitCode !== 0) add(ranked, 24, "nonzero-exit");
+    if (TEST_COMMAND_RE.test(block.command)) add(ranked, 22, "test-command");
+    if (NOISY_COMMAND_RE.test(block.command.trim())) add(ranked, -8, "exploration-command");
+  }
+
+  const path = pathFromBlock(block);
+  if (path) {
+    if (modifiedFiles.has(path)) add(ranked, 18, "hook-modified-file");
+    if (readFiles.has(path)) add(ranked, 6, "hook-read-file");
+  }
+
+  const text = block.kind === "user" || block.kind === "assistant" || block.kind === "tool_result"
+    ? block.text
+    : block.kind === "bash"
+      ? block.command
+      : JSON.stringify(block.args ?? {});
+  if (LIGHT_HINT_RE.test(text)) add(ranked, 5, "light-lexical-hint");
+
+  if (block.kind === "tool_result" && block.text.length > 1000) add(ranked, -8, "long-tool-result");
+  return ranked;
+};
+
+const boostAdjacency = (ranked: RankedBlock[]) => {
+  const important = ranked
+    .filter((r) => r.score >= 34 || r.reasons.includes("edit-tool") || r.reasons.includes("test-command") || r.reasons.includes("nonzero-exit"))
+    .map((r) => r.index);
+
+  for (const idx of important) {
+    for (let i = idx - 1; i >= Math.max(0, idx - 8); i--) {
+      if (ranked[i].block.kind === "user") {
+        add(ranked[i], 10, "near-important-event");
+        break;
+      }
+    }
+    for (let i = idx - 1; i >= Math.max(0, idx - 4); i--) {
+      if (ranked[i].block.kind === "assistant") {
+        add(ranked[i], 7, "near-important-event");
+        break;
+      }
+    }
+    for (let i = idx + 1; i <= Math.min(ranked.length - 1, idx + 4); i++) {
+      if (ranked[i].block.kind === "assistant" || ranked[i].block.kind === "bash") {
+        add(ranked[i], 5, "after-important-event");
+        break;
+      }
+    }
+  }
+};
+
+const dedupKey = (block: NormalizedBlock): string | undefined => {
+  if (block.kind === "tool_call") {
+    const path = pathFromBlock(block);
+    return path ? `tool:${block.name.toLowerCase()}:${path}` : undefined;
+  }
+  if (block.kind === "bash") {
+    const normalized = block.command.replace(/\s+/g, " ").trim();
+    return normalized ? `bash:${normalized}` : undefined;
+  }
+  return undefined;
+};
+
+export const rankBriefBlocks = (blocks: NormalizedBlock[], options: BriefRankingOptions = {}): RankedBlock[] => {
+  const modifiedFiles = asPathSet(options.fileOps?.modifiedFiles);
+  const readFiles = asPathSet(options.fileOps?.readFiles);
+  const ranked = blocks.map((block, index) => scoreBlock(block, index, blocks.length, modifiedFiles, readFiles));
+  boostAdjacency(ranked);
+  return ranked;
+};
+
+export const selectRankedBriefBlocks = (
+  blocks: NormalizedBlock[],
+  options: BriefRankingOptions = {},
+): NormalizedBlock[] => {
+  const maxBlocks = options.maxBlocks ?? DEFAULT_MAX_BLOCKS;
+  if (blocks.length <= maxBlocks) return blocks;
+
+  const preserveRecentBlocks = Math.min(options.preserveRecentBlocks ?? DEFAULT_RECENT_BLOCKS, maxBlocks);
+  const ranked = rankBriefBlocks(blocks, options);
+  const selected = new Set<number>();
+  const seenKeys = new Set<string>();
+
+  for (let i = Math.max(0, blocks.length - preserveRecentBlocks); i < blocks.length; i++) {
+    selected.add(i);
+    const key = dedupKey(blocks[i]);
+    if (key) seenKeys.add(key);
+  }
+
+  const ordered = [...ranked].sort((a, b) => b.score - a.score || b.index - a.index);
+  for (const item of ordered) {
+    if (selected.size >= maxBlocks) break;
+    const key = dedupKey(item.block);
+    if (key && seenKeys.has(key)) continue;
+    selected.add(item.index);
+    if (key) seenKeys.add(key);
+  }
+
+  return [...selected].sort((a, b) => a - b).map((i) => blocks[i]);
+};

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -15,8 +15,21 @@ export interface BriefRankingOptions {
    * until the budget is reached, and lower-value blocks are skipped rather
    * than truncating the tail. maxBlocks still applies as a safety upper bound.
    * Callers derive this from a token budget via charsPerToken.
+   * When maxBriefCharsCeiling + briefCharsPerBlock are also set, this acts as
+   * the FLOOR of a size-relative budget (see below).
    */
   maxBriefChars?: number;
+  /**
+   * Optional upper bound for a size-relative char budget. When set together
+   * with maxBriefChars (floor) and briefCharsPerBlock (slope), the effective
+   * budget becomes clamp(briefCharsPerBlock * blockCount, maxBriefChars,
+   * maxBriefCharsCeiling): larger transcripts (which carry more high-value
+   * long-tail -- edits, commands, tests) get more brief budget, while small
+   * sessions stay at the floor and this hard ceiling prevents unbounded growth.
+   */
+  maxBriefCharsCeiling?: number;
+  /** Per-block slope (chars) for the size-relative budget. Requires the ceiling. */
+  briefCharsPerBlock?: number;
 }
 
 export interface RankedBlock {
@@ -179,7 +192,19 @@ export const selectRankedBriefBlocks = (
   options: BriefRankingOptions = {},
 ): NormalizedBlock[] => {
   const maxBlocks = options.maxBlocks ?? DEFAULT_MAX_BLOCKS;
-  const maxBriefChars = options.maxBriefChars;
+  // Size-relative budget: when a ceiling + slope are provided, the effective
+  // char budget scales with transcript length (block count) between the floor
+  // (maxBriefChars) and the ceiling. Larger transcripts carry more high-value
+  // long-tail, so they earn more brief budget; small sessions stay at the floor.
+  const maxBriefChars =
+    options.maxBriefChars != null && options.maxBriefCharsCeiling != null && options.briefCharsPerBlock != null
+      ? Math.round(
+          Math.min(
+            options.maxBriefCharsCeiling,
+            Math.max(options.maxBriefChars, options.briefCharsPerBlock * blocks.length),
+          ),
+        )
+      : options.maxBriefChars;
   // Fast path: nothing to trim by count and no char budget to enforce.
   if (blocks.length <= maxBlocks && maxBriefChars == null) return blocks;
 

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -52,6 +52,31 @@ const WORKFLOW_COMMAND_RE =
   /(?:^|\s)(?:gh\s+(?:pr|issue)\s+[a-z-]+|git\s+(?:commit|push|merge|rebase|revert|cherry-pick|tag|reset|checkout|branch)\b)/i;
 const MIN_SEGMENT_CLOSING_ASSISTANT_CHARS = 120;
 
+// A bash block whose every meaningful line is pure scaffolding (set -e, cd,
+// export, ls, echo, sleep, pwd, comments, heredoc bodies) carries no durable
+// fact. Such blocks get a score penalty so the size-relative budget never
+// pulls them in ahead of real edits/commands when spare chars appear.
+const TRIVIAL_BASH_LINE_RE =
+  /^(?:set\s+[-+]|cd(?:\s+\S+)?$|export\s+\w+=|(?:source|\.)\s+\S+|pwd$|true$|:$|#|ls(?:\s|$)|echo\b|clear$|sleep\b)/;
+const HEREDOC_OPEN_RE = /<<-?\s*["']?(\w+)["']?/;
+const TRIVIAL_BASH_PENALTY = 16;
+
+const isTrivialOnlyBash = (raw: string): boolean => {
+  const lines = raw.split("\n");
+  const kept: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    kept.push(lines[i]);
+    const hd = lines[i].match(HEREDOC_OPEN_RE);
+    if (hd) {
+      const term = hd[1];
+      i++;
+      while (i < lines.length && lines[i].trim() !== term) i++;
+    }
+  }
+  const meaningful = kept.map((l) => l.trim()).filter(Boolean).filter((l) => !TRIVIAL_BASH_LINE_RE.test(l));
+  return meaningful.length === 0;
+};
+
 const asPathSet = (paths?: string[]): Set<string> => new Set((paths ?? []).filter(Boolean));
 
 const bashCommandFromBlock = (block: NormalizedBlock): string | undefined => {
@@ -98,6 +123,7 @@ const scoreBlock = (
     else if (READ_TOOL_RE.test(block.name)) add(ranked, 6, "read-tool");
     else add(ranked, 12, "tool-call");
     if (command && WORKFLOW_COMMAND_RE.test(command)) add(ranked, 14, "workflow-command");
+    if (command && isTrivialOnlyBash(command)) add(ranked, -TRIVIAL_BASH_PENALTY, "trivial-bash");
   }
 
   if (block.kind === "bash") {
@@ -105,6 +131,11 @@ const scoreBlock = (
     if (block.exitCode != null && block.exitCode !== 0) add(ranked, 24, "nonzero-exit");
     if (TEST_COMMAND_RE.test(block.command)) add(ranked, 22, "test-command");
     if (WORKFLOW_COMMAND_RE.test(block.command)) add(ranked, 14, "workflow-command");
+    // Penalize scaffolding-only commands, but not ones that failed (a failed
+    // `ls`/`cd` still records a real state fact via nonzero-exit).
+    if (isTrivialOnlyBash(block.command) && !(block.exitCode != null && block.exitCode !== 0)) {
+      add(ranked, -TRIVIAL_BASH_PENALTY, "trivial-bash");
+    }
   }
 
   const path = pathFromBlock(block);

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -1,5 +1,6 @@
 import type { NormalizedBlock, FileOps } from "../types";
 import { extractPath } from "./tool-args";
+import { compileBrief } from "./brief";
 
 export interface BriefRankingOptions {
   /** Maximum normalized blocks used to build the brief transcript. */
@@ -8,6 +9,14 @@ export interface BriefRankingOptions {
   preserveRecentBlocks?: number;
   /** Hook-provided file activity, used as structural signal instead of prose guessing. */
   fileOps?: FileOps;
+  /**
+   * Optional size budget (in characters of rendered brief) for the selected
+   * blocks. When set, this is the PRIMARY limit: blocks are added by score
+   * until the budget is reached, and lower-value blocks are skipped rather
+   * than truncating the tail. maxBlocks still applies as a safety upper bound.
+   * Callers derive this from a token budget via charsPerToken.
+   */
+  maxBriefChars?: number;
 }
 
 export interface RankedBlock {
@@ -22,10 +31,12 @@ const DEFAULT_RECENT_BLOCKS = 16;
 
 const EDIT_TOOL_RE = /^(edit|write|multiedit|quick_edit|target_edit|apply_patch)$/i;
 const READ_TOOL_RE = /^(read|glob|grep|ls|find|semantic_query|semantic_grep|semantic_show)$/i;
-const NOISY_COMMAND_RE = /^(?:ls|pwd|find\b|grep\b|rg\b|cat\b|sed\b|awk\b|head\b|tail\b)/;
 const TEST_COMMAND_RE = /\b(?:bun|npm|pnpm|yarn|node|pytest|cargo|go|mvn|gradle)\b[^\n]*(?:test|spec|check|lint|build|tsc)/i;
-const LIGHT_HINT_RE = /\b(?:fail(?:ed|ing)?|error|exception|crash|broken|blocker|fixed|implemented|resolved|commit|preference|prefer|always|never)\b/i;
 const GH_PR_POLL_RE = /(?:^|\s)gh\s+pr\s+(?:view|checks)\s+(\d+)\b/i;
+// Durable workflow facts: which PR/issue was acted on, and git state changes.
+// Structural (command shape), not prose — same spirit as TEST_COMMAND_RE.
+const WORKFLOW_COMMAND_RE =
+  /(?:^|\s)(?:gh\s+(?:pr|issue)\s+[a-z-]+|git\s+(?:commit|push|merge|rebase|revert|cherry-pick|tag|reset|checkout|branch)\b)/i;
 const MIN_SEGMENT_CLOSING_ASSISTANT_CHARS = 120;
 
 const asPathSet = (paths?: string[]): Set<string> => new Set((paths ?? []).filter(Boolean));
@@ -73,15 +84,14 @@ const scoreBlock = (
     else if (command && TEST_COMMAND_RE.test(command)) add(ranked, 26, "test-command");
     else if (READ_TOOL_RE.test(block.name)) add(ranked, 6, "read-tool");
     else add(ranked, 12, "tool-call");
-    if (command && GH_PR_POLL_RE.test(command)) add(ranked, -10, "gh-pr-poll");
+    if (command && WORKFLOW_COMMAND_RE.test(command)) add(ranked, 14, "workflow-command");
   }
 
   if (block.kind === "bash") {
     add(ranked, 8, "bash");
     if (block.exitCode != null && block.exitCode !== 0) add(ranked, 24, "nonzero-exit");
     if (TEST_COMMAND_RE.test(block.command)) add(ranked, 22, "test-command");
-    if (NOISY_COMMAND_RE.test(block.command.trim())) add(ranked, -8, "exploration-command");
-    if (GH_PR_POLL_RE.test(block.command)) add(ranked, -10, "gh-pr-poll");
+    if (WORKFLOW_COMMAND_RE.test(block.command)) add(ranked, 14, "workflow-command");
   }
 
   const path = pathFromBlock(block);
@@ -89,13 +99,6 @@ const scoreBlock = (
     if (modifiedFiles.has(path)) add(ranked, 18, "hook-modified-file");
     if (readFiles.has(path)) add(ranked, 6, "hook-read-file");
   }
-
-  const text = block.kind === "user" || block.kind === "assistant" || block.kind === "tool_result"
-    ? block.text
-    : block.kind === "bash"
-      ? block.command
-      : JSON.stringify(block.args ?? {});
-  if (LIGHT_HINT_RE.test(text)) add(ranked, 5, "light-lexical-hint");
 
   if (block.kind === "tool_result" && block.text.length > 1000) add(ranked, -8, "long-tool-result");
   return ranked;
@@ -176,16 +179,28 @@ export const selectRankedBriefBlocks = (
   options: BriefRankingOptions = {},
 ): NormalizedBlock[] => {
   const maxBlocks = options.maxBlocks ?? DEFAULT_MAX_BLOCKS;
-  if (blocks.length <= maxBlocks) return blocks;
+  const maxBriefChars = options.maxBriefChars;
+  // Fast path: nothing to trim by count and no char budget to enforce.
+  if (blocks.length <= maxBlocks && maxBriefChars == null) return blocks;
 
   const preserveRecentBlocks = Math.min(options.preserveRecentBlocks ?? DEFAULT_RECENT_BLOCKS, maxBlocks);
   const ranked = rankBriefBlocks(blocks, options);
   const selected = new Set<number>();
   const seenKeys = new Set<string>();
 
+  // Per-block rendered size, only computed when a char budget is active.
+  const costs = maxBriefChars == null
+    ? null
+    : blocks.map((b) => (b.kind === "tool_result" ? 0 : compileBrief([b]).length + 1));
+  let usedChars = 0;
+
+  // Always keep the latest blocks to preserve local continuity. These anchor
+  // the brief and are charged against the budget but never dropped.
   for (let i = Math.max(0, blocks.length - preserveRecentBlocks); i < blocks.length; i++) {
     if (blocks[i].kind === "tool_result") continue;
+    if (selected.has(i)) continue;
     selected.add(i);
+    if (costs) usedChars += costs[i];
     const key = dedupKey(blocks[i]);
     if (key) seenKeys.add(key);
   }
@@ -193,9 +208,15 @@ export const selectRankedBriefBlocks = (
   const ordered = [...ranked].sort((a, b) => b.score - a.score || b.index - a.index);
   for (const item of ordered) {
     if (selected.size >= maxBlocks) break;
+    if (selected.has(item.index)) continue;
     if (item.block.kind === "tool_result") continue;
     const key = dedupKey(item.block);
     if (key && seenKeys.has(key)) continue;
+    if (costs) {
+      // Skip (not break) so smaller high-value blocks can still fit the budget.
+      if (usedChars + costs[item.index] > maxBriefChars!) continue;
+      usedChars += costs[item.index];
+    }
     selected.add(item.index);
     if (key) seenKeys.add(key);
   }

--- a/src/core/report.ts
+++ b/src/core/report.ts
@@ -5,6 +5,7 @@ import { normalize } from "./normalize";
 import { renderMessage } from "./render-entries";
 import { searchEntries } from "./search-entries";
 import { type CompileInput, compile } from "./summarize";
+import { estimateTokensFromChars } from "./token-estimate";
 
 const SECTION_HEADERS = ["Session Goal", "Files And Changes", "Commits", "Outstanding Context"];
 
@@ -59,9 +60,6 @@ export interface CompactReport {
     probes: RecallProbe[];
   };
 }
-
-const estimateTokensFromChars = (chars: number): number =>
-  Math.ceil(chars / 4);
 
 const countRoles = (messages: Message[]): RoleCounts => {
   const counts: RoleCounts = { user: 0, assistant: 0, toolResult: 0 };

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -27,6 +27,13 @@ export interface PiVccSettings {
    * is always respected and never adjusted.
    */
   smartKeepTail: boolean;
+  /**
+   * When true (default), pi-vcc asks the agent to continue after an automatic
+   * threshold compaction. This avoids a UX cliff where the agent finishes a
+   * response, immediately compacts, and then stops instead of continuing the task.
+   * Overflow retry is still owned by pi-core via willRetry.
+   */
+  continueAfterThresholdCompact: boolean;
   /** Write debug snapshot to /tmp/pi-vcc-debug.json on each compaction. */
   debug: boolean;
 }
@@ -34,6 +41,7 @@ export interface PiVccSettings {
 export const DEFAULT_SETTINGS: PiVccSettings = {
   overrideDefaultCompaction: false,
   smartKeepTail: true,
+  continueAfterThresholdCompact: true,
   debug: false,
 };
 

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -28,9 +28,10 @@ export interface PiVccSettings {
    */
   smartKeepTail: boolean;
   /**
-   * When true (default), pi-vcc asks the agent to continue after an automatic
-   * threshold compaction. This avoids a UX cliff where the agent finishes a
-   * response, immediately compacts, and then stops instead of continuing the task.
+   * When true (default), pi-vcc asks the agent to continue after a successful
+   * automatic compaction (threshold, or overflow after the assistant already
+   * finished with stop). This avoids a UX cliff where the agent finishes a response,
+   * immediately compacts, and then stops instead of continuing the task.
    * Overflow retry is still owned by pi-core via willRetry.
    */
   continueAfterThresholdCompact: boolean;

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -23,7 +23,7 @@ export interface PiVccSettings {
    * When true (default), pi-vcc boosts the default keep-tail when the current
    * keep:1 tail is small enough. Specifically: if the estimated tail for keep:1
    * is <= MIN_SMART_TAIL_TOKENS (5k), increase keep up to the largest N whose
-   * tail stays <= MAX_SMART_TAIL_TOKENS (20k). Explicit `keep:N` from the user
+   * tail stays <= MAX_SMART_TAIL_TOKENS (25k). Explicit `keep:N` from the user
    * is always respected and never adjusted.
    */
   smartKeepTail: boolean;

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -19,12 +19,21 @@ export interface PiVccSettings {
    * falls back to pi core's default LLM-based compaction.
    */
   overrideDefaultCompaction: boolean;
+  /**
+   * When true (default), pi-vcc boosts the default keep-tail when the current
+   * keep:1 tail is small enough. Specifically: if the estimated tail for keep:1
+   * is <= MIN_SMART_TAIL_TOKENS (5k), increase keep up to the largest N whose
+   * tail stays <= MAX_SMART_TAIL_TOKENS (20k). Explicit `keep:N` from the user
+   * is always respected and never adjusted.
+   */
+  smartKeepTail: boolean;
   /** Write debug snapshot to /tmp/pi-vcc-debug.json on each compaction. */
   debug: boolean;
 }
 
 export const DEFAULT_SETTINGS: PiVccSettings = {
   overrideDefaultCompaction: false,
+  smartKeepTail: true,
   debug: false,
 };
 

--- a/src/core/summarize.ts
+++ b/src/core/summarize.ts
@@ -3,12 +3,17 @@ import type { FileOps } from "../types";
 import { normalize } from "./normalize";
 import { filterNoise } from "./filter-noise";
 import { buildSections } from "./build-sections";
-import { formatSummary, capBrief, RECALL_NOTE, wrapLongLines } from "./format";
+import { formatSummary, capBrief, BRIEF_MAX_LINES, RECALL_NOTE, wrapLongLines } from "./format";
+import { selectRankedBriefBlocks, type BriefRankingOptions } from "./rank";
 
 export interface CompileInput {
   messages: Message[];
   previousSummary?: string;
   fileOps?: FileOps;
+}
+
+export interface RankedCompileInput extends CompileInput {
+  ranking?: BriefRankingOptions;
 }
 
 const HEADER_NAMES = ["Session Goal", "Files And Changes", "Commits", "Outstanding Context", "User Preferences"];
@@ -108,7 +113,30 @@ const mergeBriefTranscript = (prev: string, fresh: string): string => {
   return prev + "\n\n" + fresh;
 };
 
-const mergePrevious = (prev: string, fresh: string): string => {
+const briefLineCount = (text: string): number =>
+  text ? text.split("\n").length : 0;
+
+const capBriefToLineBudget = (text: string, maxLines: number): string => {
+  if (!text || maxLines <= 0) return "";
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) return text;
+  const omitted = lines.length - maxLines;
+  const kept = lines.slice(-maxLines);
+  const firstHeader = kept.findIndex((l) => /^\[.+\]/.test(l));
+  const clean = firstHeader > 0 ? kept.slice(firstHeader) : kept;
+  return `...(${omitted} earlier lines omitted)\n\n${clean.join("\n")}`;
+};
+
+const mergeBriefTranscriptWithFreshBudget = (prev: string, fresh: string): string => {
+  if (!prev) return fresh;
+  if (!fresh) return capBrief(prev);
+  const freshLines = briefLineCount(fresh);
+  const remainingPrevLines = Math.max(0, BRIEF_MAX_LINES - freshLines);
+  const prevTail = capBriefToLineBudget(prev, remainingPrevLines);
+  return prevTail ? `${prevTail}\n\n${fresh}` : fresh;
+};
+
+const mergePrevious = (prev: string, fresh: string, options: { preserveFreshBrief?: boolean } = {}): string => {
   // Merge header sections
   const headers = HEADER_NAMES
     .map((header) => {
@@ -121,32 +149,54 @@ const mergePrevious = (prev: string, fresh: string): string => {
   // Merge brief transcript
   const prevBrief = briefOf(prev);
   const freshBrief = briefOf(fresh);
-  const mergedBrief = mergeBriefTranscript(prevBrief, freshBrief);
+  const mergedBrief = options.preserveFreshBrief
+    ? mergeBriefTranscriptWithFreshBudget(prevBrief, freshBrief)
+    : mergeBriefTranscript(prevBrief, freshBrief);
 
   const parts: string[] = [];
   if (headers.length > 0) {
     parts.push(headers.join("\n\n"));
   }
   if (mergedBrief) {
-    parts.push(capBrief(mergedBrief));
+    parts.push(options.preserveFreshBrief ? mergedBrief : capBrief(mergedBrief));
   }
 
   return parts.join(SEPARATOR);
 };
 
-export const compile = (input: CompileInput): string => {
+interface CompileWithBriefBlocksOptions {
+  briefBlocksFor?: (blocks: ReturnType<typeof normalize>) => ReturnType<typeof normalize>;
+  capFreshBrief?: boolean;
+  preserveFreshBriefOnMerge?: boolean;
+}
+
+const compileWithBriefBlocks = (input: CompileInput, options: CompileWithBriefBlocksOptions = {}): string => {
   const blocks = filterNoise(normalize(input.messages));
-  const data = buildSections({ blocks });
-  const fresh = formatSummary(data);
+  const briefBlocks = options.briefBlocksFor?.(blocks);
+  const data = buildSections({ blocks, briefBlocks });
+  const fresh = formatSummary(data, { capBriefTranscript: options.capFreshBrief ?? true });
   // Strip any legacy RECALL_NOTE baked into prev summary (pre-fix format)
   // so merge doesn't re-stack it inside the brief.
   const prev = input.previousSummary
     ? stripRecallNote(input.previousSummary)
     : undefined;
-  const merged = prev ? mergePrevious(prev, fresh) : fresh;
+  const merged = prev ? mergePrevious(prev, fresh, { preserveFreshBrief: options.preserveFreshBriefOnMerge }) : fresh;
   if (!merged) return "";
   return wrapLongLines(merged + SEPARATOR + RECALL_NOTE);
 };
+
+export const compile = (input: CompileInput): string =>
+  compileWithBriefBlocks(input);
+
+export const compileRanked = (input: RankedCompileInput): string =>
+  compileWithBriefBlocks(input, {
+    briefBlocksFor: (blocks) => selectRankedBriefBlocks(blocks, {
+      ...input.ranking,
+      fileOps: input.ranking?.fileOps ?? input.fileOps,
+    }),
+    capFreshBrief: false,
+    preserveFreshBriefOnMerge: true,
+  });
 
 const stripRecallNote = (text: string): string => {
   // Remove trailing RECALL_NOTE (and any separators surrounding it) if present.

--- a/src/core/summarize.ts
+++ b/src/core/summarize.ts
@@ -120,10 +120,10 @@ const capBriefToLineBudget = (text: string, maxLines: number): string => {
   if (!text || maxLines <= 0) return "";
   const lines = text.split("\n");
   if (lines.length <= maxLines) return text;
-  const omitted = lines.length - maxLines;
   const kept = lines.slice(-maxLines);
   const firstHeader = kept.findIndex((l) => /^\[.+\]/.test(l));
   const clean = firstHeader > 0 ? kept.slice(firstHeader) : kept;
+  const omitted = lines.length - clean.length;
   return `...(${omitted} earlier lines omitted)\n\n${clean.join("\n")}`;
 };
 

--- a/src/core/token-estimate.ts
+++ b/src/core/token-estimate.ts
@@ -1,7 +1,46 @@
-const APPROX_CHARS_PER_TOKEN = 4;
+export const DEFAULT_CHARS_PER_TOKEN = 4;
+export const MIN_CHARS_PER_TOKEN = 2;
+export const MAX_CHARS_PER_TOKEN = 6;
 
-export const estimateTokensFromChars = (chars: number): number =>
-  Math.ceil(chars / APPROX_CHARS_PER_TOKEN);
+export type TokenEstimateMode = "heuristic" | "calibrated";
+
+export interface TokenEstimateCalibration {
+  mode: TokenEstimateMode;
+  charsPerToken: number;
+  sourceChars?: number;
+  sourceTokens?: number;
+  rawCharsPerToken?: number;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+export const calibrateCharsPerToken = (
+  sourceChars: number,
+  sourceTokens: number | undefined,
+): TokenEstimateCalibration => {
+  if (!sourceTokens || sourceTokens <= 0 || sourceChars <= 0) {
+    return { mode: "heuristic", charsPerToken: DEFAULT_CHARS_PER_TOKEN };
+  }
+
+  const rawCharsPerToken = sourceChars / sourceTokens;
+  if (!Number.isFinite(rawCharsPerToken) || rawCharsPerToken <= 0) {
+    return { mode: "heuristic", charsPerToken: DEFAULT_CHARS_PER_TOKEN };
+  }
+
+  return {
+    mode: "calibrated",
+    charsPerToken: clamp(rawCharsPerToken, MIN_CHARS_PER_TOKEN, MAX_CHARS_PER_TOKEN),
+    sourceChars,
+    sourceTokens,
+    rawCharsPerToken,
+  };
+};
+
+export const estimateTokensFromChars = (
+  chars: number,
+  charsPerToken = DEFAULT_CHARS_PER_TOKEN,
+): number => Math.ceil(chars / charsPerToken);
 
 /** Estimate char length of a single message content (string or content-parts array). */
 export const estimateMessageContentChars = (content: unknown): number => {
@@ -25,5 +64,7 @@ export const estimateMessageContentChars = (content: unknown): number => {
   return 0;
 };
 
-export const estimateMessageContentTokens = (content: unknown): number =>
-  estimateTokensFromChars(estimateMessageContentChars(content));
+export const estimateMessageContentTokens = (
+  content: unknown,
+  charsPerToken = DEFAULT_CHARS_PER_TOKEN,
+): number => estimateTokensFromChars(estimateMessageContentChars(content), charsPerToken);

--- a/src/core/token-estimate.ts
+++ b/src/core/token-estimate.ts
@@ -1,0 +1,29 @@
+const APPROX_CHARS_PER_TOKEN = 4;
+
+export const estimateTokensFromChars = (chars: number): number =>
+  Math.ceil(chars / APPROX_CHARS_PER_TOKEN);
+
+/** Estimate char length of a single message content (string or content-parts array). */
+export const estimateMessageContentChars = (content: unknown): number => {
+  if (typeof content === "string") return content.length;
+  if (Array.isArray(content)) return content.reduce((sum: number, part: any) => {
+    if (part.text) return sum + part.text.length;
+    if (part.type === "toolCall") {
+      const inputLength = typeof part.input === "string"
+        ? part.input.length
+        : JSON.stringify(part.input ?? "").length;
+      return sum + (part.name?.length ?? 0) + inputLength;
+    }
+    if (part.type === "toolResult") {
+      const contentLength = typeof part.content === "string"
+        ? part.content.length
+        : JSON.stringify(part.content ?? "").length;
+      return sum + contentLength;
+    }
+    return sum;
+  }, 0);
+  return 0;
+};
+
+export const estimateMessageContentTokens = (content: unknown): number =>
+  estimateTokensFromChars(estimateMessageContentChars(content));

--- a/src/core/token-estimate.ts
+++ b/src/core/token-estimate.ts
@@ -42,26 +42,56 @@ export const estimateTokensFromChars = (
   charsPerToken = DEFAULT_CHARS_PER_TOKEN,
 ): number => Math.ceil(chars / charsPerToken);
 
-/** Estimate char length of a single message content (string or content-parts array). */
+/**
+ * Chars attributed to one image part, mirroring pi-agent-core's own
+ * estimateTokens heuristic (4800 chars ≈ 1200 tokens at 4 chars/token).
+ */
+export const IMAGE_CONTENT_CHARS = 4800;
+
+const safeJsonStringify = (value: unknown): string => {
+  try {
+    return JSON.stringify(value ?? "") ?? "";
+  } catch {
+    return "";
+  }
+};
+
+/**
+ * Estimate the char length of a message's content (string or content-parts
+ * array). Counts every token-bearing part that pi-agent-core's harness
+ * estimateTokens counts, so the calibrated chars/token ratio is not deflated:
+ *  - text       → text.length
+ *  - thinking   → thinking.length   (opus emits large reasoning blocks)
+ *  - toolCall   → name + arguments  (Pi uses `arguments`; `input` kept for compat)
+ *  - image      → IMAGE_CONTENT_CHARS
+ *  - toolResult → nested content    (legacy part shape)
+ */
 export const estimateMessageContentChars = (content: unknown): number => {
   if (typeof content === "string") return content.length;
-  if (Array.isArray(content)) return content.reduce((sum: number, part: any) => {
-    if (part.text) return sum + part.text.length;
-    if (part.type === "toolCall") {
-      const inputLength = typeof part.input === "string"
-        ? part.input.length
-        : JSON.stringify(part.input ?? "").length;
-      return sum + (part.name?.length ?? 0) + inputLength;
+  if (!Array.isArray(content)) return 0;
+  return content.reduce((sum: number, part: any) => {
+    if (!part || typeof part !== "object") return sum;
+    switch (part.type) {
+      case "text":
+        return sum + (typeof part.text === "string" ? part.text.length : 0);
+      case "thinking":
+        return sum + (typeof part.thinking === "string" ? part.thinking.length : 0);
+      case "toolCall": {
+        const args = part.arguments ?? part.input;
+        const argLength = typeof args === "string" ? args.length : safeJsonStringify(args).length;
+        return sum + (part.name?.length ?? 0) + argLength;
+      }
+      case "toolResult": {
+        const c = part.content;
+        return sum + (typeof c === "string" ? c.length : safeJsonStringify(c).length);
+      }
+      case "image":
+        return sum + IMAGE_CONTENT_CHARS;
+      default:
+        // Unknown part: fall back to any text field so we never undercount.
+        return sum + (typeof part.text === "string" ? part.text.length : 0);
     }
-    if (part.type === "toolResult") {
-      const contentLength = typeof part.content === "string"
-        ? part.content.length
-        : JSON.stringify(part.content ?? "").length;
-      return sum + contentLength;
-    }
-    return sum;
   }, 0);
-  return 0;
 };
 
 export const estimateMessageContentTokens = (

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -18,6 +18,10 @@ export interface CompactionStats {
   keepUserTurnsExplicit: boolean;
   keepFallbackToCompactAll: boolean;
   keptTokensEst: number;
+  /** True when smart-keep boosted the default keep beyond 1. */
+  smartKeepAdjusted?: boolean;
+  /** Base keep before smart adjustment (for toast like "1→3"). */
+  smartFromKeep?: number;
   reason?: CompactionReason;
   willRetry?: boolean;
 }
@@ -38,7 +42,10 @@ export const formatCompactionStats = (stats: CompactionStats): string => {
       ? `; requested keep:${stats.requestedKeepUserTurns}, compact-all fallback`
       : "; compact-all fallback"
     : "";
-  return `pi-vcc: ${stats.summarized} source entries processed; tail kept ${stats.keptUserTurns}/${stats.totalUserTurns} user turns${fallbackNote} (${stats.kept} messages, ~${formatTokens(stats.keptTokensEst)} tok).`;
+  const smartNote = stats.smartKeepAdjusted
+    ? `; smart keep:${stats.smartFromKeep}→${stats.keptUserTurns}`
+    : "";
+  return `pi-vcc: ${stats.summarized} source entries processed; tail kept ${stats.keptUserTurns}/${stats.totalUserTurns} user turns${fallbackNote}${smartNote} (${stats.kept} messages, ~${formatTokens(stats.keptTokensEst)} tok).`;
 };
 
 const readCompactionEventContext = (event: unknown): { reason?: CompactionReason; willRetry: boolean } => {
@@ -105,6 +112,18 @@ const previewContent = (content: unknown): string => {
       .slice(0, 300);
   }
   return "";
+};
+
+/** Estimate char length of a single message content (string or content-parts array). */
+const messageContentChars = (content: unknown): number => {
+  if (typeof content === "string") return content.length;
+  if (Array.isArray(content)) return content.reduce((s: number, p: any) => {
+    if (p.text) return s + p.text.length;
+    if (p.type === "toolCall") return s + (p.name?.length ?? 0) + (typeof p.input === "string" ? p.input.length : JSON.stringify(p.input ?? "").length);
+    if (p.type === "toolResult") return s + (typeof p.content === "string" ? p.content.length : JSON.stringify(p.content ?? "").length);
+    return s;
+  }, 0);
+  return 0;
 };
 
 interface EntryWithMessage {
@@ -215,6 +234,89 @@ export function buildOwnCut(branchEntries: any[], keepUserTurns = 1): OwnCutResu
   };
 }
 
+// ── smart keep-tail: boost default keep when tail is small ──
+
+export const MIN_SMART_TAIL_TOKENS = 5_000;
+export const MAX_SMART_TAIL_TOKENS = 20_000;
+
+export interface ResolveSmartKeepOptions {
+  branchEntries: any[];
+  /** Requested keep:N; null when user did not specify (default path). */
+  requestedKeepUserTurns: number | null;
+  /** True when user typed keep:N explicitly — always respected. */
+  explicit: boolean;
+  /** Setting toggle. */
+  smartKeepTail: boolean;
+  /** Injectable thresholds for tests. */
+  minTokens?: number;
+  maxTokens?: number;
+}
+
+export interface ResolveSmartKeepResult {
+  keepUserTurns: number;
+  smartAdjusted: boolean;
+  /** Original base keep, for toast like "1→3". */
+  fromKeep: number;
+}
+
+/**
+ * Estimate tail tokens for a given keep:N.
+ * Returns null when keep would trigger compact-all (tail lost) or cancel,
+ * so the resolver can stop growing instead of selecting a value that
+ * discards the tail entirely.
+ */
+const tailTokensForKeep = (branchEntries: any[], keepUserTurns: number): number | null => {
+  const cut = buildOwnCut(branchEntries, keepUserTurns);
+  if (!cut.ok || cut.compactAll) return null;
+  const idx = branchEntries.findIndex((e: any) => e.id === cut.firstKeptEntryId);
+  if (idx < 0) return null;
+  const kept = branchEntries.slice(idx).filter((e: any) => e.type === "message");
+  const chars = kept.reduce(
+    (sum: number, e: any) => sum + messageContentChars(e.message?.content),
+    0,
+  );
+  return Math.round(chars / 4);
+};
+
+/**
+ * Resolve the effective keep:N.
+ * - Explicit keep:N from the user is always respected.
+ * - smartKeepTail=false → old behavior (default keep:1).
+ * - smartKeepTail=true → if keep:1 tail <= minTokens, grow keep to the
+ *   largest N whose tail stays <= maxTokens. Stops at compact-all boundary.
+ */
+export const resolveSmartKeepUserTurns = (opts: ResolveSmartKeepOptions): ResolveSmartKeepResult => {
+  const minTokens = opts.minTokens ?? MIN_SMART_TAIL_TOKENS;
+  const maxTokens = opts.maxTokens ?? MAX_SMART_TAIL_TOKENS;
+  const baseKeep = opts.requestedKeepUserTurns ?? 1;
+
+  if (opts.explicit || !opts.smartKeepTail) {
+    return { keepUserTurns: baseKeep, smartAdjusted: false, fromKeep: baseKeep };
+  }
+
+  const baseTokens = tailTokensForKeep(opts.branchEntries, baseKeep);
+  // base tail already above min (or unmeasurable / compact-all) → don't grow.
+  if (baseTokens == null || baseTokens > minTokens) {
+    return { keepUserTurns: baseKeep, smartAdjusted: false, fromKeep: baseKeep };
+  }
+
+  const baseCut = buildOwnCut(opts.branchEntries, baseKeep);
+  const totalUserTurns = baseCut.ok ? baseCut.totalUserTurns : 0;
+
+  let selected = baseKeep;
+  for (let k = baseKeep + 1; k <= totalUserTurns; k++) {
+    const tokens = tailTokensForKeep(opts.branchEntries, k);
+    if (tokens == null || tokens > maxTokens) break;
+    selected = k;
+  }
+
+  return {
+    keepUserTurns: selected,
+    smartAdjusted: selected !== baseKeep,
+    fromKeep: baseKeep,
+  };
+};
+
 const REASON_MESSAGES: Record<OwnCutCancelReason, string> = {
   no_live_messages: "pi-vcc: Nothing to compact (no live messages)",
   too_few_live_messages: "pi-vcc: Too few messages to compact",
@@ -232,7 +334,15 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     pendingFollowUpPrompt = null;
     if (!isPiVcc && !settings.overrideDefaultCompaction) return;
 
-    const ownCut = buildOwnCut(branchEntries as any[], keepUserTurns);
+    // Smart keep-tail: boost default keep when the tail is small.
+    // Explicit keep:N from the user is always respected (resolver no-ops).
+    const smartKeep = resolveSmartKeepUserTurns({
+      branchEntries: branchEntries as any[],
+      requestedKeepUserTurns: keepUserTurnsExplicit ? keepUserTurns : null,
+      explicit: keepUserTurnsExplicit,
+      smartKeepTail: settings.smartKeepTail,
+    });
+    const ownCut = buildOwnCut(branchEntries as any[], smartKeep.keepUserTurns);
     if (!ownCut.ok) {
       const lastComp = [...branchEntries].reverse().find((e: any) => e.type === "compaction");
       const lastCompIdx = lastComp ? (branchEntries as any[]).indexOf(lastComp) : -1;
@@ -314,17 +424,10 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     const keptEntries = keptIdx >= 0
       ? (branchEntries as any[]).slice(keptIdx).filter((e: any) => e.type === "message")
       : [];
-    const keptChars = keptEntries.reduce((sum: number, e: any) => {
-      const c = e.message?.content;
-      if (typeof c === "string") return sum + c.length;
-      if (Array.isArray(c)) return sum + c.reduce((s: number, p: any) => {
-        if (p.text) return s + p.text.length;
-        if (p.type === "toolCall") return s + (p.name?.length ?? 0) + (typeof p.input === "string" ? p.input.length : JSON.stringify(p.input ?? "").length);
-        if (p.type === "toolResult") return s + (typeof p.content === "string" ? p.content.length : JSON.stringify(p.content ?? "").length);
-        return s;
-      }, 0);
-      return sum;
-    }, 0);
+    const keptChars = keptEntries.reduce(
+      (sum: number, e: any) => sum + messageContentChars(e.message?.content),
+      0,
+    );
     lastStats = {
       summarized: agentMessages.length,
       kept: keptEntries.length,
@@ -334,6 +437,8 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       keepUserTurnsExplicit,
       keepFallbackToCompactAll: ownCut.keepFallbackToCompactAll,
       keptTokensEst: Math.round(keptChars / 4),
+      smartKeepAdjusted: smartKeep.smartAdjusted,
+      smartFromKeep: smartKeep.fromKeep,
       reason,
       willRetry,
     };

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -258,7 +258,7 @@ export function buildOwnCut(branchEntries: any[], keepUserTurns = 1): OwnCutResu
 // ── smart keep-tail: boost default keep when tail is small ──
 
 export const MIN_SMART_TAIL_TOKENS = 5_000;
-export const MAX_SMART_TAIL_TOKENS = 20_000;
+export const MAX_SMART_TAIL_TOKENS = 25_000;
 
 export interface ResolveSmartKeepOptions {
   branchEntries: any[];

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -496,10 +496,21 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     // instead of the old unranked compile() (fixed 120-line cap). The token
     // budget is converted to a char budget via the session's calibrated
     // charsPerToken so the summary targets ~RANKED_BRIEF_BUDGET_TOKENS tokens
-    // regardless of content density. Audit (research/audit, 794 sessions) at
-    // this operating point: size parity with the old cap, recall +2.4pp, and
-    // better fact density vs the unbudgeted ranked path (which bloated ~60%).
+    // regardless of content density.
+    //
+    // The budget is SIZE-RELATIVE: it scales with transcript length between a
+    // floor (RANKED_BRIEF_BUDGET_TOKENS) and a ceiling (RANKED_BRIEF_CEILING_TOKENS)
+    // at RANKED_BRIEF_CHARS_PER_BLOCK per normalized block. Small/medium sessions
+    // stay at the floor (size parity with the old cap); very large transcripts --
+    // which carry far more high-value long-tail (edits, commands, tests) than the
+    // old 120-line brief could hold -- earn more budget up to the ceiling, while
+    // the ceiling keeps growth bounded (no return of the ~60% bloat).
+    // Audit (research/audit, 794 sessions, vs shipped master 0.3.18): SMALL/MED
+    // unchanged; LARGE bucket paired recall -5.0pp -> -2.3pp (median to parity),
+    // long-tail losers 100/369 -> 67/369; fact density stays ~1.4x master.
     const RANKED_BRIEF_BUDGET_TOKENS = 1100;
+    const RANKED_BRIEF_CEILING_TOKENS = 2000;
+    const RANKED_BRIEF_TOKENS_PER_BLOCK = 15;
     const summary = compileRanked({
       messages,
       previousSummary: preparation.previousSummary,
@@ -509,6 +520,8 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       },
       ranking: {
         maxBriefChars: Math.round(RANKED_BRIEF_BUDGET_TOKENS * tokenEstimate.charsPerToken),
+        maxBriefCharsCeiling: Math.round(RANKED_BRIEF_CEILING_TOKENS * tokenEstimate.charsPerToken),
+        briefCharsPerBlock: Math.round(RANKED_BRIEF_TOKENS_PER_BLOCK * tokenEstimate.charsPerToken),
       },
     });
 

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -29,6 +29,8 @@ export interface CompactionStats {
 let lastStats: CompactionStats | null = null;
 let lastCompactWasPiVcc = false;
 let pendingFollowUpPrompt: string | null = null;
+const THRESHOLD_CONTINUE_CUSTOM_TYPE = "pi-vcc-threshold-continue";
+const THRESHOLD_CONTINUE_PROMPT = "Continue from where you left off after automatic context compaction. Do not restate the compaction summary; proceed with the task.";
 export const getLastCompactionStats = () => lastStats;
 
 const formatTokens = (n: number): string => {
@@ -513,9 +515,18 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     if (reason === "overflow" || willRetry) return;
     const stats = lastStats;
     if (!stats) return;
+    const shouldContinueAfterThreshold = reason === "threshold" && loadSettings().continueAfterThresholdCompact;
     if (followUpPrompt) {
       try {
         await pi.sendUserMessage(followUpPrompt);
+      } catch {}
+    } else if (shouldContinueAfterThreshold) {
+      try {
+        await Promise.resolve(pi.sendMessage({
+          customType: THRESHOLD_CONTINUE_CUSTOM_TYPE,
+          content: THRESHOLD_CONTINUE_PROMPT,
+          display: false,
+        }, { triggerTurn: true }));
       } catch {}
     }
     setTimeout(() => {

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -4,7 +4,7 @@ import { writeFileSync } from "fs";
 import { compile } from "../core/summarize";
 import { parseKeepAndPrompt, PI_VCC_COMPACT_INSTRUCTION } from "../core/compact-args";
 import { loadSettings, type PiVccSettings } from "../core/settings";
-import { estimateMessageContentChars, estimateTokensFromChars } from "../core/token-estimate";
+import { calibrateCharsPerToken, estimateMessageContentChars, estimateTokensFromChars } from "../core/token-estimate";
 import type { PiVccCompactionDetails } from "../details";
 import type { CompactionReason } from "../types";
 
@@ -275,6 +275,8 @@ export interface ResolveSmartKeepOptions {
   /** Injectable thresholds for tests. */
   minTokens?: number;
   maxTokens?: number;
+  /** Calibrated chars/token for the current session; defaults to heuristic when omitted. */
+  charsPerToken?: number;
 }
 
 export interface ResolveSmartKeepResult {
@@ -290,7 +292,7 @@ export interface ResolveSmartKeepResult {
  * so the resolver can stop growing instead of selecting a value that
  * discards the tail entirely.
  */
-const tailTokensForKeep = (branchEntries: any[], keepUserTurns: number): number | null => {
+const tailTokensForKeep = (branchEntries: any[], keepUserTurns: number, charsPerToken?: number): number | null => {
   const cut = buildOwnCut(branchEntries, keepUserTurns);
   if (!cut.ok || cut.compactAll) return null;
   const idx = branchEntries.findIndex((e: any) => e.id === cut.firstKeptEntryId);
@@ -300,7 +302,7 @@ const tailTokensForKeep = (branchEntries: any[], keepUserTurns: number): number 
     (sum: number, e: any) => sum + estimateMessageContentChars(e.message?.content),
     0,
   );
-  return estimateTokensFromChars(chars);
+  return estimateTokensFromChars(chars, charsPerToken);
 };
 
 /**
@@ -319,7 +321,7 @@ export const resolveSmartKeepUserTurns = (opts: ResolveSmartKeepOptions): Resolv
     return { keepUserTurns: baseKeep, smartAdjusted: false, fromKeep: baseKeep };
   }
 
-  const baseTokens = tailTokensForKeep(opts.branchEntries, baseKeep);
+  const baseTokens = tailTokensForKeep(opts.branchEntries, baseKeep, opts.charsPerToken);
   // base tail already above min (or unmeasurable / compact-all) → don't grow.
   if (baseTokens == null || baseTokens > minTokens) {
     return { keepUserTurns: baseKeep, smartAdjusted: false, fromKeep: baseKeep };
@@ -330,7 +332,7 @@ export const resolveSmartKeepUserTurns = (opts: ResolveSmartKeepOptions): Resolv
 
   let selected = baseKeep;
   for (let k = baseKeep + 1; k <= totalUserTurns; k++) {
-    const tokens = tailTokensForKeep(opts.branchEntries, k);
+    const tokens = tailTokensForKeep(opts.branchEntries, k, opts.charsPerToken);
     if (tokens == null || tokens > maxTokens) break;
     selected = k;
   }
@@ -363,6 +365,21 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     pendingFollowUpPrompt = null;
     if (!isPiVcc && !settings.overrideDefaultCompaction) return;
 
+    const calibrationCut = buildOwnCut(branchEntries as any[], 0);
+    const calibrationMessageChars = calibrationCut.ok
+      ? calibrationCut.messages.reduce(
+          (sum: number, message: any) => sum + estimateMessageContentChars(message.content),
+          0,
+        )
+      : 0;
+    const calibrationSummaryChars = typeof preparation.previousSummary === "string"
+      ? preparation.previousSummary.length
+      : 0;
+    const tokenEstimate = calibrateCharsPerToken(
+      calibrationMessageChars + calibrationSummaryChars,
+      preparation.tokensBefore,
+    );
+
     // Smart keep-tail: boost default keep when the tail is small.
     // Explicit keep:N from the user is always respected (resolver no-ops).
     const smartKeep = resolveSmartKeepUserTurns({
@@ -370,6 +387,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       requestedKeepUserTurns: keepUserTurnsExplicit ? keepUserTurns : null,
       explicit: keepUserTurnsExplicit,
       smartKeepTail: settings.smartKeepTail,
+      charsPerToken: tokenEstimate.charsPerToken,
     });
     const ownCut = buildOwnCut(branchEntries as any[], smartKeep.keepUserTurns);
     if (!ownCut.ok) {
@@ -465,7 +483,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       requestedKeepUserTurns: ownCut.requestedKeepUserTurns,
       keepUserTurnsExplicit,
       keepFallbackToCompactAll: ownCut.keepFallbackToCompactAll,
-      keptTokensEst: estimateTokensFromChars(keptChars),
+      keptTokensEst: estimateTokensFromChars(keptChars, tokenEstimate.charsPerToken),
       smartKeepAdjusted: smartKeep.smartAdjusted,
       smartFromKeep: smartKeep.fromKeep,
       reason,
@@ -504,6 +522,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       firstKeptEntryId,
       cutWindow,
       tokensBefore: preparation.tokensBefore,
+      tokenEstimate,
       summaryLength: summary.length,
       summaryPreview: summary.slice(0, 500),
       sections: [...summary.matchAll(/^\[(.+?)\]/gm)].map((m) => m[1]),

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -45,11 +45,11 @@ const scheduleAutoContinue = (pi: any) => {
   pendingAutoContinueTimer = setTimeout(async () => {
     pendingAutoContinueTimer = null;
     try {
-      await Promise.resolve(pi.sendMessage({
+      await pi.sendMessage({
         customType: AUTO_CONTINUE_CUSTOM_TYPE,
         content: AUTO_CONTINUE_PROMPT,
         display: false,
-      }, { triggerTurn: true }));
+      }, { triggerTurn: true });
     } catch {}
   }, 0);
 };

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -4,6 +4,7 @@ import { writeFileSync } from "fs";
 import { compile } from "../core/summarize";
 import { parseKeepAndPrompt, PI_VCC_COMPACT_INSTRUCTION } from "../core/compact-args";
 import { loadSettings, type PiVccSettings } from "../core/settings";
+import { estimateMessageContentChars, estimateTokensFromChars } from "../core/token-estimate";
 import type { PiVccCompactionDetails } from "../details";
 import type { CompactionReason } from "../types";
 
@@ -148,18 +149,6 @@ const previewContent = (content: unknown): string => {
       .slice(0, 300);
   }
   return "";
-};
-
-/** Estimate char length of a single message content (string or content-parts array). */
-const messageContentChars = (content: unknown): number => {
-  if (typeof content === "string") return content.length;
-  if (Array.isArray(content)) return content.reduce((s: number, p: any) => {
-    if (p.text) return s + p.text.length;
-    if (p.type === "toolCall") return s + (p.name?.length ?? 0) + (typeof p.input === "string" ? p.input.length : JSON.stringify(p.input ?? "").length);
-    if (p.type === "toolResult") return s + (typeof p.content === "string" ? p.content.length : JSON.stringify(p.content ?? "").length);
-    return s;
-  }, 0);
-  return 0;
 };
 
 interface EntryWithMessage {
@@ -308,10 +297,10 @@ const tailTokensForKeep = (branchEntries: any[], keepUserTurns: number): number 
   if (idx < 0) return null;
   const kept = branchEntries.slice(idx).filter((e: any) => e.type === "message");
   const chars = kept.reduce(
-    (sum: number, e: any) => sum + messageContentChars(e.message?.content),
+    (sum: number, e: any) => sum + estimateMessageContentChars(e.message?.content),
     0,
   );
-  return Math.round(chars / 4);
+  return estimateTokensFromChars(chars);
 };
 
 /**
@@ -465,7 +454,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       ? (branchEntries as any[]).slice(keptIdx).filter((e: any) => e.type === "message")
       : [];
     const keptChars = keptEntries.reduce(
-      (sum: number, e: any) => sum + messageContentChars(e.message?.content),
+      (sum: number, e: any) => sum + estimateMessageContentChars(e.message?.content),
       0,
     );
     lastStats = {
@@ -476,7 +465,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       requestedKeepUserTurns: ownCut.requestedKeepUserTurns,
       keepUserTurnsExplicit,
       keepFallbackToCompactAll: ownCut.keepFallbackToCompactAll,
-      keptTokensEst: Math.round(keptChars / 4),
+      keptTokensEst: estimateTokensFromChars(keptChars),
       smartKeepAdjusted: smartKeep.smartAdjusted,
       smartFromKeep: smartKeep.fromKeep,
       reason,

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -31,6 +31,29 @@ let lastCompactWasPiVcc = false;
 let pendingFollowUpPrompt: string | null = null;
 const THRESHOLD_CONTINUE_CUSTOM_TYPE = "pi-vcc-threshold-continue";
 const THRESHOLD_CONTINUE_PROMPT = "Continue from where you left off after automatic context compaction. Do not restate the compaction summary; proceed with the task.";
+let pendingThresholdContinueTimer: ReturnType<typeof setTimeout> | null = null;
+
+const clearPendingThresholdContinue = () => {
+  if (pendingThresholdContinueTimer) {
+    clearTimeout(pendingThresholdContinueTimer);
+    pendingThresholdContinueTimer = null;
+  }
+};
+
+const scheduleThresholdContinue = (pi: any) => {
+  clearPendingThresholdContinue();
+  pendingThresholdContinueTimer = setTimeout(async () => {
+    pendingThresholdContinueTimer = null;
+    try {
+      await Promise.resolve(pi.sendMessage({
+        customType: THRESHOLD_CONTINUE_CUSTOM_TYPE,
+        content: THRESHOLD_CONTINUE_PROMPT,
+        display: false,
+      }, { triggerTurn: true }));
+    } catch {}
+  }, 0);
+};
+
 export const getLastCompactionStats = () => lastStats;
 
 const formatTokens = (n: number): string => {
@@ -325,6 +348,10 @@ const REASON_MESSAGES: Record<OwnCutCancelReason, string> = {
 };
 
 export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
+  pi.on("before_agent_start", () => {
+    clearPendingThresholdContinue();
+  });
+
   pi.on("session_before_compact", (event, ctx) => {
     const { preparation, branchEntries, customInstructions } = event;
     const { reason, willRetry } = readCompactionEventContext(event);
@@ -521,13 +548,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
         await pi.sendUserMessage(followUpPrompt);
       } catch {}
     } else if (shouldContinueAfterThreshold) {
-      try {
-        await Promise.resolve(pi.sendMessage({
-          customType: THRESHOLD_CONTINUE_CUSTOM_TYPE,
-          content: THRESHOLD_CONTINUE_PROMPT,
-          display: false,
-        }, { triggerTurn: true }));
-      } catch {}
+      scheduleThresholdContinue(pi);
     }
     setTimeout(() => {
       try {

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -81,6 +81,17 @@ const readCompactionEventContext = (event: unknown): { reason?: CompactionReason
   return { reason, willRetry: raw.willRetry === true };
 };
 
+export const scheduleCompactionStatsNotify = (ctx: any, stats: CompactionStats) => {
+  setTimeout(() => {
+    try {
+      ctx?.ui?.notify?.(
+        formatCompactionStats(stats),
+        "info",
+      );
+    } catch {}
+  }, 500);
+};
+
 const parseCompactionInstructions = (customInstructions?: string): {
   isPiVcc: boolean;
   keepUserTurns: number;
@@ -543,14 +554,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     const stats = lastStats;
     if (!stats) return;
     const shouldContinueAfterAutoCompact = (reason === "threshold" || reason === "overflow") && loadSettings().continueAfterThresholdCompact;
-    setTimeout(() => {
-      try {
-        ctx?.ui?.notify?.(
-          formatCompactionStats(stats),
-          "info",
-        );
-      } catch {}
-    }, 500);
+    scheduleCompactionStatsNotify(ctx, stats);
     if (followUpPrompt) {
       try {
         await pi.sendUserMessage(followUpPrompt);

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -29,25 +29,25 @@ export interface CompactionStats {
 let lastStats: CompactionStats | null = null;
 let lastCompactWasPiVcc = false;
 let pendingFollowUpPrompt: string | null = null;
-const THRESHOLD_CONTINUE_CUSTOM_TYPE = "pi-vcc-threshold-continue";
-const THRESHOLD_CONTINUE_PROMPT = "Continue from where you left off after automatic context compaction. Do not restate the compaction summary; proceed with the task.";
-let pendingThresholdContinueTimer: ReturnType<typeof setTimeout> | null = null;
+const AUTO_CONTINUE_CUSTOM_TYPE = "pi-vcc-auto-continue";
+const AUTO_CONTINUE_PROMPT = "Continue from where you left off after automatic context compaction. Do not restate the compaction summary; proceed with the task.";
+let pendingAutoContinueTimer: ReturnType<typeof setTimeout> | null = null;
 
-const clearPendingThresholdContinue = () => {
-  if (pendingThresholdContinueTimer) {
-    clearTimeout(pendingThresholdContinueTimer);
-    pendingThresholdContinueTimer = null;
+const clearPendingAutoContinue = () => {
+  if (pendingAutoContinueTimer) {
+    clearTimeout(pendingAutoContinueTimer);
+    pendingAutoContinueTimer = null;
   }
 };
 
-const scheduleThresholdContinue = (pi: any) => {
-  clearPendingThresholdContinue();
-  pendingThresholdContinueTimer = setTimeout(async () => {
-    pendingThresholdContinueTimer = null;
+const scheduleAutoContinue = (pi: any) => {
+  clearPendingAutoContinue();
+  pendingAutoContinueTimer = setTimeout(async () => {
+    pendingAutoContinueTimer = null;
     try {
       await Promise.resolve(pi.sendMessage({
-        customType: THRESHOLD_CONTINUE_CUSTOM_TYPE,
-        content: THRESHOLD_CONTINUE_PROMPT,
+        customType: AUTO_CONTINUE_CUSTOM_TYPE,
+        content: AUTO_CONTINUE_PROMPT,
         display: false,
       }, { triggerTurn: true }));
     } catch {}
@@ -349,7 +349,7 @@ const REASON_MESSAGES: Record<OwnCutCancelReason, string> = {
 
 export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
   pi.on("before_agent_start", () => {
-    clearPendingThresholdContinue();
+    clearPendingAutoContinue();
   });
 
   pi.on("session_before_compact", (event, ctx) => {
@@ -539,16 +539,16 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     const followUpPrompt = pendingFollowUpPrompt;
     pendingFollowUpPrompt = null;
     if (lastCompactWasPiVcc) return; // /pi-vcc handles its own toast via onComplete
-    if (reason === "overflow" || willRetry) return;
+    if (willRetry) return;
     const stats = lastStats;
     if (!stats) return;
-    const shouldContinueAfterThreshold = reason === "threshold" && loadSettings().continueAfterThresholdCompact;
+    const shouldContinueAfterAutoCompact = (reason === "threshold" || reason === "overflow") && loadSettings().continueAfterThresholdCompact;
     if (followUpPrompt) {
       try {
         await pi.sendUserMessage(followUpPrompt);
       } catch {}
-    } else if (shouldContinueAfterThreshold) {
-      scheduleThresholdContinue(pi);
+    } else if (shouldContinueAfterAutoCompact) {
+      scheduleAutoContinue(pi);
     }
     setTimeout(() => {
       try {

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -543,13 +543,6 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     const stats = lastStats;
     if (!stats) return;
     const shouldContinueAfterAutoCompact = (reason === "threshold" || reason === "overflow") && loadSettings().continueAfterThresholdCompact;
-    if (followUpPrompt) {
-      try {
-        await pi.sendUserMessage(followUpPrompt);
-      } catch {}
-    } else if (shouldContinueAfterAutoCompact) {
-      scheduleAutoContinue(pi);
-    }
     setTimeout(() => {
       try {
         ctx?.ui?.notify?.(
@@ -558,5 +551,12 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
         );
       } catch {}
     }, 500);
+    if (followUpPrompt) {
+      try {
+        await pi.sendUserMessage(followUpPrompt);
+      } catch {}
+    } else if (shouldContinueAfterAutoCompact) {
+      scheduleAutoContinue(pi);
+    }
   });
 };

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -63,15 +63,11 @@ const formatTokens = (n: number): string => {
 };
 
 export const formatCompactionStats = (stats: CompactionStats): string => {
-  const fallbackNote = stats.keepFallbackToCompactAll
-    ? stats.keepUserTurnsExplicit
-      ? `; requested keep:${stats.requestedKeepUserTurns}, compact-all fallback`
-      : "; compact-all fallback"
-    : "";
-  const smartNote = stats.smartKeepAdjusted
-    ? `; smart keep:${stats.smartFromKeep}→${stats.keptUserTurns}`
-    : "";
-  return `pi-vcc: ${stats.summarized} source entries processed; tail kept ${stats.keptUserTurns}/${stats.totalUserTurns} user turns${fallbackNote}${smartNote} (${stats.kept} messages, ~${formatTokens(stats.keptTokensEst)} tok).`;
+  const notes: string[] = [`summarized ${stats.summarized}`];
+  if (stats.smartKeepAdjusted) {
+    notes.push("smart-keep");
+  }
+  return `pi-vcc: kept ${stats.keptUserTurns}/${stats.totalUserTurns} turns, ~${formatTokens(stats.keptTokensEst)} tok (${notes.join(", ")}).`;
 };
 
 const readCompactionEventContext = (event: unknown): { reason?: CompactionReason; willRetry: boolean } => {

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { writeFileSync } from "fs";
-import { compile } from "../core/summarize";
+import { compileRanked } from "../core/summarize";
 import { parseKeepAndPrompt, PI_VCC_COMPACT_INSTRUCTION } from "../core/compact-args";
 import { loadSettings, type PiVccSettings } from "../core/settings";
 import { calibrateCharsPerToken, estimateMessageContentChars, estimateTokensFromChars } from "../core/token-estimate";
@@ -492,12 +492,23 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
 
     const config = settings;
 
-    const summary = compile({
+    // Ranked compaction: keep the highest-signal blocks under a token budget
+    // instead of the old unranked compile() (fixed 120-line cap). The token
+    // budget is converted to a char budget via the session's calibrated
+    // charsPerToken so the summary targets ~RANKED_BRIEF_BUDGET_TOKENS tokens
+    // regardless of content density. Audit (research/audit, 794 sessions) at
+    // this operating point: size parity with the old cap, recall +2.4pp, and
+    // better fact density vs the unbudgeted ranked path (which bloated ~60%).
+    const RANKED_BRIEF_BUDGET_TOKENS = 1100;
+    const summary = compileRanked({
       messages,
       previousSummary: preparation.previousSummary,
       fileOps: {
         readFiles: [...preparation.fileOps.read],
         modifiedFiles: [...preparation.fileOps.written, ...preparation.fileOps.edited],
+      },
+      ranking: {
+        maxBriefChars: Math.round(RANKED_BRIEF_BUDGET_TOKENS * tokenEstimate.charsPerToken),
       },
     });
 

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -23,6 +23,7 @@ afterAll(() => {
 function createMockPi() {
   let beforeHandler: ((event: any, ctx: any) => any) | undefined;
   let compactHandler: ((event: any, ctx: any) => any) | undefined;
+  let beforeAgentStartHandler: ((event: any, ctx: any) => any) | undefined;
   const notifyCalls: Array<{ msg: string; level: string }> = [];
   const userMessages: Array<string | unknown[]> = [];
   const customMessages: Array<{ message: any; options: any }> = [];
@@ -39,6 +40,7 @@ function createMockPi() {
       on: (eventName: string, h: (e: any, c: any) => any) => {
         if (eventName === "session_before_compact") beforeHandler = h;
         if (eventName === "session_compact") compactHandler = h;
+        if (eventName === "before_agent_start") beforeAgentStartHandler = h;
       },
       sendUserMessage: (content: string | unknown[]) => {
         userMessages.push(content);
@@ -49,6 +51,7 @@ function createMockPi() {
     } as any,
     invokeBefore: (event: any) => beforeHandler!(event, ctx),
     invokeCompact: (event: any) => compactHandler!(event, ctx),
+    invokeBeforeAgentStart: (event: any = { type: "before_agent_start", prompt: "next", systemPrompt: "", systemPromptOptions: {} }) => beforeAgentStartHandler?.(event, ctx),
     notifyCalls,
     userMessages,
     customMessages,
@@ -249,6 +252,7 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
     invokeBefore(makeEvent(entries, undefined, { reason: "threshold", willRetry: false }));
     await invokeCompact({ type: "session_compact", fromExtension: true, reason: "threshold", willRetry: false });
+    await new Promise((resolve) => setTimeout(resolve, 5));
 
     expect(userMessages).toEqual([]);
     expect(customMessages).toHaveLength(1);
@@ -260,6 +264,20 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     expect(customMessages[0].message.content).toContain("Continue from where you left off");
   });
 
+  test("threshold compact continuation is canceled when a real user prompt starts", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true });
+    const { pi, invokeBefore, invokeCompact, invokeBeforeAgentStart, customMessages } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+    invokeBefore(makeEvent(entries, undefined, { reason: "threshold", willRetry: false }));
+    await invokeCompact({ type: "session_compact", fromExtension: true, reason: "threshold", willRetry: false });
+    invokeBeforeAgentStart();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(customMessages).toEqual([]);
+  });
+
   test("threshold compact continuation can be disabled", async () => {
     setConfig({ debug: false, overrideDefaultCompaction: true, continueAfterThresholdCompact: false });
     const { pi, invokeBefore, invokeCompact, customMessages } = createMockPi();
@@ -268,6 +286,7 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
     invokeBefore(makeEvent(entries, undefined, { reason: "threshold", willRetry: false }));
     await invokeCompact({ type: "session_compact", fromExtension: true, reason: "threshold", willRetry: false });
+    await new Promise((resolve) => setTimeout(resolve, 5));
 
     expect(customMessages).toEqual([]);
   });

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -258,7 +258,27 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     expect(customMessages).toHaveLength(1);
     expect(customMessages[0].options).toEqual({ triggerTurn: true });
     expect(customMessages[0].message).toMatchObject({
-      customType: "pi-vcc-threshold-continue",
+      customType: "pi-vcc-auto-continue",
+      display: false,
+    });
+    expect(customMessages[0].message.content).toContain("Continue from where you left off");
+  });
+
+  test("successful overflow compact auto-continues by default with hidden custom message", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true });
+    const { pi, invokeBefore, invokeCompact, customMessages, userMessages } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+    invokeBefore(makeEvent(entries, undefined, { reason: "overflow", willRetry: false }));
+    await invokeCompact({ type: "session_compact", fromExtension: true, reason: "overflow", willRetry: false });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(userMessages).toEqual([]);
+    expect(customMessages).toHaveLength(1);
+    expect(customMessages[0].options).toEqual({ triggerTurn: true });
+    expect(customMessages[0].message).toMatchObject({
+      customType: "pi-vcc-auto-continue",
       display: false,
     });
     expect(customMessages[0].message.content).toContain("Continue from where you left off");
@@ -286,6 +306,19 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
     invokeBefore(makeEvent(entries, undefined, { reason: "threshold", willRetry: false }));
     await invokeCompact({ type: "session_compact", fromExtension: true, reason: "threshold", willRetry: false });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(customMessages).toEqual([]);
+  });
+
+  test("successful overflow compact continuation can be disabled", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true, continueAfterThresholdCompact: false });
+    const { pi, invokeBefore, invokeCompact, customMessages } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+    invokeBefore(makeEvent(entries, undefined, { reason: "overflow", willRetry: false }));
+    await invokeCompact({ type: "session_compact", fromExtension: true, reason: "overflow", willRetry: false });
     await new Promise((resolve) => setTimeout(resolve, 5));
 
     expect(customMessages).toEqual([]);

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -333,7 +333,7 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     await invokeCompact({ type: "session_compact", fromExtension: true });
     await new Promise((resolve) => setTimeout(resolve, 550));
     expect(userMessages).toEqual(["continue"]);
-    expect(notifyCalls.some((call) => call.msg.includes("tail kept 1/2 user turns (2 messages,"))).toBe(true);
+    expect(notifyCalls.some((call) => call.msg.startsWith("pi-vcc: kept 1/2 turns,"))).toBe(true);
   });
 
   test("follow-up prompt does not block compact metrics notify", async () => {
@@ -351,7 +351,7 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     await new Promise((resolve) => setTimeout(resolve, 550));
 
     expect(userMessages).toEqual(["continue"]);
-    expect(notifyCalls.some((call) => call.msg.includes("tail kept 1/2 user turns (2 messages,"))).toBe(true);
+    expect(notifyCalls.some((call) => call.msg.startsWith("pi-vcc: kept 1/2 turns,"))).toBe(true);
   });
 
   test("override=true + /compact keep prefix keeps requested turns and strips follow-up", async () => {
@@ -418,8 +418,8 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     expect(notifyCalls).toEqual([]);
   });
 
-  test("formatCompactionStats surfaces compact-all fallback when keep cannot be honored", () => {
-    expect(formatCompactionStats({
+  test("formatCompactionStats shows kept 0/N result for compact-all fallback without extra wording", () => {
+    const msg = formatCompactionStats({
       summarized: 2,
       kept: 4,
       keptUserTurns: 0,
@@ -428,11 +428,13 @@ describe("registerBeforeCompactHook: compact-all path", () => {
       keepUserTurnsExplicit: true,
       keepFallbackToCompactAll: true,
       keptTokensEst: 10,
-    })).toContain("tail kept 0/2 user turns; requested keep:2, compact-all fallback");
+    });
+    expect(msg).toBe("pi-vcc: kept 0/2 turns, ~10 tok (summarized 2).");
+    expect(msg).not.toMatch(/fallback/i);
   });
 
-  test("formatCompactionStats avoids requested keep wording for default compact-all fallback", () => {
-    expect(formatCompactionStats({
+  test("formatCompactionStats shows kept 0/N result for default compact-all fallback without extra wording", () => {
+    const msg = formatCompactionStats({
       summarized: 2,
       kept: 4,
       keptUserTurns: 0,
@@ -441,7 +443,25 @@ describe("registerBeforeCompactHook: compact-all path", () => {
       keepUserTurnsExplicit: false,
       keepFallbackToCompactAll: true,
       keptTokensEst: 10,
-    })).toContain("tail kept 0/1 user turns; compact-all fallback");
+    });
+    expect(msg).toBe("pi-vcc: kept 0/1 turns, ~10 tok (summarized 2).");
+    expect(msg).not.toMatch(/fallback/i);
+  });
+
+  test("formatCompactionStats appends smart-keep tag when adjusted", () => {
+    const msg = formatCompactionStats({
+      summarized: 5,
+      kept: 6,
+      keptUserTurns: 3,
+      totalUserTurns: 5,
+      requestedKeepUserTurns: 1,
+      keepUserTurnsExplicit: false,
+      keepFallbackToCompactAll: false,
+      keptTokensEst: 3200,
+      smartKeepAdjusted: true,
+      smartFromKeep: 1,
+    });
+    expect(msg).toBe("pi-vcc: kept 3/5 turns, ~3.2k tok (summarized 5, smart-keep).");
   });
 
   test("/pi-vcc keep instruction changes firstKeptEntryId and stats", () => {

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -25,6 +25,7 @@ function createMockPi() {
   let compactHandler: ((event: any, ctx: any) => any) | undefined;
   const notifyCalls: Array<{ msg: string; level: string }> = [];
   const userMessages: Array<string | unknown[]> = [];
+  const customMessages: Array<{ message: any; options: any }> = [];
   const ctx = {
     hasUI: true,
     ui: {
@@ -42,11 +43,15 @@ function createMockPi() {
       sendUserMessage: (content: string | unknown[]) => {
         userMessages.push(content);
       },
+      sendMessage: (message: any, options: any) => {
+        customMessages.push({ message, options });
+      },
     } as any,
     invokeBefore: (event: any) => beforeHandler!(event, ctx),
     invokeCompact: (event: any) => compactHandler!(event, ctx),
     notifyCalls,
     userMessages,
+    customMessages,
   };
 }
  
@@ -236,6 +241,37 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     expect(getLastCompactionStats()).toMatchObject({ reason: "threshold", willRetry: false });
   });
 
+  test("threshold compact auto-continues by default with hidden custom message", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true });
+    const { pi, invokeBefore, invokeCompact, customMessages, userMessages } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+    invokeBefore(makeEvent(entries, undefined, { reason: "threshold", willRetry: false }));
+    await invokeCompact({ type: "session_compact", fromExtension: true, reason: "threshold", willRetry: false });
+
+    expect(userMessages).toEqual([]);
+    expect(customMessages).toHaveLength(1);
+    expect(customMessages[0].options).toEqual({ triggerTurn: true });
+    expect(customMessages[0].message).toMatchObject({
+      customType: "pi-vcc-threshold-continue",
+      display: false,
+    });
+    expect(customMessages[0].message.content).toContain("Continue from where you left off");
+  });
+
+  test("threshold compact continuation can be disabled", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true, continueAfterThresholdCompact: false });
+    const { pi, invokeBefore, invokeCompact, customMessages } = createMockPi();
+    registerBeforeCompactHook(pi);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+    invokeBefore(makeEvent(entries, undefined, { reason: "threshold", willRetry: false }));
+    await invokeCompact({ type: "session_compact", fromExtension: true, reason: "threshold", willRetry: false });
+
+    expect(customMessages).toEqual([]);
+  });
+
   test("override=true + customInstructions sends follow-up user message after compact", async () => {
     setConfig({ debug: false, overrideDefaultCompaction: true });
     const { pi, invokeBefore, invokeCompact, userMessages, notifyCalls } = createMockPi();
@@ -299,7 +335,7 @@ describe("registerBeforeCompactHook: compact-all path", () => {
 
   test("session_compact overflow retry does not send follow-up prompt", async () => {
     setConfig({ debug: false, overrideDefaultCompaction: true });
-    const { pi, invokeBefore, invokeCompact, userMessages, notifyCalls } = createMockPi();
+    const { pi, invokeBefore, invokeCompact, userMessages, customMessages, notifyCalls } = createMockPi();
     registerBeforeCompactHook(pi);
 
     const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
@@ -308,6 +344,7 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     await new Promise((resolve) => setTimeout(resolve, 550));
 
     expect(userMessages).toEqual([]);
+    expect(customMessages).toEqual([]);
     expect(notifyCalls).toEqual([]);
   });
 

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -336,6 +336,24 @@ describe("registerBeforeCompactHook: compact-all path", () => {
     expect(notifyCalls.some((call) => call.msg.includes("tail kept 1/2 user turns (2 messages,"))).toBe(true);
   });
 
+  test("follow-up prompt does not block compact metrics notify", async () => {
+    setConfig({ debug: false, overrideDefaultCompaction: true });
+    const { pi, invokeBefore, invokeCompact, userMessages, notifyCalls } = createMockPi();
+    pi.sendUserMessage = (content: string | unknown[]) => {
+      userMessages.push(content);
+      return new Promise(() => {});
+    };
+    registerBeforeCompactHook(pi);
+    const entries = [msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+    invokeBefore(makeEvent(entries, "continue"));
+
+    invokeCompact({ type: "session_compact", fromExtension: true });
+    await new Promise((resolve) => setTimeout(resolve, 550));
+
+    expect(userMessages).toEqual(["continue"]);
+    expect(notifyCalls.some((call) => call.msg.includes("tail kept 1/2 user turns (2 messages,"))).toBe(true);
+  });
+
   test("override=true + /compact keep prefix keeps requested turns and strips follow-up", async () => {
     setConfig({ debug: false, overrideDefaultCompaction: true });
     const { pi, invokeBefore, invokeCompact, userMessages } = createMockPi();

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -104,14 +104,29 @@ describe("compileBrief", () => {
     expect(r).not.toContain("word299");
   });
 
-  it("truncates long assistant text", () => {
-    const longText = Array.from({ length: 300 }, (_, i) => `word${i}`).join(" ");
+  it("truncates segment-closing assistant text with head and tail", () => {
+    const longText = Array.from({ length: 600 }, (_, i) => `word${i}`).join(" ");
     const blocks: NormalizedBlock[] = [
       { kind: "assistant", text: longText },
     ];
     const r = compileBrief(blocks);
-    expect(r).toContain("(truncated)");
-    expect(r).not.toContain("word299");
+    expect(r).toContain("...(middle truncated)...");
+    expect(r).toContain("word0");
+    expect(r).toContain("word599");
+    expect(r).not.toContain("word300");
+  });
+
+  it("truncates non-closing assistant text with head and tail", () => {
+    const longText = Array.from({ length: 600 }, (_, i) => `word${i}`).join(" ");
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: longText },
+      { kind: "tool_call", name: "Read", args: { file_path: "a.ts" } },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("...(middle truncated)...");
+    expect(r).toContain("word0");
+    expect(r).toContain("word599");
+    expect(r).not.toContain("word300");
   });
 
   it("renders a realistic conversation flow", () => {

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -51,6 +51,144 @@ describe("compileBrief", () => {
     expect(r).not.toContain("FAIL noisy output");
   });
 
+  it("drops trivial preamble lines and surfaces the real command", () => {
+    const blocks: NormalizedBlock[] = [
+      {
+        kind: "bash",
+        command: "set -euo pipefail\ngit add README.md\ngit commit -m \"fix\"\ngit push",
+        output: "",
+        exitCode: 0,
+        sourceIndex: 3,
+      },
+    ];
+    const r = compileBrief(blocks);
+    // set -euo pipefail must not be the rendered marker; the git work must show.
+    expect(r).toContain('git commit -m "fix"');
+    expect(r).toContain("git push");
+    expect(r).not.toMatch(/\$ set -euo pipefail/);
+  });
+
+  it("keeps a bare trivial command rather than emitting an empty marker", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "bash", command: "set -e", output: "", exitCode: 0, sourceIndex: 4 },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("$ set -e (#4)");
+  });
+
+  it("drops redirect-heredoc bodies but keeps the opener", () => {
+    const blocks: NormalizedBlock[] = [
+      {
+        kind: "bash",
+        command: "cat > /tmp/pr.md <<'EOF'\n## Summary\n- a very long PR body line\nEOF\ngh pr create --body-file /tmp/pr.md",
+        output: "",
+        exitCode: 0,
+        sourceIndex: 5,
+      },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("cat > /tmp/pr.md <<'EOF'");
+    expect(r).toContain("gh pr create --body-file /tmp/pr.md");
+    // The body content must not leak into the brief.
+    expect(r).not.toContain("a very long PR body line");
+  });
+
+  it("previews the first meaningful body line of an interpreter heredoc", () => {
+    const blocks: NormalizedBlock[] = [
+      {
+        kind: "bash",
+        command: "python3 - <<'PY'\nimport csv\ntotal = sum(1 for _ in open('data.csv'))\nprint(total)\nPY",
+        output: "",
+        exitCode: 0,
+        sourceIndex: 6,
+      },
+    ];
+    const r = compileBrief(blocks);
+    // Opener alone is content-free; a preview of the real work must appear.
+    expect(r).toContain("python3 - <<'PY'");
+    expect(r).toContain("total = sum(1 for _ in open('data.csv'))");
+    // Boilerplate import must be skipped as the preview.
+    expect(r).not.toMatch(/<<'PY' import csv/);
+  });
+
+  it("previews a non-allowlisted interpreter heredoc (sqlite3) via the denylist", () => {
+    const blocks: NormalizedBlock[] = [
+      {
+        kind: "bash",
+        command: "sqlite3 app.db <<'SQL'\nSELECT count(*) FROM users;\nSQL",
+        output: "",
+        exitCode: 0,
+        sourceIndex: 7,
+      },
+    ];
+    const r = compileBrief(blocks);
+    // sqlite3 is not a file-writer, so its content-free opener gets a preview.
+    expect(r).toContain("sqlite3 app.db <<'SQL'");
+    expect(r).toContain("SELECT count(*) FROM users;");
+  });
+
+  it("previews an ssh remote-command heredoc body", () => {
+    const blocks: NormalizedBlock[] = [
+      {
+        kind: "bash",
+        command: "ssh deploy@host <<'CMD'\nsudo systemctl restart api\nCMD",
+        output: "",
+        exitCode: 0,
+        sourceIndex: 8,
+      },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("ssh deploy@host <<'CMD'");
+    expect(r).toContain("sudo systemctl restart api");
+  });
+
+  it("previews an interpreter heredoc combined with a redirect", () => {
+    const blocks: NormalizedBlock[] = [
+      {
+        kind: "bash",
+        command: "python3 - <<'PY' > /tmp/out.sh\nprint('build config')\nPY\nbash /tmp/out.sh",
+        output: "",
+        exitCode: 0,
+        sourceIndex: 9,
+      },
+    ];
+    const r = compileBrief(blocks);
+    // The `>` redirect must not suppress the body preview (old lookahead bug).
+    expect(r).toContain("print('build config')");
+    // The command after the heredoc terminator must survive.
+    expect(r).toContain("bash /tmp/out.sh");
+  });
+
+  it("does not treat `<<` shift operators as a heredoc opener", () => {
+    const blocks: NormalizedBlock[] = [
+      {
+        kind: "bash",
+        command: "n=$((1<<10))\ngit commit -m shift",
+        output: "",
+        exitCode: 0,
+        sourceIndex: 10,
+      },
+    ];
+    const r = compileBrief(blocks);
+    // `1<<10` is a bit-shift, not a heredoc: the commit below must not be eaten.
+    expect(r).toContain("git commit -m shift");
+  });
+
+  it("does not eat following commands when a `<<` has no closing terminator", () => {
+    const blocks: NormalizedBlock[] = [
+      {
+        kind: "bash",
+        command: "echo \"see <<NOTE for details\"\nnpm run build",
+        output: "",
+        exitCode: 0,
+        sourceIndex: 11,
+      },
+    ];
+    const r = compileBrief(blocks);
+    // `<<NOTE` has no closing `NOTE` line, so it is not a heredoc opener.
+    expect(r).toContain("npm run build");
+  });
+
   it("strips filler prefixes but preserves meaningful lead-ins", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "assistant", text: "Okay, I found the root cause." },

--- a/tests/brief.test.ts
+++ b/tests/brief.test.ts
@@ -19,6 +19,29 @@ describe("compileBrief", () => {
     expect(r).toContain("Let me look at the auth module.");
   });
 
+  it("preserves assistant markdown line breaks", () => {
+    const blocks: NormalizedBlock[] = [
+      {
+        kind: "assistant",
+        text: "Output nhìn tốt.\n\n```text\nblock #41: head\ntail\n```\n\n- first\n- second",
+        sourceIndex: 96,
+      },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("Output nhìn tốt.\n\n```text\nblock #41: head\ntail\n```\n\n- first\n- second (#96)");
+  });
+
+  it("preserves assistant line breaks when head/tail truncating", () => {
+    const lines = Array.from({ length: 300 }, (_, i) => `line${i} signal${i}`);
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: lines.join("\n") },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("line0 signal0\nline1 signal1");
+    expect(r).toContain("...(middle truncated)...");
+    expect(r).toContain("\nline299 signal299");
+  });
+
   it("renders bash commands as user actions", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "bash", command: "npm test", output: "FAIL noisy output", exitCode: 1, sourceIndex: 2 },

--- a/tests/pi-vcc-command.test.ts
+++ b/tests/pi-vcc-command.test.ts
@@ -153,7 +153,7 @@ describe("registerPiVccCommand", () => {
     expect(notifyCalls).toEqual([]);
 
     await new Promise((resolve) => setTimeout(resolve, 550));
-    expect(notifyCalls.some((call) => call.msg.includes("tail kept 1/2 user turns (2 messages,"))).toBe(true);
+    expect(notifyCalls.some((call) => call.msg.startsWith("pi-vcc: kept 1/2 turns,"))).toBe(true);
   });
 
   test("handles rejected follow-up send without throwing", async () => {

--- a/tests/pi-vcc-command.test.ts
+++ b/tests/pi-vcc-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { registerPiVccCommand } from "../src/commands/pi-vcc";
-import { PI_VCC_COMPACT_INSTRUCTION } from "../src/hooks/before-compact";
+import { PI_VCC_COMPACT_INSTRUCTION, registerBeforeCompactHook } from "../src/hooks/before-compact";
 
 type CompactOptions = {
   customInstructions?: string;
@@ -94,6 +94,66 @@ describe("registerPiVccCommand", () => {
     compactCalls[0].onComplete?.();
 
     expect(userMessages).toEqual(["continue"]);
+  });
+
+  test("schedules metric notify even when /pi-vcc follow-up starts immediately", async () => {
+    let commandHandler: ((args: string, ctx: any) => Promise<void>) | undefined;
+    let beforeHandler: ((event: any, ctx: any) => any) | undefined;
+    const compactCalls: CompactOptions[] = [];
+    const notifyCalls: Array<{ msg: string; level: string }> = [];
+    const userMessages: Array<string | unknown[]> = [];
+
+    const pi = {
+      registerCommand: (name: string, command: { handler: typeof commandHandler }) => {
+        expect(name).toBe("pi-vcc");
+        commandHandler = command.handler;
+      },
+      on: (eventName: string, h: (event: any, ctx: any) => any) => {
+        if (eventName === "session_before_compact") beforeHandler = h;
+      },
+      sendUserMessage: (content: string | unknown[]) => {
+        userMessages.push(content);
+        return new Promise(() => {});
+      },
+    } as any;
+
+    const ctx = {
+      compact: (options: CompactOptions) => {
+        compactCalls.push(options);
+      },
+      ui: {
+        notify: (msg: string, level: string) => {
+          notifyCalls.push({ msg, level });
+        },
+      },
+    };
+
+    registerBeforeCompactHook(pi);
+    registerPiVccCommand(pi);
+    await commandHandler!("continue", ctx);
+    beforeHandler!({
+      type: "session_before_compact",
+      customInstructions: compactCalls[0].customInstructions,
+      branchEntries: [
+        { id: "m1", type: "message", message: { role: "user", content: "one" } },
+        { id: "m2", type: "message", message: { role: "assistant", content: "reply one" } },
+        { id: "m3", type: "message", message: { role: "user", content: "two" } },
+        { id: "m4", type: "message", message: { role: "assistant", content: "reply two" } },
+      ],
+      preparation: {
+        previousSummary: undefined,
+        fileOps: { read: [], written: [], edited: [] },
+        tokensBefore: 1000,
+      },
+      signal: new AbortController().signal,
+    }, ctx);
+
+    compactCalls[0].onComplete?.();
+    expect(userMessages).toEqual(["continue"]);
+    expect(notifyCalls).toEqual([]);
+
+    await new Promise((resolve) => setTimeout(resolve, 550));
+    expect(notifyCalls.some((call) => call.msg.includes("tail kept 1/2 user turns (2 messages,"))).toBe(true);
   });
 
   test("handles rejected follow-up send without throwing", async () => {

--- a/tests/rank.test.ts
+++ b/tests/rank.test.ts
@@ -198,4 +198,39 @@ describe("section-aware brief ranking prototype", () => {
     expect(brief.length).toBeLessThanOrEqual(maxBriefChars + 400);
     expect(brief.length).toBeGreaterThan(0);
   });
+
+  it("scales the char budget with transcript length between floor and ceiling", () => {
+    // Size-relative budget: clamp(briefCharsPerBlock * blockCount, floor, ceiling).
+    const mkBlocks = (n: number): NormalizedBlock[] =>
+      Array.from({ length: n }, (_, i) => ({ kind: "assistant" as const, text: `block ${i} ` + "x".repeat(300) }));
+    const opts = { maxBlocks: 500, preserveRecentBlocks: 0, maxBriefChars: 4400, maxBriefCharsCeiling: 8000, briefCharsPerBlock: 60 };
+
+    // Small transcript (10 blocks -> 600 < floor): pinned at the floor.
+    const small = compileBrief(selectRankedBriefBlocks(mkBlocks(10), opts));
+    expect(small.length).toBeLessThanOrEqual(4400);
+
+    // Mid transcript (100 blocks -> 6000, between floor and ceiling): exceeds the floor.
+    const mid = compileBrief(selectRankedBriefBlocks(mkBlocks(100), opts));
+    expect(mid.length).toBeGreaterThan(4400);
+    expect(mid.length).toBeLessThanOrEqual(6000);
+
+    // Huge transcript (400 blocks -> 24000, clamped): never exceeds the ceiling.
+    const huge = compileBrief(selectRankedBriefBlocks(mkBlocks(400), opts));
+    expect(huge.length).toBeLessThanOrEqual(8000);
+    expect(huge.length).toBeGreaterThan(mid.length);
+  });
+
+  it("ignores the size-relative ceiling unless slope and floor are both set", () => {
+    // Ceiling alone must not change behavior: falls back to the flat maxBriefChars.
+    const blocks: NormalizedBlock[] = Array.from({ length: 200 }, (_, i) => ({
+      kind: "assistant" as const,
+      text: `block ${i} ` + "x".repeat(300),
+    }));
+    const flat = compileBrief(selectRankedBriefBlocks(blocks, { maxBlocks: 500, preserveRecentBlocks: 0, maxBriefChars: 4400 }));
+    const ceilOnly = compileBrief(
+      selectRankedBriefBlocks(blocks, { maxBlocks: 500, preserveRecentBlocks: 0, maxBriefChars: 4400, maxBriefCharsCeiling: 8000 }),
+    );
+    expect(ceilOnly.length).toBe(flat.length);
+    expect(flat.length).toBeLessThanOrEqual(4400);
+  });
 });

--- a/tests/rank.test.ts
+++ b/tests/rank.test.ts
@@ -85,22 +85,13 @@ describe("section-aware brief ranking prototype", () => {
     expect(selected).not.toContain(blocks[4]);
   });
 
-  it("penalizes and deduplicates repeated gh PR polling commands", () => {
+  it("deduplicates repeated gh PR polling commands", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "user", text: "Merge PR 123 when green" },
       { kind: "tool_call", name: "bash", args: { command: "gh pr view 123 --json mergeStateStatus" } },
       { kind: "tool_call", name: "bash", args: { command: "gh pr checks 123 --watch" } },
       { kind: "tool_call", name: "bash", args: { command: "gh pr merge 123 --squash --delete-branch" } },
     ];
-    const ranked = rankBriefBlocks(blocks);
-    const view = ranked.find((r) => r.block === blocks[1])!;
-    const checks = ranked.find((r) => r.block === blocks[2])!;
-    const merge = ranked.find((r) => r.block === blocks[3])!;
-
-    expect(view.reasons).toContain("gh-pr-poll");
-    expect(checks.reasons).toContain("gh-pr-poll");
-    expect(merge.reasons).not.toContain("gh-pr-poll");
-
     const selected = selectRankedBriefBlocks(blocks, { maxBlocks: 3, preserveRecentBlocks: 0 });
     const pollCount = selected.filter((block) =>
       block.kind === "tool_call"

--- a/tests/rank.test.ts
+++ b/tests/rank.test.ts
@@ -67,6 +67,52 @@ describe("section-aware brief ranking prototype", () => {
     expect(report.score).toBeGreaterThan(chatter.score);
   });
 
+  it("does not spend ranked selection budget on tool results", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "Fix auth bug" },
+      { kind: "assistant", text: "Root cause is stale token refresh." },
+      { kind: "tool_call", name: "Edit", args: { file_path: "src/auth.ts" } },
+      { kind: "tool_result", name: "Edit", text: "large hidden tool output".repeat(200) },
+      { kind: "tool_result", name: "bash", text: "more hidden output".repeat(200) },
+    ];
+
+    const selected = selectRankedBriefBlocks(blocks, { maxBlocks: 4, preserveRecentBlocks: 2 });
+
+    expect(selected).toContain(blocks[0]);
+    expect(selected).toContain(blocks[1]);
+    expect(selected).toContain(blocks[2]);
+    expect(selected).not.toContain(blocks[3]);
+    expect(selected).not.toContain(blocks[4]);
+  });
+
+  it("penalizes and deduplicates repeated gh PR polling commands", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "Merge PR 123 when green" },
+      { kind: "tool_call", name: "bash", args: { command: "gh pr view 123 --json mergeStateStatus" } },
+      { kind: "tool_call", name: "bash", args: { command: "gh pr checks 123 --watch" } },
+      { kind: "tool_call", name: "bash", args: { command: "gh pr merge 123 --squash --delete-branch" } },
+    ];
+    const ranked = rankBriefBlocks(blocks);
+    const view = ranked.find((r) => r.block === blocks[1])!;
+    const checks = ranked.find((r) => r.block === blocks[2])!;
+    const merge = ranked.find((r) => r.block === blocks[3])!;
+
+    expect(view.reasons).toContain("gh-pr-poll");
+    expect(checks.reasons).toContain("gh-pr-poll");
+    expect(merge.reasons).not.toContain("gh-pr-poll");
+
+    const selected = selectRankedBriefBlocks(blocks, { maxBlocks: 3, preserveRecentBlocks: 0 });
+    const pollCount = selected.filter((block) =>
+      block.kind === "tool_call"
+        && /^bash$/i.test(block.name)
+        && typeof block.args.command === "string"
+        && /gh pr (?:view|checks) 123/.test(block.args.command),
+    ).length;
+
+    expect(pollCount).toBeLessThanOrEqual(1);
+    expect(selected).toContain(blocks[3]);
+  });
+
   it("compileRanked reduces brief noise while keeping semantic sections from all blocks", () => {
     const exploration = Array.from({ length: 15 }, (_, i) => [
       userMsg(`look around ${i}`),

--- a/tests/rank.test.ts
+++ b/tests/rank.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import { compile, compileRanked } from "../src/core/summarize";
+import { rankBriefBlocks, selectRankedBriefBlocks } from "../src/core/rank";
+import type { NormalizedBlock } from "../src/types";
+import { assistantText, assistantWithToolCall, userMsg } from "./fixtures";
+
+const briefPart = (summary: string): string => summary.split("\n\n---\n\n")[1] ?? "";
+
+describe("section-aware brief ranking prototype", () => {
+  it("scores structural edit/test events above read-only exploration", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_call", name: "Read", args: { file_path: "src/auth.ts" } },
+      { kind: "tool_call", name: "Edit", args: { file_path: "src/auth.ts" } },
+      { kind: "tool_call", name: "bash", args: { command: "bun test tests/auth.test.ts" } },
+    ];
+
+    const ranked = rankBriefBlocks(blocks);
+    const read = ranked.find((r) => r.block.kind === "tool_call" && r.block.name === "Read")!;
+    const edit = ranked.find((r) => r.block.kind === "tool_call" && r.block.name === "Edit")!;
+    const test = ranked.find((r) => r.block.kind === "tool_call" && r.block.name === "bash")!;
+
+    expect(edit.score).toBeGreaterThan(read.score);
+    expect(test.score).toBeGreaterThan(read.score);
+    expect(edit.reasons).toContain("edit-tool");
+    expect(test.reasons).toContain("test-command");
+  });
+
+  it("selects ranked blocks chronologically after scoring", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_call", name: "Read", args: { file_path: "noise-a.ts" } },
+      { kind: "tool_call", name: "Read", args: { file_path: "noise-b.ts" } },
+      { kind: "user", text: "Fix auth bug" },
+      { kind: "assistant", text: "Root cause is stale token refresh." },
+      { kind: "tool_call", name: "Edit", args: { file_path: "src/auth.ts" } },
+      { kind: "tool_call", name: "bash", args: { command: "bun test tests/auth.test.ts" } },
+    ];
+
+    const selected = selectRankedBriefBlocks(blocks, { maxBlocks: 4, preserveRecentBlocks: 1 });
+
+    expect(selected).toEqual([
+      blocks[2],
+      blocks[3],
+      blocks[4],
+      blocks[5],
+    ]);
+  });
+
+  it("compileRanked reduces brief noise while keeping semantic sections from all blocks", () => {
+    const exploration = Array.from({ length: 15 }, (_, i) => [
+      userMsg(`look around ${i}`),
+      assistantWithToolCall("Read", { file_path: `noise${i}.ts` }),
+    ]).flat();
+    const critical = [
+      userMsg("Fix auth bug"),
+      assistantText("Root cause is stale token refresh."),
+      assistantWithToolCall("Edit", { file_path: "src/auth.ts" }),
+      assistantWithToolCall("bash", { command: "bun test tests/auth.test.ts" }),
+      assistantText("Fixed auth bug and tests passed."),
+    ];
+
+    const baseline = compile({ messages: [...exploration, ...critical] });
+    const ranked = compileRanked({
+      messages: [...exploration, ...critical],
+      ranking: { maxBlocks: 10, preserveRecentBlocks: 4 },
+    });
+
+    expect(ranked.length).toBeLessThan(baseline.length);
+    expect(ranked).toContain("[Session Goal]");
+    expect(ranked).toContain("Fix auth bug");
+    expect(ranked).toContain('* Edit "src/auth.ts"');
+    expect(ranked).toContain('* bash "bun test tests/auth.test.ts"');
+    expect(briefPart(ranked)).not.toContain('Read "noise0.ts"');
+  });
+
+  it("keeps fresh ranked brief and gives previous brief the remaining budget", () => {
+    const previousBrief = Array.from({ length: 200 }, (_, i) => `[user]\nold context ${i}`).join("\n\n");
+    const previousSummary = `[Session Goal]\n- Original goal\n\n---\n\n${previousBrief}`;
+    const ranked = compileRanked({
+      previousSummary,
+      messages: [
+        userMsg("Fix fresh ranked bug"),
+        assistantText("Fresh ranked root cause should survive merge."),
+        assistantWithToolCall("Edit", { file_path: "src/fresh.ts" }),
+        assistantWithToolCall("bash", { command: "bun test tests/fresh.test.ts" }),
+        assistantText("Fresh ranked fix passed tests."),
+      ],
+      ranking: { maxBlocks: 5, preserveRecentBlocks: 2 },
+    });
+
+    expect(ranked).toContain("Fresh ranked root cause should survive merge.");
+    expect(ranked).toContain('* Edit "src/fresh.ts"');
+    expect(ranked).toContain('* bash "bun test tests/fresh.test.ts"');
+    expect(ranked).toContain("Fresh ranked fix passed tests.");
+    expect(ranked).toContain("old context 199");
+    expect(ranked).not.toContain("old context 0");
+  });
+});

--- a/tests/rank.test.ts
+++ b/tests/rank.test.ts
@@ -39,6 +39,16 @@ describe("section-aware brief ranking prototype", () => {
     expect(work.score).toBeGreaterThan(scaffold.score);
   });
 
+  it("does not penalize a real command hidden after a stray '<<' with no terminator", () => {
+    const blocks: NormalizedBlock[] = [
+      // `<<NOTE` has no closing `NOTE` line, so it must not be treated as a
+      // heredoc opener that swallows the git commit below into a skipped body.
+      { kind: "bash", command: "echo \"see <<NOTE for details\"\ngit commit -m fix", exitCode: 0 },
+    ];
+    const ranked = rankBriefBlocks(blocks);
+    expect(ranked[0].reasons).not.toContain("trivial-bash");
+  });
+
   it("does not penalize a scaffolding command that failed (nonzero exit is a real fact)", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "bash", command: "cd /tmp/missing", exitCode: 1 },

--- a/tests/rank.test.ts
+++ b/tests/rank.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { compile, compileRanked } from "../src/core/summarize";
 import { rankBriefBlocks, selectRankedBriefBlocks } from "../src/core/rank";
+import { compileBrief } from "../src/core/brief";
 import type { NormalizedBlock } from "../src/types";
 import { assistantText, assistantWithToolCall, userMsg } from "./fixtures";
 
@@ -152,5 +153,49 @@ describe("section-aware brief ranking prototype", () => {
     expect(ranked).toContain("Fresh ranked fix passed tests.");
     expect(ranked).toContain("old context 199");
     expect(ranked).not.toContain("old context 0");
+  });
+
+  it("charges preserve-recent blocks against the char budget so large recent runs cannot blow past it", () => {
+    // Regression: on very long transcripts the newest blocks alone could exceed
+    // maxBriefChars because preserve-recent was added unconditionally. They must
+    // now be charged against the budget (iterating newest-first) and skipped once full.
+    const blocks: NormalizedBlock[] = Array.from({ length: 8 }, (_, i) => ({
+      kind: "assistant" as const,
+      text: `recent block ${i} ` + "x".repeat(1200),
+    }));
+    const maxBriefChars = 3000;
+
+    const selected = selectRankedBriefBlocks(blocks, {
+      maxBlocks: 80,
+      preserveRecentBlocks: 8, // ask to preserve every block
+      maxBriefChars,
+    });
+    const rendered = compileBrief(selected);
+
+    // Budget is a true ceiling even though all candidates are "recent" blocks.
+    expect(rendered.length).toBeLessThanOrEqual(maxBriefChars);
+    // Newest block is always kept (recency preserved).
+    expect(selected).toContain(blocks[7]);
+    // ...but not everything fits, so oldest recent blocks are dropped.
+    expect(selected).not.toContain(blocks[0]);
+    expect(selected.length).toBeLessThan(blocks.length);
+  });
+
+  it("keeps the ranked brief within the char budget even when recent turns are huge", () => {
+    const huge = Array.from({ length: 10 }, (_, i) =>
+      assistantText(`huge recent turn ${i} ` + "y".repeat(900)),
+    );
+    const maxBriefChars = 3000;
+
+    const ranked = compileRanked({
+      messages: [userMsg("start a big task"), ...huge],
+      ranking: { maxBlocks: 80, preserveRecentBlocks: 10, maxBriefChars },
+    });
+    const brief = briefPart(ranked);
+
+    // Without the fix this brief would be ~9000+ chars; the budget caps it.
+    // Small slack covers the "...omitted" marker and line-wrap newlines.
+    expect(brief.length).toBeLessThanOrEqual(maxBriefChars + 400);
+    expect(brief.length).toBeGreaterThan(0);
   });
 });

--- a/tests/rank.test.ts
+++ b/tests/rank.test.ts
@@ -26,6 +26,28 @@ describe("section-aware brief ranking prototype", () => {
     expect(test.reasons).toContain("test-command");
   });
 
+  it("penalizes scaffolding-only bash so it ranks below substantive commands", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "bash", command: "set -euo pipefail\ncd /tmp/proj\nls -la", exitCode: 0 },
+      { kind: "bash", command: "set -euo pipefail\ngit commit -m \"fix\"\ngit push", exitCode: 0 },
+    ];
+    const ranked = rankBriefBlocks(blocks);
+    const scaffold = ranked[0];
+    const work = ranked[1];
+    expect(scaffold.reasons).toContain("trivial-bash");
+    expect(work.reasons).not.toContain("trivial-bash");
+    expect(work.score).toBeGreaterThan(scaffold.score);
+  });
+
+  it("does not penalize a scaffolding command that failed (nonzero exit is a real fact)", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "bash", command: "cd /tmp/missing", exitCode: 1 },
+    ];
+    const ranked = rankBriefBlocks(blocks);
+    expect(ranked[0].reasons).not.toContain("trivial-bash");
+    expect(ranked[0].reasons).toContain("nonzero-exit");
+  });
+
   it("selects ranked blocks chronologically after scoring", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "tool_call", name: "Read", args: { file_path: "noise-a.ts" } },

--- a/tests/rank.test.ts
+++ b/tests/rank.test.ts
@@ -45,6 +45,28 @@ describe("section-aware brief ranking prototype", () => {
     ]);
   });
 
+  it("boosts non-trivial assistant turns that close a user segment", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "Fix auth bug" },
+      { kind: "assistant", text: "I'll inspect this now." },
+      { kind: "tool_call", name: "Read", args: { file_path: "noise-a.ts" } },
+      { kind: "tool_call", name: "Edit", args: { file_path: "src/auth.ts" } },
+      { kind: "tool_call", name: "bash", args: { command: "bun test tests/auth.test.ts" } },
+      {
+        kind: "assistant",
+        text: "Implemented the auth fix, verified the focused auth test, confirmed the changed file is limited to src/auth.ts, and no follow-up blockers remain for this task.",
+      },
+      { kind: "user", text: "ok next" },
+    ];
+    const ranked = rankBriefBlocks(blocks);
+    const report = ranked.find((r) => r.block === blocks[5])!;
+    const chatter = ranked.find((r) => r.block === blocks[1])!;
+
+    expect(report.reasons).toContain("segment-closing-assistant");
+    expect(chatter.reasons).not.toContain("segment-closing-assistant");
+    expect(report.score).toBeGreaterThan(chatter.score);
+  });
+
   it("compileRanked reduces brief noise while keeping semantic sections from all blocks", () => {
     const exploration = Array.from({ length: 15 }, (_, i) => [
       userMsg(`look around ${i}`),

--- a/tests/smart-keep.test.ts
+++ b/tests/smart-keep.test.ts
@@ -51,12 +51,12 @@ describe("resolveSmartKeepUserTurns", () => {
     expect(r.smartAdjusted).toBe(false);
   });
 
-  test("keep:1 tail <= min → boost to largest N staying <= max", () => {
+  test("keep:1 tail <= min → boost to largest safe N before compact-all boundary", () => {
     // Each user+assistant turn pair = 3+3 = 6 tokens.
     // keep:1 tail = u3+a3 = 6 tokens (<= min 10).
     // keep:2 tail = u2+a2+u3+a3 = 12 (<= max 40).
-    // keep:3 tail = all = 18 (<= max 40).
-    // → select 3.
+    // keep:3 would keep all user turns, which buildOwnCut treats as compact-all.
+    // → select 2.
     const entries = [
       msg("u1", "user", tokenContent(3)),
       msg("a1", "assistant", tokenContent(3)),
@@ -73,7 +73,7 @@ describe("resolveSmartKeepUserTurns", () => {
       minTokens: 10,
       maxTokens: 40,
     });
-    expect(r.keepUserTurns).toBe(3);
+    expect(r.keepUserTurns).toBe(2);
     expect(r.smartAdjusted).toBe(true);
     expect(r.fromKeep).toBe(1);
   });
@@ -162,7 +162,7 @@ describe("resolveSmartKeepUserTurns", () => {
     expect(r.smartAdjusted).toBe(false);
   });
 
-  test("default thresholds (5k/20k): small tail → boost available", () => {
+  test("default thresholds (5k/20k): small tail → boost before compact-all boundary", () => {
     // Tiny content: keep:1 tail way below 5k.
     const entries = [
       msg("u1", "user", "hi"),
@@ -179,8 +179,8 @@ describe("resolveSmartKeepUserTurns", () => {
       smartKeepTail: true,
       // use default thresholds
     });
-    // All turns fit well under 20k, so boost to 3.
-    expect(r.keepUserTurns).toBe(3);
+    // keep:3 would cross the compact-all boundary, so boost only to 2.
+    expect(r.keepUserTurns).toBe(2);
     expect(r.smartAdjusted).toBe(true);
     expect(r.fromKeep).toBe(1);
   });

--- a/tests/smart-keep.test.ts
+++ b/tests/smart-keep.test.ts
@@ -162,7 +162,7 @@ describe("resolveSmartKeepUserTurns", () => {
     expect(r.smartAdjusted).toBe(false);
   });
 
-  test("default thresholds (5k/20k): small tail → boost before compact-all boundary", () => {
+  test("default thresholds (5k/25k): small tail → boost before compact-all boundary", () => {
     // Tiny content: keep:1 tail way below 5k.
     const entries = [
       msg("u1", "user", "hi"),

--- a/tests/smart-keep.test.ts
+++ b/tests/smart-keep.test.ts
@@ -1,0 +1,187 @@
+import { describe, test, expect } from "bun:test";
+import { resolveSmartKeepUserTurns } from "../src/hooks/before-compact";
+
+const msg = (id: string, role: "user" | "assistant" | "toolResult", content = "x") => ({
+  id,
+  type: "message",
+  message: { role, content },
+});
+
+// Helper to build a long content string of roughly N tokens (4 chars/token).
+const tokenContent = (n: number): string => "a".repeat(n * 4);
+
+describe("resolveSmartKeepUserTurns", () => {
+  test("smart disabled → old behavior, keep base (1)", () => {
+    const entries = [
+      msg("u1", "user", tokenContent(3)),
+      msg("a1", "assistant", tokenContent(3)),
+      msg("u2", "user", tokenContent(3)),
+      msg("a2", "assistant", tokenContent(3)),
+    ];
+    const r = resolveSmartKeepUserTurns({
+      branchEntries: entries,
+      requestedKeepUserTurns: null,
+      explicit: false,
+      smartKeepTail: false,
+      minTokens: 10,
+      maxTokens: 40,
+    });
+    expect(r.keepUserTurns).toBe(1);
+    expect(r.smartAdjusted).toBe(false);
+  });
+
+  test("explicit keep:N is respected, never adjusted", () => {
+    const entries = [
+      msg("u1", "user", tokenContent(3)),
+      msg("a1", "assistant", tokenContent(3)),
+      msg("u2", "user", tokenContent(3)),
+      msg("a2", "assistant", tokenContent(3)),
+      msg("u3", "user", tokenContent(3)),
+      msg("a3", "assistant", tokenContent(3)),
+    ];
+    const r = resolveSmartKeepUserTurns({
+      branchEntries: entries,
+      requestedKeepUserTurns: 2,
+      explicit: true,
+      smartKeepTail: true,
+      minTokens: 10,
+      maxTokens: 40,
+    });
+    expect(r.keepUserTurns).toBe(2);
+    expect(r.smartAdjusted).toBe(false);
+  });
+
+  test("keep:1 tail <= min → boost to largest N staying <= max", () => {
+    // Each user+assistant turn pair = 3+3 = 6 tokens.
+    // keep:1 tail = u3+a3 = 6 tokens (<= min 10).
+    // keep:2 tail = u2+a2+u3+a3 = 12 (<= max 40).
+    // keep:3 tail = all = 18 (<= max 40).
+    // → select 3.
+    const entries = [
+      msg("u1", "user", tokenContent(3)),
+      msg("a1", "assistant", tokenContent(3)),
+      msg("u2", "user", tokenContent(3)),
+      msg("a2", "assistant", tokenContent(3)),
+      msg("u3", "user", tokenContent(3)),
+      msg("a3", "assistant", tokenContent(3)),
+    ];
+    const r = resolveSmartKeepUserTurns({
+      branchEntries: entries,
+      requestedKeepUserTurns: null,
+      explicit: false,
+      smartKeepTail: true,
+      minTokens: 10,
+      maxTokens: 40,
+    });
+    expect(r.keepUserTurns).toBe(3);
+    expect(r.smartAdjusted).toBe(true);
+    expect(r.fromKeep).toBe(1);
+  });
+
+  test("keep:1 tail <= min but keep:2 > max → keep 1", () => {
+    // keep:1 tail = 6 tokens (<= min 10).
+    // keep:2 tail = 12 (> max 11) → stop, keep 1.
+    const entries = [
+      msg("u1", "user", tokenContent(3)),
+      msg("a1", "assistant", tokenContent(3)),
+      msg("u2", "user", tokenContent(3)),
+      msg("a2", "assistant", tokenContent(3)),
+      msg("u3", "user", tokenContent(3)),
+      msg("a3", "assistant", tokenContent(3)),
+    ];
+    const r = resolveSmartKeepUserTurns({
+      branchEntries: entries,
+      requestedKeepUserTurns: null,
+      explicit: false,
+      smartKeepTail: true,
+      minTokens: 10,
+      maxTokens: 11,
+    });
+    expect(r.keepUserTurns).toBe(1);
+    expect(r.smartAdjusted).toBe(false);
+  });
+
+  test("keep:1 tail > min → no boost (already above threshold)", () => {
+    // keep:1 tail = 8+8 = 16 tokens (> min 10).
+    const entries = [
+      msg("u1", "user", tokenContent(3)),
+      msg("a1", "assistant", tokenContent(3)),
+      msg("u2", "user", tokenContent(8)),
+      msg("a2", "assistant", tokenContent(8)),
+    ];
+    const r = resolveSmartKeepUserTurns({
+      branchEntries: entries,
+      requestedKeepUserTurns: null,
+      explicit: false,
+      smartKeepTail: true,
+      minTokens: 10,
+      maxTokens: 100,
+    });
+    expect(r.keepUserTurns).toBe(1);
+    expect(r.smartAdjusted).toBe(false);
+  });
+
+  test("keep:1 > max → still keep 1 (minimum tail)", () => {
+    // keep:1 tail = 50 tokens (> max 40, > min 10).
+    const entries = [
+      msg("u1", "user", tokenContent(3)),
+      msg("a1", "assistant", tokenContent(3)),
+      msg("u2", "user", tokenContent(50)),
+      msg("a2", "assistant", tokenContent(50)),
+    ];
+    const r = resolveSmartKeepUserTurns({
+      branchEntries: entries,
+      requestedKeepUserTurns: null,
+      explicit: false,
+      smartKeepTail: true,
+      minTokens: 10,
+      maxTokens: 40,
+    });
+    expect(r.keepUserTurns).toBe(1);
+    expect(r.smartAdjusted).toBe(false);
+  });
+
+  test("stop at compact-all boundary (keep:N falls back to compact-all → null)", () => {
+    // 2 user turns. keep:2 → cutIdx<=0 → compactAll → tailTokensForKeep returns null.
+    // keep:1 tail = 6 (<= min 10). Next k=2 → null → break, keep 1.
+    const entries = [
+      msg("u1", "user", tokenContent(3)),
+      msg("a1", "assistant", tokenContent(3)),
+      msg("u2", "user", tokenContent(3)),
+      msg("a2", "assistant", tokenContent(3)),
+    ];
+    const r = resolveSmartKeepUserTurns({
+      branchEntries: entries,
+      requestedKeepUserTurns: null,
+      explicit: false,
+      smartKeepTail: true,
+      minTokens: 10,
+      maxTokens: 100,
+    });
+    expect(r.keepUserTurns).toBe(1);
+    expect(r.smartAdjusted).toBe(false);
+  });
+
+  test("default thresholds (5k/20k): small tail → boost available", () => {
+    // Tiny content: keep:1 tail way below 5k.
+    const entries = [
+      msg("u1", "user", "hi"),
+      msg("a1", "assistant", "hello"),
+      msg("u2", "user", "do thing"),
+      msg("a2", "assistant", "done"),
+      msg("u3", "user", "more"),
+      msg("a3", "assistant", "ok"),
+    ];
+    const r = resolveSmartKeepUserTurns({
+      branchEntries: entries,
+      requestedKeepUserTurns: null,
+      explicit: false,
+      smartKeepTail: true,
+      // use default thresholds
+    });
+    // All turns fit well under 20k, so boost to 3.
+    expect(r.keepUserTurns).toBe(3);
+    expect(r.smartAdjusted).toBe(true);
+    expect(r.fromKeep).toBe(1);
+  });
+});

--- a/tests/smart-keep.test.ts
+++ b/tests/smart-keep.test.ts
@@ -184,4 +184,29 @@ describe("resolveSmartKeepUserTurns", () => {
     expect(r.smartAdjusted).toBe(true);
     expect(r.fromKeep).toBe(1);
   });
+
+  test("uses calibrated chars/token ratio when estimating tail size", () => {
+    const entries = [
+      msg("u1", "user", tokenContent(3)),
+      msg("a1", "assistant", tokenContent(3)),
+      msg("u2", "user", tokenContent(3)),
+      msg("a2", "assistant", tokenContent(3)),
+      msg("u3", "user", tokenContent(3)),
+      msg("a3", "assistant", tokenContent(3)),
+    ];
+    const r = resolveSmartKeepUserTurns({
+      branchEntries: entries,
+      requestedKeepUserTurns: null,
+      explicit: false,
+      smartKeepTail: true,
+      minTokens: 10,
+      maxTokens: 20,
+      charsPerToken: 2,
+    });
+
+    // With default 4 chars/token: keep:1 is 6 tokens and keep:2 is 12, so it would boost.
+    // Calibrated 2 chars/token makes keep:1 already 12 tokens (> minTokens=10), so it stays at 1.
+    expect(r.keepUserTurns).toBe(1);
+    expect(r.smartAdjusted).toBe(false);
+  });
 });

--- a/tests/token-estimate.test.ts
+++ b/tests/token-estimate.test.ts
@@ -45,7 +45,26 @@ describe("token estimate", () => {
       { type: "toolCall", name: "read", input: { path: "a.ts" } },
       { type: "toolResult", content: "done" },
       { type: "image", mimeType: "image/png" },
-    ])).toBe(5 + 4 + JSON.stringify({ path: "a.ts" }).length + 4);
+    ])).toBe(5 + 4 + JSON.stringify({ path: "a.ts" }).length + 4 + 4800);
+  });
+
+  test("counts real Pi part shapes: thinking text and toolCall arguments", () => {
+    // Pi assistant content: thinking.thinking + toolCall.arguments (not .input).
+    expect(estimateMessageContentChars([
+      { type: "thinking", thinking: "reasoning", thinkingSignature: "sig" },
+      { type: "text", text: "answer" },
+      { type: "toolCall", name: "bash", arguments: { command: "ls" } },
+    ])).toBe(9 + 6 + 4 + JSON.stringify({ command: "ls" }).length);
+  });
+
+  test("ignores non-token parts and unknown shapes without throwing", () => {
+    expect(estimateMessageContentChars([
+      { type: "thinking" },              // missing thinking field → 0
+      { type: "toolCall", name: "noop" }, // name(4) + stringify("")=('""'=2) → 6
+      { type: "mystery", text: "x" },     // unknown → falls back to text → 1
+      null,                               // 0
+      "not-an-object",                    // 0
+    ] as any)).toBe(0 + 6 + 1 + 0 + 0);
   });
 
   test("estimates message content tokens through the shared char estimator", () => {

--- a/tests/token-estimate.test.ts
+++ b/tests/token-estimate.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { estimateMessageContentChars, estimateMessageContentTokens, estimateTokensFromChars } from "../src/core/token-estimate";
+
+describe("token estimate", () => {
+  test("estimates tokens from chars with ceil to avoid undercounting", () => {
+    expect(estimateTokensFromChars(0)).toBe(0);
+    expect(estimateTokensFromChars(1)).toBe(1);
+    expect(estimateTokensFromChars(4)).toBe(1);
+    expect(estimateTokensFromChars(5)).toBe(2);
+  });
+
+  test("estimates message content chars from strings and content parts", () => {
+    expect(estimateMessageContentChars("hello")).toBe(5);
+    expect(estimateMessageContentChars([
+      { type: "text", text: "hello" },
+      { type: "toolCall", name: "read", input: { path: "a.ts" } },
+      { type: "toolResult", content: "done" },
+      { type: "image", mimeType: "image/png" },
+    ])).toBe(5 + 4 + JSON.stringify({ path: "a.ts" }).length + 4);
+  });
+
+  test("estimates message content tokens through the shared char estimator", () => {
+    expect(estimateMessageContentTokens("abcde")).toBe(2);
+  });
+});

--- a/tests/token-estimate.test.ts
+++ b/tests/token-estimate.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { estimateMessageContentChars, estimateMessageContentTokens, estimateTokensFromChars } from "../src/core/token-estimate";
+import {
+  calibrateCharsPerToken,
+  estimateMessageContentChars,
+  estimateMessageContentTokens,
+  estimateTokensFromChars,
+} from "../src/core/token-estimate";
 
 describe("token estimate", () => {
   test("estimates tokens from chars with ceil to avoid undercounting", () => {
@@ -7,6 +12,30 @@ describe("token estimate", () => {
     expect(estimateTokensFromChars(1)).toBe(1);
     expect(estimateTokensFromChars(4)).toBe(1);
     expect(estimateTokensFromChars(5)).toBe(2);
+  });
+
+  test("supports calibrated chars/token ratios", () => {
+    expect(estimateTokensFromChars(5, 2)).toBe(3);
+    expect(estimateMessageContentTokens("abcde", 2)).toBe(3);
+  });
+
+  test("calibrates chars/token from source chars and tokens", () => {
+    expect(calibrateCharsPerToken(120, 40)).toMatchObject({
+      mode: "calibrated",
+      charsPerToken: 3,
+      sourceChars: 120,
+      sourceTokens: 40,
+      rawCharsPerToken: 3,
+    });
+  });
+
+  test("clamps calibrated ratios and falls back without usable source tokens", () => {
+    expect(calibrateCharsPerToken(10, 100).charsPerToken).toBe(2);
+    expect(calibrateCharsPerToken(1000, 10).charsPerToken).toBe(6);
+    expect(calibrateCharsPerToken(1000, 0)).toMatchObject({
+      mode: "heuristic",
+      charsPerToken: 4,
+    });
   });
 
   test("estimates message content chars from strings and content parts", () => {


### PR DESCRIPTION
## Summary
- add smart default keep-tail expansion when the kept tail is small, while respecting explicit `keep:N`
- preserve section-ranking compaction improvements on this branch
- auto-continue after successful pi-vcc auto-compaction for threshold and overflow-success cases
- defer/cancel hidden continuation when a real user prompt starts, avoiding prompt-processing races

## Tests
- `bun test tests/before-compact-hook.test.ts tests/smart-keep.test.ts`
- `bun test`
