### PR TITLE
fix(extract): correct file-activity tool classification; default to pi-vcc compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@sting8k/pi-vcc` are documented in this file.
 
+## [0.4.1]
+
+### Fixes
+
+- **File activity: recognise lowercase `read`** — `FILE_READ_TOOLS` only matched `Read`/`read_file`/`View`, so Pi's lowercase `read` tool never registered and `[Files And Changes]` emitted no `Read:` line at all (0 of 179 audited sessions produced one).
+- **File activity: recognise modern edit tools** — `quick_edit`, `target_edit` and `apply_patch` are ranked as edits in `src/core/rank.ts` but were missing from `FILE_WRITE_TOOLS`, so files changed through them never appeared under `Modified:`.
+- **File activity: use hook-provided file ops** — `buildSections` never received `CompileInput.fileOps`, so the hook's authoritative read/modified sets were dropped before the summary was built. `extractFiles` already accepted the argument; it is now wired through.
+
+Audit on 790 real sessions: weighted recall 63.6% → 74.5% (median 68.2% → 79.3%), weighted fact density 6.00 → 7.08, summary size +6% (4183 → 4433 chars).
+
 ## [0.4.0]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to `@sting8k/pi-vcc` are documented in this file.
 
 ## [0.4.1]
 
+### Changes
+
+- **`overrideDefaultCompaction` now defaults to `true`** — fresh installs let pi-vcc handle `/compact` and auto-threshold/overflow compaction, not just `/pi-vcc`. Existing config files keep their stored value; set `false` to restore pi core's LLM-based compaction for those paths.
+
 ### Fixes
 
-- **File activity: recognise lowercase `read`** — `FILE_READ_TOOLS` only matched `Read`/`read_file`/`View`, so Pi's lowercase `read` tool never registered and `[Files And Changes]` emitted no `Read:` line at all (0 of 179 audited sessions produced one).
+- **File activity: case-insensitive tool matching** — `FILE_READ_TOOLS`/`FILE_WRITE_TOOLS`/`FILE_CREATE_TOOLS` were exact-match sets, so Pi's lowercase `read` tool never registered and `[Files And Changes]` emitted no `Read:` line at all (0 of 179 audited sessions produced one). Matching is now case-insensitive, mirroring the `/i` tool regexes in `core/rank.ts`.
 - **File activity: recognise modern edit tools** — `quick_edit`, `target_edit` and `apply_patch` are ranked as edits in `src/core/rank.ts` but were missing from `FILE_WRITE_TOOLS`, so files changed through them never appeared under `Modified:`.
 - **File activity: use hook-provided file ops** — `buildSections` never received `CompileInput.fileOps`, so the hook's authoritative read/modified sets were dropped before the summary was built. `extractFiles` already accepted the argument; it is now wired through.
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ pi -e https://github.com/sting8k/pi-vcc
 
 ## Usage
 
-pi-vcc runs automatically when your context window fills up (if `overrideDefaultCompaction` is enabled), or on-demand via commands.
+pi-vcc runs automatically when your context window fills up, or on-demand via commands.
 
 ### Compaction
 
 - **`/pi-vcc`** — manual compaction, keeps the last 1 user turn by default.
 - **`/pi-vcc keep:N [prompt]`** — keep the last `N` user turns; optional prompt is sent to the agent after compaction.
   - `keep:1` = default, `keep:0` = compact everything, no tail.
-- By default `/compact` and auto-threshold go through Pi core. Set `overrideDefaultCompaction: true` to let pi-vcc handle all paths.
+- By default pi-vcc also handles `/compact` and auto-threshold compactions. Set `overrideDefaultCompaction: false` to send those paths back to Pi core.
 - **Smart keep**: when enabled, pi-vcc auto-boosts `keep:1` to a larger N if the tail is small enough (< 5k tokens, capped at 20k).
 
 ### Compacted message structure
@@ -152,14 +152,14 @@ Config lives at `~/.pi/agent/pi-vcc-config.json` (auto-scaffolded on first load 
 
 ```json
 {
-  "overrideDefaultCompaction": false,
+  "overrideDefaultCompaction": true,
   "smartKeepTail": true,
   "continueAfterThresholdCompact": true,
   "debug": false
 }
 ```
 
-- **`overrideDefaultCompaction`** *(default `false`)*: when `false`, pi-vcc only runs for `/pi-vcc`; `/compact` and auto-threshold compactions fall through to pi core. Set `true` to make pi-vcc handle all compaction paths.
+- **`overrideDefaultCompaction`** *(default `true`)*: when `true`, pi-vcc handles all compaction paths — `/pi-vcc`, `/compact`, and auto-threshold/overflow. Set `false` to restrict pi-vcc to `/pi-vcc` and let the rest fall through to pi core. Existing config files keep whatever value they already have.
 - **`smartKeepTail`** *(default `true`)*: when `true`, pi-vcc boosts the default `keep:1` to the largest `N` whose tail stays ≤ 20k tokens, but only when the `keep:1` tail is already small (≤ 5k tokens). Explicit `keep:N` from the user is always respected.
 - **`continueAfterThresholdCompact`** *(default `true`)*: when `true`, pi-vcc asks the agent to continue after a successful automatic compaction (threshold or overflow), avoiding a UX cliff where the agent stops after compaction instead of continuing the task.
 - **`debug`** *(default `false`)*: when `true`, each compaction writes detailed info to `/tmp/pi-vcc-debug.json` — message counts, cut boundary, summary preview, sections, token estimate calibration.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sting8k/pi-vcc",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Algorithmic conversation compactor for pi - transcript-preserving structured summaries, no LLM calls",
   "main": "index.ts",
   "keywords": [

--- a/src/core/build-sections.ts
+++ b/src/core/build-sections.ts
@@ -1,4 +1,4 @@
-import type { NormalizedBlock } from "../types";
+import type { FileOps, NormalizedBlock } from "../types";
 import { clip, clipSentence, nonEmptyLines } from "./content";
 import type { SectionData } from "../sections";
 import { extractGoals } from "../extract/goals";
@@ -10,6 +10,8 @@ import { buildBriefSections, stringifyBrief } from "./brief";
 export interface BuildSectionsInput {
   blocks: NormalizedBlock[];
   briefBlocks?: NormalizedBlock[];
+  /** Hook-provided file activity; authoritative for files touched before this compaction. */
+  fileOps?: FileOps;
 }
 
 const BLOCKER_RE =
@@ -39,8 +41,8 @@ const extractOutstandingContext = (blocks: NormalizedBlock[]): string[] => {
   return items.slice(0, 5);
 };
 
-const formatFileActivity = (blocks: NormalizedBlock[]): string[] => {
-  const act = extractFiles(blocks);
+const formatFileActivity = (blocks: NormalizedBlock[], fileOps?: FileOps): string[] => {
+  const act = extractFiles(blocks, fileOps);
   // Dedup: if already Modified, drop from Created (file existed before)
   for (const p of act.modified) act.created.delete(p);
   const lines: string[] = [];
@@ -66,7 +68,7 @@ export const buildSections = (input: BuildSectionsInput): SectionData => {
   return {
     sessionGoal,
     outstandingContext: extractOutstandingContext(blocks),
-    filesAndChanges: formatFileActivity(blocks),
+    filesAndChanges: formatFileActivity(blocks, input.fileOps),
     commits: formatCommits(extractCommits(blocks)),
     userPreferences,
     briefTranscript: stringifyBrief(briefSections),

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -9,14 +9,15 @@ export const SETTINGS_PATH = settingsPath();
 
 export interface PiVccSettings {
   /**
-   * When true, pi-vcc handles ALL compactions:
+   * When true (default), pi-vcc handles ALL compactions:
    *   - /compact (no args)
    *   - /compact <text>
    *   - auto threshold / overflow
    *   - /pi-vcc (always handled regardless)
    *
-   * When false (default), pi-vcc only handles /pi-vcc; everything else
-   * falls back to pi core's default LLM-based compaction.
+   * When false, pi-vcc only handles /pi-vcc; everything else falls back to
+   * pi core's default LLM-based compaction. Existing config files keep their
+   * stored value; the new default applies to fresh installs only.
    */
   overrideDefaultCompaction: boolean;
   /**
@@ -40,7 +41,7 @@ export interface PiVccSettings {
 }
 
 export const DEFAULT_SETTINGS: PiVccSettings = {
-  overrideDefaultCompaction: false,
+  overrideDefaultCompaction: true,
   smartKeepTail: true,
   continueAfterThresholdCompact: true,
   debug: false,

--- a/src/core/summarize.ts
+++ b/src/core/summarize.ts
@@ -173,7 +173,7 @@ interface CompileWithBriefBlocksOptions {
 const compileWithBriefBlocks = (input: CompileInput, options: CompileWithBriefBlocksOptions = {}): string => {
   const blocks = filterNoise(normalize(input.messages));
   const briefBlocks = options.briefBlocksFor?.(blocks);
-  const data = buildSections({ blocks, briefBlocks });
+  const data = buildSections({ blocks, briefBlocks, fileOps: input.fileOps });
   const fresh = formatSummary(data, { capBriefTranscript: options.capFreshBrief ?? true });
   // Strip any legacy RECALL_NOTE baked into prev summary (pre-fix format)
   // so merge doesn't re-stack it inside the brief.

--- a/src/extract/files.ts
+++ b/src/extract/files.ts
@@ -8,12 +8,12 @@ interface FileActivity {
 }
 
 const FILE_READ_TOOLS = new Set([
-  "Read", "read_file", "View",
+  "Read", "read", "read_file", "View",
 ]);
 
 const FILE_WRITE_TOOLS = new Set([
   "Edit", "Write", "edit", "write", "edit_file", "write_file",
-  "MultiEdit",
+  "MultiEdit", "quick_edit", "target_edit", "apply_patch",
 ]);
 
 const FILE_CREATE_TOOLS = new Set([

--- a/src/extract/files.ts
+++ b/src/extract/files.ts
@@ -7,18 +7,25 @@ interface FileActivity {
   created: Set<string>;
 }
 
+// Tool names are matched case-insensitively (see `matches`), mirroring the /i
+// regexes in core/rank.ts. Entries must be lowercase.
 const FILE_READ_TOOLS = new Set([
-  "Read", "read", "read_file", "View",
+  "read", "read_file", "view",
 ]);
 
+// Multi-file patch tools (apply_patch) carry their paths inside the diff payload,
+// not in a path arg, so extractPath yields nothing for them; those files are
+// recovered from the hook-provided fileOps below.
 const FILE_WRITE_TOOLS = new Set([
-  "Edit", "Write", "edit", "write", "edit_file", "write_file",
-  "MultiEdit", "quick_edit", "target_edit", "apply_patch",
+  "edit", "write", "edit_file", "write_file",
+  "multiedit", "quick_edit", "target_edit", "apply_patch",
 ]);
 
 const FILE_CREATE_TOOLS = new Set([
-  "Write", "write", "write_file",
+  "write", "write_file",
 ]);
+
+const matches = (tools: Set<string>, name: string): boolean => tools.has(name.toLowerCase());
 
 /**
  * Find the longest common directory prefix among absolute paths.
@@ -63,9 +70,9 @@ export const extractFiles = (
     const p = extractPath(b.args);
     if (!p) continue;
 
-    if (FILE_READ_TOOLS.has(b.name)) act.read.add(p);
-    if (FILE_WRITE_TOOLS.has(b.name)) act.modified.add(p);
-    if (FILE_CREATE_TOOLS.has(b.name)) act.created.add(p);
+    if (matches(FILE_READ_TOOLS, b.name)) act.read.add(p);
+    if (matches(FILE_WRITE_TOOLS, b.name)) act.modified.add(p);
+    if (matches(FILE_CREATE_TOOLS, b.name)) act.created.add(p);
   }
 
   const all = [...act.read, ...act.modified, ...act.created];

--- a/tests/extract-files.test.ts
+++ b/tests/extract-files.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "bun:test";
+import { extractFiles } from "../src/extract/files";
+import { DEFAULT_SETTINGS } from "../src/core/settings";
+import type { NormalizedBlock } from "../src/types";
+
+describe("extractFiles", () => {
+  it("matches tool names case-insensitively", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_call", name: "read", args: { path: "a.ts" } },
+      { kind: "tool_call", name: "Read", args: { path: "b.ts" } },
+      { kind: "tool_call", name: "Write", args: { path: "c.ts" } },
+      { kind: "tool_call", name: "MultiEdit", args: { path: "d.ts" } },
+    ];
+    const r = extractFiles(blocks);
+    expect([...r.read].sort()).toEqual(["a.ts", "b.ts"]);
+    expect([...r.modified].sort()).toEqual(["c.ts", "d.ts"]);
+    expect([...r.created]).toEqual(["c.ts"]);
+  });
+
+  it("records modern edit tools as modifications", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_call", name: "quick_edit", args: { path: "a.ts" } },
+      { kind: "tool_call", name: "target_edit", args: { path: "b.ts" } },
+    ];
+    const r = extractFiles(blocks);
+    expect([...r.modified].sort()).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("seeds activity from hook-provided fileOps", () => {
+    const r = extractFiles([], { readFiles: ["x.ts"], modifiedFiles: ["y.ts"], createdFiles: [] });
+    expect([...r.read]).toEqual(["x.ts"]);
+    expect([...r.modified]).toEqual(["y.ts"]);
+  });
+});
+
+describe("settings defaults", () => {
+  it("overrides pi core compaction by default", () => {
+    expect(DEFAULT_SETTINGS.overrideDefaultCompaction).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two things: a set of file-activity extraction fixes, plus a default-behaviour change so pi-vcc owns compaction out of the box.

## 1. Default: pi-vcc handles all compaction

`overrideDefaultCompaction` now defaults to `true`. Fresh installs route `/compact` and auto-threshold/overflow compaction through pi-vcc instead of pi core's LLM-based compaction.

Existing users are unaffected: `scaffoldSettings` only fills in missing keys, so a config that already stores `false` keeps `false`. No migration, no clobbering user intent.

## 2. File-activity extraction fixes

`[Files And Changes]` systematically under-reported what a session touched. Three defects, all class mismatches between the extractor and the rest of the pipeline.

| Defect | Effect |
|---|---|
| Tool-name sets were exact-match while `core/rank.ts` matches with `/i` regexes | Pi emits lowercase `read`, so **no session ever produced a `Read:` line** (0 of 179 audited) |
| `FILE_WRITE_TOOLS` missed `quick_edit`, `target_edit`, `apply_patch` | `rank.ts` already ranks these as edits; files changed through them never showed as `Modified:` |
| `buildSections` never received `CompileInput.fileOps` | The hook's authoritative read/modified sets were dropped. `extractFiles` already accepted the argument — it was simply never passed |

Matching is now case-insensitive across read/write/create sets, which subsumes the `Read`/`read` duplication and closes the casing-drift gap rather than patching one name.

## Metrics

Audit corpus: **790 real sessions**, production-like input, same compiler budget before and after.

| Metric | Before | After |
|---|---:|---:|
| Weighted recall (mean) | 63.6% | **74.5%** |
| Weighted recall (median) | 68.2% | **79.3%** |
| Weighted fact density | 6.00 | **7.08** |
| Summary size (mean chars) | 4,183 | 4,433 (+6%) |

Recall and density both rise while output grows only 6%.

Note on methodology: the audit's ground truth derives from the same extractor, so before/after recall is measured against a corrected reference. The reliable signal is that density rises alongside recall — the added content is fact-bearing, not filler.

## Changes

- `src/extract/files.ts` — case-insensitive tool matching; add `quick_edit`, `target_edit`, `apply_patch` to write tools; document why multi-file patch tools depend on `fileOps`.
- `src/core/build-sections.ts` — accept `fileOps` and forward it to `extractFiles`.
- `src/core/summarize.ts` — pass `CompileInput.fileOps` into `buildSections`.
- `src/core/settings.ts` — `overrideDefaultCompaction` defaults to `true`.
- `README.md`, `CHANGELOG.md` — document the new default; version 0.4.1.
- `tests/extract-files.test.ts` — lock case-insensitive matching, modern edit tools, `fileOps` seeding, and the new default.

## Verification

- `bun test`: 221 pass, 0 fail.
- Full audit re-run: 790/790 sessions, 0 errors.
- Spot-checked rendered summaries: sessions whose only activity was a `read` now report the file instead of producing an empty section.
