### PR TITLE
feat: add proactive compaction threshold support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { scaffoldSettings } from "./src/core/settings";
 import { registerBeforeCompactHook } from "./src/hooks/before-compact";
+import { registerProactiveThresholdHook } from "./src/hooks/proactive-threshold";
 import { registerPiVccCommand } from "./src/commands/pi-vcc";
 import { registerVccRecallCommand } from "./src/commands/vcc-recall";
 import { registerRecallTool } from "./src/tools/recall";
@@ -8,6 +9,7 @@ import { registerRecallTool } from "./src/tools/recall";
 export default (pi: ExtensionAPI) => {
   scaffoldSettings();
   registerBeforeCompactHook(pi);
+  registerProactiveThresholdHook(pi);
   registerPiVccCommand(pi);
   registerVccRecallCommand(pi);
   registerRecallTool(pi);

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -7,6 +7,35 @@ const settingsPath = (): string => process.env.PI_VCC_CONFIG_PATH ?? SETTINGS_PA
 /** Backwards-compat export. Resolves at access time, not import time. */
 export const SETTINGS_PATH = settingsPath();
 
+/** Per-model or global compaction threshold. */
+export interface ModelThreshold {
+  /**
+   * Tokens to reserve for LLM response. Overrides pi-core's
+   * compaction.reserveTokens for matching models.
+   *
+   * A higher value compacts earlier (more conservative); a lower value
+   * lets context grow larger before compacting.
+   *
+   * Takes precedence over compactAtTokens and compactPercent when multiple are set.
+   */
+  reserveTokens?: number;
+  /**
+   * Absolute context token count where compaction triggers.
+   *
+   * Useful when you want the same trigger point across models with
+   * different context windows. Ignored when reserveTokens is also set;
+   * takes precedence over compactPercent.
+   */
+  compactAtTokens?: number;
+  /**
+   * Compaction trigger as a percentage of context window (1–99).
+   * Compaction fires when: contextTokens > contextWindow × compactPercent / 100
+   *
+   * Ignored when reserveTokens or compactAtTokens is also set.
+   */
+  compactPercent?: number;
+}
+
 export interface PiVccSettings {
   /**
    * When true (default), pi-vcc handles ALL compactions:
@@ -36,6 +65,22 @@ export interface PiVccSettings {
    * Overflow retry is still owned by pi-core via willRetry.
    */
   continueAfterThresholdCompact: boolean;
+  /**
+   * Per-model compaction thresholds. Keys are matched against
+   * "provider/modelId" (e.g., "anthropic/claude-3-5-sonnet") or
+   * just "modelId" (e.g., "claude-3-5-sonnet").
+   *
+   * When a model matches, its threshold overrides pi-core's global
+   * compaction settings for the *when to compact* decision. This lets
+   * different models compact at different context fill levels.
+   */
+  modelThresholds?: Record<string, ModelThreshold>;
+  /**
+   * Global threshold applied to all models not matched by modelThresholds.
+   * Uses reserveTokens, compactAtTokens, or compactPercent. If omitted,
+   * pi-core's global compaction settings apply (no override).
+   */
+  globalThreshold?: ModelThreshold;
   /** Write debug snapshot to /tmp/pi-vcc-debug.json on each compaction. */
   debug: boolean;
 }
@@ -59,6 +104,67 @@ export function loadSettings(): PiVccSettings {
   const parsed = readJson(settingsPath());
   if (!parsed || typeof parsed !== "object") return { ...DEFAULT_SETTINGS };
   return { ...DEFAULT_SETTINGS, ...(parsed as Partial<PiVccSettings>) };
+}
+
+/**
+ * Resolve the effective ModelThreshold for a given model.
+ *
+ * Lookup order:
+ *  1. Exact match on "provider/modelId" key
+ *  2. Exact match on "modelId" key
+ *  3. globalThreshold from settings
+ *  4. undefined (no override — pi-core's global settings apply)
+ */
+export function getModelThreshold(
+  settings: PiVccSettings,
+  model: { id: string; provider?: string } | undefined,
+): ModelThreshold | undefined {
+  if (!model) return settings.globalThreshold;
+
+  const providerModelId = model.provider ? `${model.provider}/${model.id}` : undefined;
+
+  // Exact match on provider/modelId
+  if (providerModelId && settings.modelThresholds?.[providerModelId]) {
+    return settings.modelThresholds[providerModelId];
+  }
+
+  // Exact match on just modelId
+  if (settings.modelThresholds?.[model.id]) {
+    return settings.modelThresholds[model.id];
+  }
+
+  return settings.globalThreshold;
+}
+
+/**
+ * Resolve the context token count where compaction should trigger.
+ *
+ * Precedence: reserveTokens > compactAtTokens > compactPercent.
+ * Returns undefined when the threshold cannot produce a usable trigger.
+ */
+export function resolveTriggerTokens(
+  threshold: ModelThreshold,
+  contextWindow: number,
+): number | undefined {
+  if (contextWindow <= 0) return undefined;
+
+  if (threshold.reserveTokens != null) {
+    return contextWindow - threshold.reserveTokens;
+  }
+
+  if (threshold.compactAtTokens != null) {
+    const tokens = threshold.compactAtTokens;
+    if (!Number.isFinite(tokens) || tokens < 1) return undefined;
+    return Math.round(tokens);
+  }
+
+  if (threshold.compactPercent != null) {
+    const pct = threshold.compactPercent;
+    if (pct < 1 || pct > 99) return undefined;
+    return Math.round(contextWindow * (1 - pct / 100));
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -7,6 +7,7 @@ import { loadSettings, type PiVccSettings } from "../core/settings";
 import { calibrateCharsPerToken, estimateMessageContentChars, estimateTokensFromChars } from "../core/token-estimate";
 import type { PiVccCompactionDetails } from "../details";
 import type { CompactionReason } from "../types";
+import { isProactiveTriggerActive } from "./proactive-threshold";
 
 export { PI_VCC_COMPACT_INSTRUCTION } from "../core/compact-args";
 
@@ -29,6 +30,7 @@ export interface CompactionStats {
 
 let lastStats: CompactionStats | null = null;
 let lastCompactWasPiVcc = false;
+let lastCompactWasProactive = false;
 let pendingFollowUpPrompt: string | null = null;
 const AUTO_CONTINUE_CUSTOM_TYPE = "pi-vcc-auto-continue";
 const AUTO_CONTINUE_PROMPT = "Continue from where you left off after automatic context compaction. Do not restate the compaction summary; proceed with the task.";
@@ -559,6 +561,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     };
 
     lastCompactWasPiVcc = isPiVcc;
+    lastCompactWasProactive = isProactiveTriggerActive();
 
     return {
       compaction: {
@@ -581,7 +584,10 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     if (willRetry) return;
     const stats = lastStats;
     if (!stats) return;
-    const shouldContinueAfterAutoCompact = (reason === "threshold" || reason === "overflow") && loadSettings().continueAfterThresholdCompact;
+    const shouldContinueAfterAutoCompact =
+      lastCompactWasProactive ||
+      ((reason === "threshold" || reason === "overflow") && loadSettings().continueAfterThresholdCompact);
+    lastCompactWasProactive = false;
     scheduleCompactionStatsNotify(ctx, stats);
     if (followUpPrompt) {
       try {

--- a/src/hooks/proactive-threshold.ts
+++ b/src/hooks/proactive-threshold.ts
@@ -1,0 +1,110 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { loadSettings, getModelThreshold, resolveTriggerTokens } from "../core/settings";
+
+type ProactiveContext = {
+  model?: any;
+  getContextUsage?: () => any;
+  compact?: (options?: any) => void;
+  ui?: any;
+};
+
+const formatTokens = (n: number): string => {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+};
+
+// Cooldown after compaction to prevent double-trigger.
+let lastCompactTime = 0;
+const COOLDOWN_MS = 3000;
+
+// Flag: when true, session_before_compact knows we initiated this compaction
+let proactiveTriggerActive = false;
+
+const setCooldown = () => { lastCompactTime = Date.now(); };
+const isCoolingDown = () => Date.now() - lastCompactTime < COOLDOWN_MS;
+
+/** Check if a proactive trigger is currently in flight. */
+export const isProactiveTriggerActive = () => proactiveTriggerActive;
+
+/** Reset all proactive state (for testing / session start). */
+export const resetProactiveState = () => {
+  lastCompactTime = 0;
+  proactiveTriggerActive = false;
+};
+
+/**
+ * Check if a configured threshold has been crossed and trigger compaction
+ * if so. Safe to call from multiple event handlers — cooldown prevents
+ * double-triggering.
+ */
+const checkAndTrigger = (ctx: ProactiveContext, source: string) => {
+  const settings = loadSettings();
+  const threshold = getModelThreshold(settings, ctx.model);
+
+  // No threshold → nothing to do (pi-core's global threshold owns it)
+  if (!threshold) return;
+
+  const contextWindow = ctx.model?.contextWindow ?? 0;
+  const effectiveThreshold = resolveTriggerTokens(threshold, contextWindow);
+  if (effectiveThreshold == null) return;
+
+  const usage = ctx.getContextUsage?.();
+  if (!usage || usage.tokens === null) return;
+
+  // Only trigger if context EXCEEDS the threshold.
+  if (usage.tokens <= effectiveThreshold) return;
+
+  // Cooldown guard — prevent double-trigger within 3s of last compaction.
+  if (isCoolingDown()) return;
+
+  try {
+    const pct = Math.round((usage.tokens / contextWindow) * 100);
+    ctx?.ui?.notify?.(
+      `pi-vcc: [${source}] Context at ${pct}% exceeds threshold (${formatTokens(effectiveThreshold)} tok). Compacting...`,
+      "info",
+    );
+  } catch {}
+
+  // Set cooldown IMMEDIATELY to prevent pi-core from also triggering
+  setCooldown();
+
+  // Mark that this compaction was triggered by us
+  proactiveTriggerActive = true;
+
+  ctx.compact?.();
+};
+
+/**
+ * Registers proactive configured compaction thresholds.
+ *
+ * Triggers:
+ *
+ * 1. `agent_end` — after each agent run completes, check if context
+ *    exceeds the active configured threshold.
+ *
+ * 2. `model_select` — when switching models, the new model may have a
+ *    different threshold. Check immediately.
+ *
+ * 3. `session_compact` — cooldown tracking + clear proactiveTriggerActive.
+ */
+export const registerProactiveThresholdHook = (pi: ExtensionAPI) => {
+  pi.on("agent_end", (_event, ctx) => {
+    checkAndTrigger(ctx, "auto");
+  });
+
+  pi.on("model_select", (_event, ctx) => {
+    checkAndTrigger(ctx, "model-switch");
+  });
+
+  // Track compaction completion: set cooldown and clear self-initiated flag
+  pi.on("session_compact", () => {
+    setCooldown();
+    proactiveTriggerActive = false;
+  });
+
+  // Reset state on session start so state doesn't leak between sessions
+  pi.on("session_start", () => {
+    lastCompactTime = 0;
+    proactiveTriggerActive = false;
+  });
+};


### PR DESCRIPTION
## Summary

This PR adds proactive compaction threshold support to pi-vcc, allowing it to trigger compaction earlier than pi-core's default threshold.

### Changes

- **New `ModelThreshold` interface** with three threshold modes:
  - `reserveTokens` — tokens to reserve for LLM response (overrides pi-core's setting)
  - `compactAtTokens` — absolute token count where compaction triggers
  - `compactPercent` — percentage of context window (1-99)

- **New settings fields**:
  - `modelThresholds` — per-model thresholds keyed by `provider/modelId` or `modelId`
  - `globalThreshold` — fallback threshold for all models

- **New `proactive-threshold.ts` hook** that:
  - Monitors context usage after each agent run (`agent_end`)
  - Triggers compaction when context exceeds the configured threshold
  - Handles model switches (`model_select`) for threshold changes
  - Uses cooldown to prevent double-triggering

- **Updated `session_compact` handler** to always continue after proactive compaction

### Usage

Add to `~/.pi/agent/pi-vcc-config.json`:

```json
{
  "globalThreshold": {
    "compactAtTokens": 128000
  }
}
```

Or per-model:

```json
{
  "modelThresholds": {
    "anthropic/claude-3-5-sonnet": {
      "compactAtTokens": 150000
    },
    "openai/gpt-4": {
      "reserveTokens": 32000
    }
  }
}
```

### Why This Matters

Pi-core triggers compaction at `contextWindow - reserveTokens` (default: ~184k tokens for a 200k window). This leaves a narrow buffer before overflow. With proactive thresholds, pi-vcc can trigger earlier (e.g., 128k tokens), giving a 72k-token safety buffer.

This is especially important for models with smaller context windows or when using tools that return large outputs.