### PR TITLE
v0.6.0: autonomous-session tail fixes, recall touched mode, invisible auto-continue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to `@sting8k/pi-vcc` are documented in this file.
 
+## [0.6.0]
+
+### Features
+
+- **Recall `mode:"touched"` — file activity index** — answers the question agents actually ask after a compaction ("did I already edit this file, and what did I do?"). One call returns every file touched in the session mapped to the entries that touched it (`./src/core/config-manager.ts    #155 (quick_edit), #157 (edit)`), sorted by recency and paged. Classification is shape-based (a call counts when its arguments carry a path plus `content`/`edits`/`oldText`/`newText`), so custom edit tools are recognised without a tool-name allowlist and reads never pollute the index. Indices are the same global message indices `expand` uses. Ported from [pi-blackhole](https://github.com/k0valik/pi-blackhole).
+- **Recall `#N:path` drill-down** — expands the file-scoped content of a single operation inside an entry (`#155:config-manager`, `:full`, or `:offset:limit` for long files), instead of the summarised `quick_edit(path=…)` line `expand` used to return. `#N` alone lists the file operations in that entry. The pattern is anchored, so an inline mention such as "see #42:auth.ts" is still an ordinary search. Ported from [pi-blackhole](https://github.com/k0valik/pi-blackhole).
+
+### Changes
+
+- **Invisible auto-continue** — the prompt sent after a compaction is now a custom message with empty content delivered as a follow-up (`triggerTurn`, `deliverAs:"followUp"`) and filtered out of the LLM payload by a `context` hook, instead of a user-role prompt that stayed in context for the rest of the session. Same gating, same timing, no per-compaction context cost. Pattern ported from [monotykamary/pi-vcc](https://github.com/monotykamary/pi-vcc) (`tom` branch).
+- **Compaction toast reports tail tokens on budget cuts** — a budget cut keeps no whole user turn, so the old line read `kept 0/1 turns` and looked like everything was lost. It now leads with what is actually kept: `kept ~18.2k tok tail (mid-turn cut, no user anchor), summarized 42`. Turn-anchored cuts are unchanged.
+
+### Fixes
+
+- **Compaction: token-budget tail cut for autonomous sessions** — the tail was anchored exclusively to user-message boundaries, which breaks when a session has one user prompt and then runs on its own. With no boundary to keep, the hook fell back to compacting everything (`firstKeptEntryId` empty), orphan recovery rebuilt a window whose only user message was again at index 0, and every subsequent compaction repeated it: the working tail was lost every time, for the rest of the run. Measured on 755 real sessions, 21.7% hit this path. The default path now falls back to a token budget, cutting at the nearest non-`toolResult` boundary (never inside a `toolCall`/`toolResult` pair), mirroring pi core's `findCutPoint` semantics. The mirror case is handled too: a tail larger than 62.5k tokens (2.5x the 25k budget) is re-cut to roughly the budget, so a compaction that used to free almost nothing now does. Explicit `keep:N` is respected absolutely and is never re-cut. Audit on the same corpus: 43 of 43 rescuable sessions keep a tail (median 21.7k tokens) instead of none, 16 of 17 oversized tails drop from a median 73k to 20k tokens, and weighted fact recall for the rescued group rises 0.558 → 0.909. The 682 unaffected sessions are bit-identical.
+- **Compaction: `custom_message` and `branch_summary` reached the summariser** — the live window only collected `type: "message"` entries, so anything an extension injected through `sendMessage` (including pi-vcc's own auto-continue) was invisible: not counted, and never passed to the summariser, so its content disappeared silently at every compaction. Both entry types are now converted to their message form in the live window, matching pi core, which treats them as user-role messages. Turn counting still counts only real user messages, so `keep:N` anchoring is unchanged.
+- **Recall: `#N:path` drill-down honours `scope`** — the drill-down branch dispatched before scope resolution and read the session unfiltered, making it the one recall path that could return entries from abandoned branches without `scope:"all"`. The target entry is now checked against the active lineage by global index; `expandEntryFile` still loads unfiltered so `#N` stays aligned with the global message index. The same issue exists upstream in pi-blackhole and has been reported there.
+
+Known trade-off: when an oversized tail is re-cut, facts that live in `toolResult` blocks cannot be expressed in the brief (ranking skips those blocks), so that group loses a median 0.049 weighted recall in exchange for freeing ~50k tokens per session. Raising the brief ceiling and block budget was tested and made no difference; a dedicated failures section is the actual fix and is planned. Known limit: a single message at or above the budget cannot be cut around (1 of 755 sessions).
+
 ## [0.5.0]
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ Local benchmarks / research comparing the ranked brief against the shipped pi-vc
 - [VCC](https://github.com/lllyasviel/VCC) — the original transcript-preserving conversation compiler
 - [Pi](https://github.com/badlogic/pi-mono) — the AI coding agent this extension is built for
 
+## Acknowledgments
+
+- Recall `mode:"touched"` + `#N:path` drill-down ported from
+  [pi-blackhole](https://github.com/k0valik/pi-blackhole) by [@k0valik](https://github.com/k0valik),
+  who also suggested the feature.
+- Invisible auto-continue pattern ported from
+  [monotykamary/pi-vcc](https://github.com/monotykamary/pi-vcc) (`tom` branch) by [@monotykamary](https://github.com/monotykamary).
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sting8k/pi-vcc",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Algorithmic conversation compactor for pi - transcript-preserving structured summaries, no LLM calls",
   "main": "index.ts",
   "keywords": [

--- a/src/core/content.ts
+++ b/src/core/content.ts
@@ -1,4 +1,5 @@
 import type { Message } from "@earendil-works/pi-ai";
+import { PATH_KEYS } from "./tool-args";
 
 export const clip = (text: string, max = 200): string => {
   if (text.length <= max) return text;
@@ -47,6 +48,71 @@ export const textParts = (content: Message["content"]): string[] => {
 
 export const textOf = (content: Message["content"]): string =>
   textParts(content).join("\n");
+
+/**
+ * Check if tool call arguments contain content-bearing data.
+ *
+ * A call is content-bearing if it has a path argument AND at least one
+ * large string/array field (content, edits, oldText, newText).
+ * This is a generic heuristic — not dependent on tool names.
+ *
+ * Ported from pi-blackhole (https://github.com/k0valik/pi-blackhole, MIT) by
+ * k0valik — a pi-vcc derivative.
+ */
+export const isContentBearing = (args: Record<string, unknown>): boolean => {
+  if (!args || typeof args !== "object") return false;
+  // Must have a path in one of the known keys
+  const hasPath = PATH_KEYS.some((k) => typeof args[k] === "string");
+  if (!hasPath) return false;
+  // Must have at least one content-bearing field
+  if (typeof args.content === "string" && args.content.length > 0) return true;
+  // edits must be a non-empty array of objects (each with oldText/newText)
+  if (
+    Array.isArray(args.edits) &&
+    args.edits.length > 0 &&
+    args.edits.every((e) => typeof e === "object" && e !== null)
+  )
+    return true;
+  // oldText/newText without edits are content-bearing
+  if (
+    typeof args.oldText === "string" &&
+    args.oldText.length > 0 &&
+    args.edits === undefined
+  )
+    return true;
+  if (
+    typeof args.newText === "string" &&
+    args.newText.length > 0 &&
+    args.edits === undefined
+  )
+    return true;
+  return false;
+};
+
+/**
+ * Extract textual content from tool call arguments (content, edits,
+ * oldText, newText). Used for counting touched-file lines and search.
+ *
+ * Ported from pi-blackhole (https://github.com/k0valik/pi-blackhole, MIT) by
+ * k0valik — a pi-vcc derivative.
+ */
+export const extractToolCallText = (args: Record<string, unknown>): string => {
+  let text = "";
+  if (typeof args.content === "string") text += args.content + "\n";
+  if (Array.isArray(args.edits)) {
+    for (const edit of args.edits) {
+      if (edit && typeof edit === "object") {
+        if (typeof edit.oldText === "string") text += edit.oldText + "\n";
+        if (typeof edit.newText === "string") text += edit.newText + "\n";
+      }
+    }
+  }
+  if (typeof args.oldText === "string" && !Array.isArray(args.edits))
+    text += args.oldText + "\n";
+  if (typeof args.newText === "string" && !Array.isArray(args.edits))
+    text += args.newText + "\n";
+  return text;
+};
 
 /** Extract a snippet of ~`radius` chars around the first match of `term` in `text`. */
 export const snippet = (text: string, term: string, radius = 60): string | null => {

--- a/src/core/drill-down.ts
+++ b/src/core/drill-down.ts
@@ -1,0 +1,298 @@
+/**
+ * Drill-down: resolve #N:path syntax to tool call file content.
+ *
+ * Ported from pi-blackhole (https://github.com/k0valik/pi-blackhole, MIT) by
+ * k0valik — a pi-vcc derivative.
+ *
+ * Supports: #42:auth.ts (preview), #42:auth.ts:full (full content), #42:file (auto-select).
+ *
+ * Path matching notes:
+ * - The regex uses $ anchor so lazy .+? consumes the full path — spaces, dots, and
+ *   Windows drive-letter colons (C:\) all work correctly.
+ * - One edge case: a file path literally ending in ":full" (e.g. C:\file:full)
+ *   would be misinterpreted as the :full flag. This is extremely unlikely.
+ * - Inline queries like "check #42:auth.ts" are NOT drill-down — the ^ anchor
+ *   requires the entire query to be the drill-down pattern.
+ */
+import { isContentBearing } from "./content";
+import { extractPath } from "./tool-args";
+import { loadAllMessages } from "./load-messages";
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+interface ContentBearingCall {
+  name: string;
+  path: string;
+  content?: string;
+  oldText?: string;
+  newText?: string;
+  edits?: Array<{ oldText?: string; newText?: string }>;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Find content-bearing tool calls that have a `path` argument and at least
+ * one content field (content, edits, oldText, newText).
+ * Uses the shared isContentBearing() heuristic from content.ts.
+ */
+function findContentBearingCalls(content: unknown[]): ContentBearingCall[] {
+  if (!Array.isArray(content)) return [];
+  const results: ContentBearingCall[] = [];
+  for (const part of content) {
+    if (!part || (part as any).type !== "toolCall") continue;
+    const args = (part as any).arguments ?? {};
+    if (!isContentBearing(args)) continue;
+    const path = extractPath(args);
+    if (!path) continue;
+    const entry: ContentBearingCall = { name: (part as any).name ?? "", path };
+    if (typeof args.content === "string") entry.content = args.content;
+    if (Array.isArray(args.edits)) {
+      entry.edits = args.edits.filter(
+        (e: unknown): e is { oldText?: string; newText?: string } =>
+          e !== null && typeof e === "object",
+      );
+    }
+    if (typeof args.oldText === "string" && !Array.isArray(args.edits))
+      entry.oldText = args.oldText;
+    if (typeof args.newText === "string" && !Array.isArray(args.edits))
+      entry.newText = args.newText;
+    results.push(entry);
+  }
+  return results;
+}
+
+/** Format content for display with optional offset/limit slicing.
+ *
+ * When full=true, shows everything ignoring offset/limit.
+ * When offset/limit given, shows a window with "Lines X-Y (of Z)" header.
+ * When neither, shows preview (first 30 lines) with truncation hint.
+ */
+function formatToolCallContent(
+  tc: ContentBearingCall,
+  entryIndex: number,
+  options?: { full?: boolean; offset?: number; limit?: number },
+): string {
+  let body: string;
+  if (tc.content) {
+    body = tc.content;
+  } else if (tc.edits) {
+    body = tc.edits
+      .map(
+        (e, i) =>
+          `--- edit ${i + 1} ---\n${e.oldText ?? ""}\n--- becomes ---\n${e.newText ?? ""}`,
+      )
+      .join("\n\n");
+  } else if (tc.oldText && tc.newText) {
+    body = `--- old ---\n${tc.oldText}\n--- new ---\n${tc.newText}`;
+  } else {
+    body = "(no file content found in tool call arguments)";
+  }
+
+  const full = options?.full ?? false;
+  const offset = options?.offset;
+  const limit = options?.limit;
+  const allLines = body.split("\n");
+  const totalLines = allLines.length;
+  const previewLimit = 30;
+  const MAX_FULL_BYTES = 50 * 1024;
+
+  if (full) {
+    // Full content: capped at 50KB
+    if (Buffer.byteLength(body, "utf8") > MAX_FULL_BYTES) {
+      const truncated = body.slice(0, MAX_FULL_BYTES);
+      return `File: ${tc.path}
+Tool: ${tc.name}
+
+${truncated}
+
+... (${Buffer.byteLength(body, "utf8") - MAX_FULL_BYTES} more bytes — file exceeds 50KB display limit. Use #${entryIndex}:${tc.path}:${previewLimit} for next page.)`;
+    }
+    return `File: ${tc.path}
+Tool: ${tc.name}
+
+${body}`;
+  }
+
+  if (offset !== undefined) {
+    // Offset-based window: show slice
+    const startLine = Math.max(0, offset);
+    const maxLines = limit ?? 30;
+    const endLine = Math.min(startLine + maxLines, totalLines);
+    const visible = allLines.slice(startLine, endLine);
+    const displayStart = startLine + 1; // 1-indexed for user display
+
+    if (visible.length === 0) {
+      return `Offset ${startLine} is beyond file length ${totalLines}. Use #${entryIndex}:${tc.path} for the first ${previewLimit} lines.`;
+    }
+
+    let result = `File: ${tc.path}
+Tool: ${tc.name}
+Lines ${displayStart}-${endLine} (of ${totalLines}):
+
+`;
+    result += visible.join("\n");
+
+    if (endLine < totalLines) {
+      result += `\n\n--- Use #${entryIndex}:${tc.path}:${endLine} or #${entryIndex}:${tc.path}:${endLine}:${maxLines} for next ${maxLines} lines, #${entryIndex}:${tc.path}:full for complete ---`;
+    } else if (offset > 0) {
+      result += `\n\n(End of file)`;
+    }
+
+    return result;
+  }
+
+  // Default preview mode: first ${previewLimit} lines
+  if (totalLines > previewLimit) {
+    const preview = allLines.slice(0, previewLimit).join("\n");
+    return `File: ${tc.path}
+Tool: ${tc.name}
+
+${preview}
+
+...(${totalLines - previewLimit} more lines — use #${entryIndex}:${tc.path}:full for complete content, or #${entryIndex}:${tc.path}:${previewLimit} for next ${previewLimit} lines)`;
+  }
+
+  return `File: ${tc.path}
+Tool: ${tc.name}
+
+${body}`;
+}
+
+// ── Parse drill-down query ────────────────────────────────────────────────
+
+/**
+ * Pattern: #N:path, #N:path:full, #N:path:offset, or #N:path:offset:limit
+ * Group 1: index number
+ * Group 2: path (consumed lazily, expanded until suffix can match)
+ * Group 3: suffix — "full", a number (offset), or "offset:limit"
+ */
+const DRILLDOWN_PATTERN = /^#(\d+):(.+?)(?::(full|\d+(?::\d+)?))?$/;
+
+/**
+ * Parse a drill-down query like #42:auth.ts or #42:auth.ts:full.
+ * Returns null if the query doesn't match the drill-down pattern.
+ *
+ * Suffixes:
+ *   :full       → full content (no truncation)
+ *   :30         → offset 30 lines, default limit (30)
+ *   :30:20      → offset 30 lines, limit 20 lines
+ *   (none)      → preview first 30 lines
+ */
+export function parseDrillDown(query: string): {
+  index: number;
+  pathPattern: string;
+  full: boolean;
+  offset?: number;
+  limit?: number;
+} | null {
+  const match = query.match(DRILLDOWN_PATTERN);
+  if (!match) return null;
+  const index = parseInt(match[1], 10);
+  const pathPattern = match[2];
+  const suffix = match[3];
+
+  if (suffix === "full") {
+    return {
+      index,
+      pathPattern,
+      full: true,
+      offset: undefined,
+      limit: undefined,
+    };
+  }
+
+  if (suffix !== undefined) {
+    // Parse "offset" or "offset:limit"
+    const parts = suffix.split(":");
+    const offset = parseInt(parts[0], 10);
+    const limit = parts[1] !== undefined ? parseInt(parts[1], 10) : undefined;
+    if (!Number.isNaN(offset)) {
+      return { index, pathPattern, full: false, offset, limit };
+    }
+  }
+
+  return {
+    index,
+    pathPattern,
+    full: false,
+    offset: undefined,
+    limit: undefined,
+  };
+}
+
+// ── Main export ───────────────────────────────────────────────────────────
+
+/**
+ * Expand a drill-down query (#N:path) to tool call content.
+ *
+ * Offset/limit let you page through file content incrementally (like pi's read tool):
+ *   #42:auth.ts         → first 30 lines (preview)
+ *   #42:auth.ts:full    → all content
+ *   #42:auth.ts:30      → lines 31-60 (default limit 30)
+ *   #42:auth.ts:30:20   → lines 31-50 (custom limit 20)
+ *
+ * @param sessionFile - Path to the JSONL session file
+ * @param entryIndex - The message index (#N)
+ * @param pathPattern - File path substring to match (or "file" keyword)
+ * @param full - If true, return complete content without truncation
+ * @param offset - Line offset (0-indexed) for windowed content
+ * @param limit - Max lines to show (default 30 for windowed, ignored if full=true)
+ * @returns Formatted content string
+ */
+export function expandEntryFile(
+  sessionFile: string,
+  entryIndex: number,
+  pathPattern: string,
+  full = false,
+  offset?: number,
+  limit?: number,
+): string {
+  const { rawMessages } = loadAllMessages(sessionFile, true);
+
+  if (entryIndex < 0 || entryIndex >= rawMessages.length) {
+    return `Entry #${entryIndex} not found in session history.`;
+  }
+
+  const msg = rawMessages[entryIndex];
+  const content = msg.content as unknown[];
+  const calls = findContentBearingCalls(content);
+
+  // Special case: #42:file keyword
+  if (pathPattern === "file") {
+    if (calls.length === 0) {
+      return `No file content found in entry #${entryIndex}.`;
+    }
+    if (calls.length === 1) {
+      return formatToolCallContent(calls[0], entryIndex, {
+        full,
+        offset,
+        limit,
+      });
+    }
+    // Multiple content-bearing calls — list them
+    const items = calls.map(
+      (tc) => `  [#${entryIndex}:${tc.path}] ${tc.name}(${tc.path})`,
+    );
+    return `Entry #${entryIndex} has ${calls.length} file operations:\n${items.join("\n")}\n\nUse #${entryIndex}:path to drill into a specific file.`;
+  }
+
+  const matched = calls.filter((tc) => tc.path.includes(pathPattern));
+
+  if (matched.length === 0) {
+    return `No file content found in entry #${entryIndex} for "${pathPattern}".`;
+  }
+
+  if (matched.length > 1) {
+    // Ambiguous match — list options instead of silently picking the first
+    const items = matched.map(
+      (tc) => `  [#${entryIndex}:${tc.path}] ${tc.name}(${tc.path})`,
+    );
+    return `Entry #${entryIndex} has ${matched.length} file operations matching "${pathPattern}":
+${items.join("\n")}
+
+Use #${entryIndex}:<more-specific-path> to drill into a specific file.`;
+  }
+
+  return formatToolCallContent(matched[0], entryIndex, { full, offset, limit });
+}

--- a/src/core/format-recall.ts
+++ b/src/core/format-recall.ts
@@ -1,4 +1,77 @@
-import type { SearchHit } from "./search-entries";
+import type { SearchHit, TouchedFile } from "./search-entries";
+
+// ── Path shortening ───────────────────────────────────────────────────────
+
+const CWD = process.cwd();
+
+/**
+ * Shorten an absolute file path for display:
+ * - If within cwd, return `./relative/path`
+ * - Otherwise, show last 3 path components with `.../` prefix
+ * - Short paths (≤3 components) returned as-is
+ *
+ * Ported from pi-blackhole (https://github.com/k0valik/pi-blackhole, MIT) by
+ * k0valik — a pi-vcc derivative.
+ */
+export function shortPath(fullPath: string): string {
+  const normalized = fullPath.replace(/\\/g, "/");
+  const cwdNormalized = CWD.replace(/\\/g, "/");
+  if (normalized.startsWith(cwdNormalized + "/")) {
+    return "." + normalized.slice(cwdNormalized.length);
+  }
+  const parts = normalized.split("/");
+  if (parts.length > 3) {
+    return ".../" + parts.slice(-3).join("/");
+  }
+  return normalized;
+}
+
+// ── Touched file output ───────────────────────────────────────────────────
+
+export const TOUCHED_PAGE_SIZE = 5;
+
+/**
+ * Format aggregated "files touched" output.
+ *
+ * Ported from pi-blackhole (https://github.com/k0valik/pi-blackhole, MIT) by
+ * k0valik — a pi-vcc derivative.
+ */
+export function formatTouchedOutput(
+  touched: TouchedFile[],
+  page?: number,
+  pageSize?: number,
+): string {
+  if (touched.length === 0) {
+    return "No file operations found in session history.";
+  }
+
+  const ps = pageSize ?? TOUCHED_PAGE_SIZE;
+  const totalPages = Math.ceil(touched.length / ps);
+  const currentPage = Math.max(1, page ?? 1);
+  const start = (currentPage - 1) * ps;
+  const pageFiles = touched.slice(start, start + ps);
+
+  const header =
+    totalPages > 1
+      ? `Page ${currentPage}/${totalPages} (${touched.length} total files)`
+      : `${touched.length} files touched`;
+
+  const lines = pageFiles.map((tf) => {
+    const displayPath = shortPath(tf.path);
+    const indices = tf.entries
+      .map((e) => `#${e.index} (${e.toolName})`)
+      .join(", ");
+    return `  ${displayPath}    ${indices}`;
+  });
+
+  let result = `${header}:\n\n${lines.join("\n")}`;
+
+  if (currentPage < totalPages) {
+    result += `\n\n--- Use page:${currentPage + 1} for more results ---`;
+  }
+
+  return result;
+}
 
 export const formatRecallOutput = (
   entries: SearchHit[],

--- a/src/core/recall-scope.ts
+++ b/src/core/recall-scope.ts
@@ -1,9 +1,25 @@
 export type RecallScope = "lineage" | "all";
+export type RecallMode = "hybrid" | "touched";
 
 const SCOPE_RE = /\bscope:(lineage|all)\b/i;
 
+const VALID_MODES = new Set(["hybrid", "touched"]);
+
 export const normalizeRecallScope = (scope?: unknown): RecallScope =>
   typeof scope === "string" && scope.toLowerCase() === "all" ? "all" : "lineage";
+
+/**
+ * Normalize a mode param to a supported recall mode. Without OM integration,
+ * only "touched" adds behavior beyond the default hybrid search — "file"-only
+ * search is not implemented in pi-vcc, so it is not exposed.
+ *
+ * Ported from pi-blackhole (https://github.com/k0valik/pi-blackhole, MIT) by
+ * k0valik — a pi-vcc derivative.
+ */
+export const normalizeRecallMode = (mode?: unknown): RecallMode =>
+  typeof mode === "string" && VALID_MODES.has(mode.toLowerCase())
+    ? (mode.toLowerCase() as RecallMode)
+    : "hybrid";
 
 export const parseRecallScope = (text: string): { scope: RecallScope; text: string } => {
   const match = text.match(SCOPE_RE);

--- a/src/core/search-entries.ts
+++ b/src/core/search-entries.ts
@@ -1,6 +1,6 @@
 import type { Message } from "@earendil-works/pi-ai";
 import type { RenderedEntry } from "./render-entries";
-import { textOf } from "./content";
+import { textOf, isContentBearing, extractToolCallText } from "./content";
 
 export interface SearchHit extends RenderedEntry {
   /** Context snippet around the first matched term (only when query provided) */
@@ -8,7 +8,17 @@ export interface SearchHit extends RenderedEntry {
   /** Number of query terms matched (for ranking) */
   matchCount?: number;
 }
+/** A file touched in one entry — used by mode:touched aggregation. */
+export interface FileTouch {
+  index: number;
+  toolName: string;
+}
 
+/** Aggregated view of a file touched across multiple entries. */
+export interface TouchedFile {
+  path: string;
+  entries: FileTouch[];
+}
 const escapeRegex = (s: string): string =>
   s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -219,6 +229,59 @@ const fullText = (msg: Message): string => {
   }
   return textOf(msg.content);
 };
+
+/**
+ * Compute file indicators from a message, counting non-empty content lines
+ * per content-bearing file call. Shape-based — no tool-name allowlist.
+ *
+ * Ported from pi-blackhole (https://github.com/k0valik/pi-blackhole, MIT) by
+ * k0valik — a pi-vcc derivative.
+ */
+export function getFileIndicators(msg: Message): { toolName: string; path: string; lineCount: number }[] {
+  if (!msg?.content || typeof msg.content === "string") return [];
+  const indicators: { toolName: string; path: string; lineCount: number }[] = [];
+  for (const part of msg.content) {
+    if (!part || typeof part !== "object" || part.type !== "toolCall") continue;
+    const args = part.arguments as Record<string, unknown>;
+    if (!isContentBearing(args)) continue;
+    const path = ["path", "filePath", "file_path", "file"]
+      .map((k) => args[k])
+      .find((v): v is string => typeof v === "string")!;
+    const totalText = extractToolCallText(args);
+    const nonEmpty = totalText.split("\n").filter((l) => l.trim().length > 0);
+    indicators.push({
+      toolName: part.name || "",
+      path,
+      lineCount: nonEmpty.length,
+    });
+  }
+  return indicators;
+}
+
+/**
+ * Aggregate file operations across all entries for mode:touched.
+ *
+ * Ported from pi-blackhole (https://github.com/k0valik/pi-blackhole, MIT) by
+ * k0valik — a pi-vcc derivative.
+ */
+export function getTouchedFiles(
+  messages: Message[],
+  rendered: RenderedEntry[],
+): TouchedFile[] {
+  const map = new Map<string, TouchedFile>();
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    const indicators = getFileIndicators(msg);
+    for (const fm of indicators) {
+      const index = rendered[i]?.index ?? i;
+      if (!map.has(fm.path)) {
+        map.set(fm.path, { path: fm.path, entries: [] });
+      }
+      (map.get(fm.path) as TouchedFile).entries.push({ index, toolName: fm.toolName });
+    }
+  }
+  return Array.from(map.values());
+}
 
 export const searchEntries = (
   entries: RenderedEntry[],

--- a/src/core/tool-args.ts
+++ b/src/core/tool-args.ts
@@ -1,3 +1,5 @@
+export const PATH_KEYS = ["path", "file_path", "filePath", "file"] as const;
+
 export const extractPath = (args: Record<string, unknown>): string | null => {
   for (const key of ["path", "file_path", "filePath", "file"]) {
     if (typeof args[key] === "string") return args[key] as string;

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -163,6 +163,33 @@ interface EntryWithMessage {
   message: { role: string; content: unknown };
 }
 
+// Convert a non-message entry that carries LLM-context text (custom_message /
+// branch_summary) into its agent-message form, mirroring pi-core's
+// createCustomMessage / createBranchSummaryMessage (not root-exported, so inlined).
+const toLiveMessage = (entry: any): { role: string; content: unknown; [key: string]: unknown } | null => {
+  if (entry.type === "message" && entry.message) return entry.message;
+  if (entry.type === "custom_message") {
+    return {
+      role: "custom",
+      customType: entry.customType,
+      content: entry.content,
+      display: entry.display,
+      details: entry.details,
+      timestamp: entry.timestamp != null ? new Date(entry.timestamp).getTime() : undefined,
+    };
+  }
+  if (entry.type === "branch_summary") {
+    return {
+      role: "branchSummary",
+      summary: entry.summary,
+      fromId: entry.fromId,
+      content: undefined,
+      timestamp: entry.timestamp != null ? new Date(entry.timestamp).getTime() : undefined,
+    };
+  }
+  return null;
+};
+
 export type OwnCutCancelReason =
   | "no_live_messages"
   | "too_few_live_messages";
@@ -206,9 +233,8 @@ const collectLiveMessages = (branchEntries: any[]): EntryWithMessage[] => {
     for (let i = lastCompactionIdx + 1; i < branchEntries.length; i++) {
       const e = branchEntries[i];
       if (e.type === "compaction") continue;
-      if (e.type === "message" && e.message) {
-        liveMessages.push({ entry: e, message: e.message });
-      }
+      const m = toLiveMessage(e);
+      if (m) liveMessages.push({ entry: e, message: m });
     }
   } else {
     let foundKept = !lastKeptId; // if no prior compaction, start collecting immediately
@@ -216,9 +242,8 @@ const collectLiveMessages = (branchEntries: any[]): EntryWithMessage[] => {
       if (!foundKept && e.id === lastKeptId) foundKept = true;
       if (!foundKept) continue;
       if (e.type === "compaction") continue;
-      if (e.type === "message" && e.message) {
-        liveMessages.push({ entry: e, message: e.message });
-      }
+      const m = toLiveMessage(e);
+      if (m) liveMessages.push({ entry: e, message: m });
     }
   }
   return liveMessages;

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -68,15 +68,13 @@ const formatTokens = (n: number): string => {
 };
 
 export const formatCompactionStats = (stats: CompactionStats): string => {
+  if (stats.budgetCut) {
+    const reason = stats.budgetCut === "no_anchor" ? "no user anchor" : "oversized tail";
+    return `pi-vcc: kept ~${formatTokens(stats.keptTokensEst)} tok tail (mid-turn cut, ${reason}), summarized ${stats.summarized}.`;
+  }
   const notes: string[] = [`summarized ${stats.summarized}`];
   if (stats.smartKeepAdjusted) {
     notes.push("smart-keep");
-  }
-  if (stats.budgetCut === "no_anchor") {
-    notes.push("budget cut: no user anchor");
-  }
-  if (stats.budgetCut === "oversized_tail") {
-    notes.push("budget cut: oversized tail");
   }
   return `pi-vcc: kept ${stats.keptUserTurns}/${stats.totalUserTurns} turns, ~${formatTokens(stats.keptTokensEst)} tok (${notes.join(", ")}).`;
 };

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -4,7 +4,7 @@ import { writeFileSync } from "fs";
 import { compileRanked } from "../core/summarize";
 import { parseKeepAndPrompt, PI_VCC_COMPACT_INSTRUCTION } from "../core/compact-args";
 import { loadSettings, type PiVccSettings } from "../core/settings";
-import { calibrateCharsPerToken, estimateMessageContentChars, estimateTokensFromChars } from "../core/token-estimate";
+import { calibrateCharsPerToken, estimateMessageContentChars, estimateMessageContentTokens, estimateTokensFromChars } from "../core/token-estimate";
 import type { PiVccCompactionDetails } from "../details";
 import type { CompactionReason } from "../types";
 
@@ -18,6 +18,8 @@ export interface CompactionStats {
   requestedKeepUserTurns: number;
   keepUserTurnsExplicit: boolean;
   keepFallbackToCompactAll: boolean;
+  /** Set when the tail came from a token-budget cut instead of a user-turn cut. */
+  budgetCut?: BudgetCutKind;
   keptTokensEst: number;
   /** True when smart-keep boosted the default keep beyond 1. */
   smartKeepAdjusted?: boolean;
@@ -26,6 +28,9 @@ export interface CompactionStats {
   reason?: CompactionReason;
   willRetry?: boolean;
 }
+
+export type BudgetCutKind = "no_anchor" | "oversized_tail";
+export const OVERSIZED_TAIL_FACTOR = 2.5;
 
 let lastStats: CompactionStats | null = null;
 let lastCompactWasPiVcc = false;
@@ -66,6 +71,12 @@ export const formatCompactionStats = (stats: CompactionStats): string => {
   const notes: string[] = [`summarized ${stats.summarized}`];
   if (stats.smartKeepAdjusted) {
     notes.push("smart-keep");
+  }
+  if (stats.budgetCut === "no_anchor") {
+    notes.push("budget cut: no user anchor");
+  }
+  if (stats.budgetCut === "oversized_tail") {
+    notes.push("budget cut: oversized tail");
   }
   return `pi-vcc: kept ${stats.keptUserTurns}/${stats.totalUserTurns} turns, ~${formatTokens(stats.keptTokensEst)} tok (${notes.join(", ")}).`;
 };
@@ -166,11 +177,11 @@ export type OwnCutResult =
       totalUserTurns: number;
       requestedKeepUserTurns: number;
       keepFallbackToCompactAll: boolean;
+      budgetCut?: BudgetCutKind;
     }
   | { ok: false; reason: OwnCutCancelReason };
 
-export function buildOwnCut(branchEntries: any[], keepUserTurns = 1): OwnCutResult {
-  const normalizedKeepUserTurns = normalizeKeepUserTurns(keepUserTurns);
+const collectLiveMessages = (branchEntries: any[]): EntryWithMessage[] => {
   // Find the last compaction entry and its firstKeptEntryId
   let lastCompactionIdx = -1;
   let lastKeptId: string | undefined;
@@ -210,6 +221,12 @@ export function buildOwnCut(branchEntries: any[], keepUserTurns = 1): OwnCutResu
       }
     }
   }
+  return liveMessages;
+};
+
+export function buildOwnCut(branchEntries: any[], keepUserTurns = 1): OwnCutResult {
+  const normalizedKeepUserTurns = normalizeKeepUserTurns(keepUserTurns);
+  const liveMessages = collectLiveMessages(branchEntries);
 
   if (liveMessages.length === 0) return { ok: false, reason: "no_live_messages" };
   if (liveMessages.length <= 2) return { ok: false, reason: "too_few_live_messages" };
@@ -254,6 +271,76 @@ export function buildOwnCut(branchEntries: any[], keepUserTurns = 1): OwnCutResu
     keepFallbackToCompactAll: false,
   };
 }
+
+// Token-budget tail cut: rescue default-path sessions when the user-turn
+// anchored tail is absent (autonomous: no user boundary in the live window)
+// or oversized (a single giant last user turn). Cuts at the nearest valid
+// non-toolResult boundary, mirroring pi-core's findCutPoint.
+export const findBudgetCutIndex = (
+  live: EntryWithMessage[],
+  maxTokens: number,
+  charsPerToken?: number,
+): number => {
+  let acc = 0;
+  let crossed = -1;
+  for (let i = live.length - 1; i >= 0; i--) {
+    acc += estimateMessageContentTokens(live[i].message.content, charsPerToken);
+    if (acc >= maxTokens) {
+      crossed = i;
+      break;
+    }
+  }
+  if (crossed < 0) return -1;
+  // Snap forward off any toolResult to the next valid boundary.
+  for (let j = Math.max(crossed, 1); j < live.length; j++) {
+    if (live[j].message.role !== "toolResult") return j;
+  }
+  return -1;
+};
+
+export const applyTailBudget = (
+  branchEntries: any[],
+  cut: OwnCutResult,
+  opts: { maxTokens?: number; oversizedFactor?: number; charsPerToken?: number } = {},
+): OwnCutResult => {
+  if (!cut.ok) return cut;
+  const maxTokens = opts.maxTokens ?? MAX_SMART_TAIL_TOKENS;
+  const factor = opts.oversizedFactor ?? OVERSIZED_TAIL_FACTOR;
+  const live = collectLiveMessages(branchEntries);
+
+  const budgetResult = (idx: number, budgetCut: BudgetCutKind): OwnCutResult => ({
+    ok: true,
+    messages: live.slice(0, idx).map((m) => m.message),
+    firstKeptEntryId: live[idx].entry.id,
+    compactAll: false,
+    keptUserTurns: live.slice(idx).filter((m) => m.message.role === "user").length,
+    totalUserTurns: live.filter((m) => m.message.role === "user").length,
+    requestedKeepUserTurns: cut.requestedKeepUserTurns,
+    keepFallbackToCompactAll: false,
+    budgetCut,
+  });
+
+  // Case A: no user anchor → compact-all. Re-cut to a token budget unless the
+  // compact-all came from explicit keep:0 (which must be respected absolutely).
+  if (cut.compactAll) {
+    if (!cut.keepFallbackToCompactAll) return cut;
+    const idx = findBudgetCutIndex(live, maxTokens, opts.charsPerToken);
+    if (idx < 0) return cut;
+    return budgetResult(idx, "no_anchor");
+  }
+
+  // Case B: oversized user-boundary tail. Only re-cut when the kept tail exceeds
+  // maxTokens * factor (tolerance zone below is unchanged).
+  const tailStart = cut.messages.length; // equals the cut index in the live window
+  let tailTokens = 0;
+  for (let i = tailStart; i < live.length; i++) {
+    tailTokens += estimateMessageContentTokens(live[i].message.content, opts.charsPerToken);
+  }
+  if (tailTokens <= maxTokens * factor) return cut;
+  const idx = findBudgetCutIndex(live, maxTokens, opts.charsPerToken);
+  if (idx <= tailStart) return cut;
+  return budgetResult(idx, "oversized_tail");
+};
 
 // ── smart keep-tail: boost default keep when tail is small ──
 
@@ -385,7 +472,12 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       smartKeepTail: settings.smartKeepTail,
       charsPerToken: tokenEstimate.charsPerToken,
     });
-    const ownCut = buildOwnCut(branchEntries as any[], smartKeep.keepUserTurns);
+    let ownCut = buildOwnCut(branchEntries as any[], smartKeep.keepUserTurns);
+    // Default path only: rescue autonomous / oversized-tail sessions with a
+    // token-budget cut. Explicit keep:N is respected absolutely (no-op here).
+    if (ownCut.ok && !keepUserTurnsExplicit) {
+      ownCut = applyTailBudget(branchEntries as any[], ownCut, { charsPerToken: tokenEstimate.charsPerToken });
+    }
     if (!ownCut.ok) {
       const lastComp = [...branchEntries].reverse().find((e: any) => e.type === "compaction");
       const lastCompIdx = lastComp ? (branchEntries as any[]).indexOf(lastComp) : -1;
@@ -482,6 +574,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       keptTokensEst: estimateTokensFromChars(keptChars, tokenEstimate.charsPerToken),
       smartKeepAdjusted: smartKeep.smartAdjusted,
       smartFromKeep: smartKeep.fromKeep,
+      budgetCut: ownCut.ok ? ownCut.budgetCut : undefined,
       reason,
       willRetry,
     };
@@ -534,6 +627,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
 
     dbg(config, {
       usedOwnCut: true,
+      budgetCut: ownCut.budgetCut,
       compaction: { reason, willRetry },
       messagesToSummarize: agentMessages.length,
       messagesPreviewHead: agentMessages.slice(0, 3).map((m: any) => ({ role: m.role, preview: previewContent(m.content) })),

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -35,11 +35,37 @@ export const OVERSIZED_TAIL_FACTOR = 2.5;
 let lastStats: CompactionStats | null = null;
 let lastCompactWasPiVcc = false;
 let pendingFollowUpPrompt: string | null = null;
-const AUTO_CONTINUE_CUSTOM_TYPE = "pi-vcc-auto-continue";
-const AUTO_CONTINUE_PROMPT = "Continue from where you left off after automatic context compaction. Do not restate the compaction summary; proceed with the task.";
 let pendingAutoContinueTimer: ReturnType<typeof setTimeout> | null = null;
 
+// Invisible auto-continue: resume the agent after compaction without polluting
+// the LLM context with a user-visible continue prompt. triggerInvisibleContinue
+// sends a custom message marked with a dedicated customType (content:[],
+// display:false, triggerTurn:true, deliverAs:'followUp') so Pi's queue/busy-state
+// stays coherent; the on('context') filter registered in registerBeforeCompactHook
+// removes that message (by customType ONLY) from the LLM payload — the model
+// simply continues from the compaction summary.
+//
+// Ported from monotykamary/pi-vcc branch 'tom'
+// (https://github.com/monotykamary/pi-vcc, MIT) — a pi-vcc derivative.
+export const AUTO_CONTINUE_CUSTOM_TYPE = "pi-vcc-auto-continue";
+
+export const triggerInvisibleContinue = (pi: ExtensionAPI): void => {
+  pi.sendMessage(
+    {
+      customType: AUTO_CONTINUE_CUSTOM_TYPE,
+      content: [],
+      display: false,
+      details: undefined,
+    },
+    {
+      triggerTurn: true,
+      deliverAs: "followUp",
+    },
+  );
+};
+
 const clearPendingAutoContinue = () => {
+
   if (pendingAutoContinueTimer) {
     clearTimeout(pendingAutoContinueTimer);
     pendingAutoContinueTimer = null;
@@ -48,14 +74,10 @@ const clearPendingAutoContinue = () => {
 
 const scheduleAutoContinue = (pi: any) => {
   clearPendingAutoContinue();
-  pendingAutoContinueTimer = setTimeout(async () => {
+  pendingAutoContinueTimer = setTimeout(() => {
     pendingAutoContinueTimer = null;
     try {
-      await pi.sendMessage({
-        customType: AUTO_CONTINUE_CUSTOM_TYPE,
-        content: AUTO_CONTINUE_PROMPT,
-        display: false,
-      }, { triggerTurn: true });
+      triggerInvisibleContinue(pi);
     } catch {}
   }, 0);
 };
@@ -456,6 +478,16 @@ const REASON_MESSAGES: Record<OwnCutCancelReason, string> = {
 };
 
 export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
+  // Filter our invisible-continue marker out of the LLM context payload so the
+  // model just continues from the compaction summary (matched by customType ONLY).
+  pi.on("context", (event) => {
+    const messages = event.messages.filter((message) => {
+      if (message.role !== "custom") return true;
+      return message.customType !== AUTO_CONTINUE_CUSTOM_TYPE;
+    });
+    if (messages.length !== event.messages.length) return { messages };
+  });
+
   pi.on("before_agent_start", () => {
     clearPendingAutoContinue();
   });

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -62,11 +62,29 @@ export const registerRecallTool = (pi: ExtensionAPI) => {
         };
       }
 
+      const scope = normalizeRecallScope(params.scope);
+      const lineageEntryIds = scope === "lineage"
+        ? getActiveLineageEntryIds(ctx.sessionManager)
+        : undefined;
+
       // Drill-down: #N:path resolves to file-scoped tool content. Anchored so
       // inline mentions like "see #42:auth.ts" are never treated as drill-down.
+      // Honors scope like every other recall path: the target entry must be on
+      // the active lineage unless scope:'all'. Membership is checked against
+      // global indices; expandEntryFile keeps loading unfiltered so #N stays
+      // aligned with the global message index.
       const q = params.query?.trim();
       if (q && parseDrillDown(q)) {
         const parsed = parseDrillDown(q)!;
+        if (lineageEntryIds) {
+          const { rendered } = loadAllMessages(sessionFile, false, lineageEntryIds);
+          if (!rendered.some((m) => m.index === parsed.index)) {
+            return {
+              content: [{ type: "text", text: `Cannot expand indices outside active lineage: ${parsed.index}. Use scope:'all' to reach other branches.` }],
+              details: undefined,
+            };
+          }
+        }
         const text = expandEntryFile(
           sessionFile,
           parsed.index,
@@ -80,11 +98,6 @@ export const registerRecallTool = (pi: ExtensionAPI) => {
           details: undefined,
         };
       }
-
-      const scope = normalizeRecallScope(params.scope);
-      const lineageEntryIds = scope === "lineage"
-        ? getActiveLineageEntryIds(ctx.sessionManager)
-        : undefined;
 
       // touched mode: aggregate file operations across the live window.
       if (normalizeRecallMode(params.mode) === "touched") {

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -1,10 +1,11 @@
 import { Type } from "typebox";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { loadAllMessages } from "../core/load-messages";
-import { searchEntries } from "../core/search-entries";
-import { formatRecallOutput } from "../core/format-recall";
+import { searchEntries, getTouchedFiles } from "../core/search-entries";
+import { formatRecallOutput, formatTouchedOutput } from "../core/format-recall";
 import { getActiveLineageEntryIds } from "../core/lineage";
-import { normalizeRecallScope } from "../core/recall-scope";
+import { normalizeRecallScope, normalizeRecallMode } from "../core/recall-scope";
+import { parseDrillDown, expandEntryFile } from "../core/drill-down";
 
 const DEFAULT_RECENT = 25;
 const PAGE_SIZE = 5;
@@ -20,11 +21,15 @@ export const registerRecallTool = (pi: ExtensionAPI) => {
       "Recall earlier parts of the current session — decisions made, files touched, commands run, " +
       "including anything dropped by compaction. Reach for this before telling the user you no longer " +
       "have the context. Plain keywords work best; a regex pattern is also accepted. Results are paged " +
-      "(page); pass expand with entry indices to read full untruncated content. Only the current session " +
-      "is searchable — earlier sessions are not.",
+      "(page); pass expand with entry indices to read full untruncated content. Use mode:'touched' to " +
+      "list files worked on in this session with their entry indices, and #N:path to drill into a file's " +
+      "content from an entry (#N:path:full for all lines). Note: apply_patch paths (inside the diff " +
+      "payload) and bash redirects do not appear in the touched index. Only the current session is " +
+      "searchable — earlier sessions are not.",
     promptSnippet:
       "vcc_recall: recall earlier parts of this session before saying the context is gone. " +
-      "Plain keywords work best; scope:'all' widens to other conversation branches.",
+      "Plain keywords work best; scope:'all' widens to other conversation branches. " +
+      "mode:'touched' lists files worked on; #N:path drills into a file's content from an entry.",
     parameters: Type.Object({
       query: Type.Optional(
         Type.String({ description: "What to recall, in plain keywords (e.g. 'redis cache decision'). Multi-word queries are ranked by relevance. A regex pattern also works." }),
@@ -41,6 +46,12 @@ export const registerRecallTool = (pi: ExtensionAPI) => {
           Type.Literal("all"),
         ], { description: "Default 'lineage' covers the active conversation path. Use 'all' to also reach messages from other branches, such as turns that were edited or retried." }),
       ),
+      mode: Type.Optional(
+        Type.Union([
+          Type.Literal("hybrid"),
+          Type.Literal("touched"),
+        ], { description: "What to show. hybrid (default) = normal search; touched = aggregated files-by-path with entry indices." }),
+      ),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const sessionFile = ctx.sessionManager.getSessionFile();
@@ -51,10 +62,41 @@ export const registerRecallTool = (pi: ExtensionAPI) => {
         };
       }
 
+      // Drill-down: #N:path resolves to file-scoped tool content. Anchored so
+      // inline mentions like "see #42:auth.ts" are never treated as drill-down.
+      const q = params.query?.trim();
+      if (q && parseDrillDown(q)) {
+        const parsed = parseDrillDown(q)!;
+        const text = expandEntryFile(
+          sessionFile,
+          parsed.index,
+          parsed.pathPattern,
+          parsed.full,
+          parsed.offset,
+          parsed.limit,
+        );
+        return {
+          content: [{ type: "text", text }],
+          details: undefined,
+        };
+      }
+
       const scope = normalizeRecallScope(params.scope);
       const lineageEntryIds = scope === "lineage"
         ? getActiveLineageEntryIds(ctx.sessionManager)
         : undefined;
+
+      // touched mode: aggregate file operations across the live window.
+      if (normalizeRecallMode(params.mode) === "touched") {
+        const { rendered, rawMessages } = loadAllMessages(sessionFile, false, lineageEntryIds);
+        const touched = getTouchedFiles(rawMessages, rendered);
+        const text = formatTouchedOutput(touched, params.page);
+        return {
+          content: [{ type: "text", text }],
+          details: undefined,
+        };
+      }
+
       const expandSet = new Set(params.expand ?? []);
       const hasExpand = expandSet.size > 0;
 

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -634,7 +634,7 @@ describe("applyTailBudget: token-budget tail cut (default path)", () => {
     expect(keptFirst.message.role).toBe("assistant");
   });
 
-  test("formatCompactionStats renders both budget-cut notes", () => {
+  test("formatCompactionStats leads with tail tokens for budget cuts", () => {
     const base = {
       summarized: 4,
       kept: 2,
@@ -645,8 +645,8 @@ describe("applyTailBudget: token-budget tail cut (default path)", () => {
       keepFallbackToCompactAll: false,
       keptTokensEst: 5000,
     };
-    expect(formatCompactionStats({ ...base, budgetCut: "no_anchor" })).toContain("budget cut: no user anchor");
-    expect(formatCompactionStats({ ...base, budgetCut: "oversized_tail" })).toContain("budget cut: oversized tail");
+    expect(formatCompactionStats({ ...base, budgetCut: "no_anchor" })).toBe("pi-vcc: kept ~5.0k tok tail (mid-turn cut, no user anchor), summarized 4.");
+    expect(formatCompactionStats({ ...base, budgetCut: "oversized_tail" })).toBe("pi-vcc: kept ~5.0k tok tail (mid-turn cut, oversized tail), summarized 4.");
   });
 });
 

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -258,12 +258,12 @@ describe("registerBeforeCompactHook: compact-all path", () => {
 
     expect(userMessages).toEqual([]);
     expect(customMessages).toHaveLength(1);
-    expect(customMessages[0].options).toEqual({ triggerTurn: true });
+    expect(customMessages[0].options).toEqual({ triggerTurn: true, deliverAs: "followUp" });
     expect(customMessages[0].message).toMatchObject({
       customType: "pi-vcc-auto-continue",
       display: false,
     });
-    expect(customMessages[0].message.content).toContain("Continue from where you left off");
+    expect(customMessages[0].message.content).toEqual([]);
   });
 
   test("successful overflow compact auto-continues by default with hidden custom message", async () => {
@@ -278,12 +278,12 @@ describe("registerBeforeCompactHook: compact-all path", () => {
 
     expect(userMessages).toEqual([]);
     expect(customMessages).toHaveLength(1);
-    expect(customMessages[0].options).toEqual({ triggerTurn: true });
+    expect(customMessages[0].options).toEqual({ triggerTurn: true, deliverAs: "followUp" });
     expect(customMessages[0].message).toMatchObject({
       customType: "pi-vcc-auto-continue",
       display: false,
     });
-    expect(customMessages[0].message.content).toContain("Continue from where you left off");
+    expect(customMessages[0].message.content).toEqual([]);
   });
 
   test("threshold compact continuation is canceled when a real user prompt starts", async () => {

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } fr
 import { existsSync, unlinkSync, writeFileSync, readFileSync, mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { registerBeforeCompactHook, PI_VCC_COMPACT_INSTRUCTION, getLastCompactionStats, formatCompactionStats } from "../src/hooks/before-compact";
+import { registerBeforeCompactHook, PI_VCC_COMPACT_INSTRUCTION, getLastCompactionStats, formatCompactionStats, buildOwnCut, applyTailBudget } from "../src/hooks/before-compact";
 
 let tmpDir: string;
 let CONFIG_PATH: string;
@@ -527,5 +527,182 @@ describe("registerBeforeCompactHook: compact-all path", () => {
       keptUserTurns: 0,
       totalUserTurns: 2,
     });
+  });
+});
+
+describe("applyTailBudget: token-budget tail cut (default path)", () => {
+  const big = (n: number) => "x".repeat(n);
+
+  test("Case A: no user anchor + oversized live window → non-compact-all budget cut (no_anchor)", () => {
+    const entries = [
+      msg("u1", "user", "go"),
+      msg("a1", "assistant", "tool"),
+      msg("t1", "toolResult", "res"),
+      msg("a2", "assistant", big(200_000)), // 50k tok at 4 chars/tok
+    ];
+    const cut = buildOwnCut(entries, 1);
+    expect(cut.ok).toBe(true);
+    if (!cut.ok) return;
+    expect(cut.compactAll).toBe(true);
+
+    const result = applyTailBudget(entries, cut, { charsPerToken: 4 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.compactAll).toBe(false);
+    expect(result.firstKeptEntryId).toBe("a2");
+    expect(result.firstKeptEntryId).not.toBe("");
+    expect(result.budgetCut).toBe("no_anchor");
+    const keptFirst = entries.find((e: any) => e.id === result.firstKeptEntryId)!;
+    expect(keptFirst.message.role).not.toBe("toolResult");
+  });
+
+  test("Case A small window: everything < budget → unchanged compact-all fallback", () => {
+    const entries = [
+      msg("u1", "user", "go"),
+      msg("a1", "assistant", "tool"),
+      msg("t1", "toolResult", "res"),
+      msg("a2", "assistant", "done"),
+    ];
+    const cut = buildOwnCut(entries, 1);
+    if (!cut.ok) return;
+    const result = applyTailBudget(entries, cut, { charsPerToken: 4 });
+    expect(result).toBe(cut); // returned unchanged
+    if (!result.ok) return;
+    expect(result.compactAll).toBe(true);
+    expect(result.firstKeptEntryId).toBe("");
+    expect(result.budgetCut).toBeUndefined();
+  });
+
+  test("Case B: oversized tail (>62.5k tok) re-cuts inside the last turn, not at toolResult", () => {
+    const entries = [
+      msg("u1", "user", "one"),
+      msg("a1", "assistant", "reply"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", big(300_000)), // 75k tok at 4 chars/tok
+      msg("t1", "toolResult", "res"),
+      msg("a3", "assistant", "wrap"),
+    ];
+    const cut = buildOwnCut(entries, 1);
+    if (!cut.ok) return;
+    expect(cut.compactAll).toBe(false);
+    expect(cut.firstKeptEntryId).toBe("u2");
+
+    const result = applyTailBudget(entries, cut, { charsPerToken: 4 });
+    if (!result.ok) return;
+    expect(result.budgetCut).toBe("oversized_tail");
+    expect(result.compactAll).toBe(false);
+    expect(result.firstKeptEntryId).toBe("a2"); // cut landed inside the last turn
+    const keptFirst = entries.find((e: any) => e.id === result.firstKeptEntryId)!;
+    expect(keptFirst.message.role).toBe("assistant");
+  });
+
+  test("Case B tolerance: last turn ~37.5k tok → no budget cut", () => {
+    const entries = [
+      msg("u1", "user", "one"),
+      msg("a1", "assistant", "reply"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", big(150_000)), // 37.5k tok at 4 chars/tok < 62.5k
+      msg("t1", "toolResult", "res"),
+      msg("a3", "assistant", "wrap"),
+    ];
+    const cut = buildOwnCut(entries, 1);
+    if (!cut.ok) return;
+    const result = applyTailBudget(entries, cut, { charsPerToken: 4 });
+    expect(result).toBe(cut); // tolerance zone: unchanged
+    if (!result.ok) return;
+    expect(result.budgetCut).toBeUndefined();
+    expect(result.firstKeptEntryId).toBe("u2");
+  });
+
+  test("toolResult snap: crossing lands on a toolResult → snapped forward to next non-toolResult", () => {
+    const entries = [
+      msg("u1", "user", "go"),
+      msg("a1", "assistant", "tool"),
+      msg("t1", "toolResult", big(200_000)), // crossing lands here
+      msg("a2", "assistant", "done"),
+    ];
+    const cut = buildOwnCut(entries, 1);
+    if (!cut.ok) return;
+    expect(cut.compactAll).toBe(true);
+    const result = applyTailBudget(entries, cut, { charsPerToken: 4 });
+    if (!result.ok) return;
+    expect(result.budgetCut).toBe("no_anchor");
+    expect(result.firstKeptEntryId).toBe("a2"); // snapped past the toolResult
+    const keptFirst = entries.find((e: any) => e.id === result.firstKeptEntryId)!;
+    expect(keptFirst.message.role).toBe("assistant");
+  });
+
+  test("formatCompactionStats renders both budget-cut notes", () => {
+    const base = {
+      summarized: 4,
+      kept: 2,
+      keptUserTurns: 0,
+      totalUserTurns: 1,
+      requestedKeepUserTurns: 1,
+      keepUserTurnsExplicit: false,
+      keepFallbackToCompactAll: false,
+      keptTokensEst: 5000,
+    };
+    expect(formatCompactionStats({ ...base, budgetCut: "no_anchor" })).toContain("budget cut: no user anchor");
+    expect(formatCompactionStats({ ...base, budgetCut: "oversized_tail" })).toContain("budget cut: oversized tail");
+  });
+});
+
+describe("registerBeforeCompactHook: budget-cut hook integration", () => {
+  beforeEach(() => {
+    if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
+  });
+  afterEach(() => {
+    if (existsSync(CONFIG_PATH)) unlinkSync(CONFIG_PATH);
+    if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
+  });
+
+  test("Case A default path: no_anchor budget cut keeps a tail and sets stats", () => {
+    setConfig({ debug: false, overrideDefaultCompaction: false });
+    const { pi, invokeBefore } = createMockPi();
+    registerBeforeCompactHook(pi);
+    const entries = [
+      msg("u1", "user", "go"),
+      msg("a1", "assistant", "tool"),
+      msg("t1", "toolResult", "res"),
+      msg("a2", "assistant", "x".repeat(200_000)),
+    ];
+    const result = invokeBefore(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+    expect(result.cancel).toBeUndefined();
+    expect(result.compaction.firstKeptEntryId).not.toBe("");
+    expect(getLastCompactionStats()!.budgetCut).toBe("no_anchor");
+  });
+
+  test("Case A small window: unchanged compact-all fallback and no budgetCut", () => {
+    setConfig({ debug: false, overrideDefaultCompaction: false });
+    const { pi, invokeBefore } = createMockPi();
+    registerBeforeCompactHook(pi);
+    const entries = [
+      msg("u1", "user", "go"),
+      msg("a1", "assistant", "tool"),
+      msg("t1", "toolResult", "res"),
+      msg("a2", "assistant", "done"),
+    ];
+    const result = invokeBefore(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+    expect(result.compaction.firstKeptEntryId).toBe("");
+    expect(getLastCompactionStats()!.budgetCut).toBeUndefined();
+  });
+
+  test("Explicit keep:N with giant last turn is untouched (no budgetCut)", () => {
+    setConfig({ debug: false, overrideDefaultCompaction: false });
+    const { pi, invokeBefore } = createMockPi();
+    registerBeforeCompactHook(pi);
+    const entries = [
+      msg("u1", "user", "one"),
+      msg("a1", "assistant", "reply"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", "x".repeat(300_000)),
+      msg("u3", "user", "three"),
+      msg("a3", "assistant", "reply three"),
+    ];
+    const result = invokeBefore(makeEvent(entries, `${PI_VCC_COMPACT_INSTRUCTION} keep:2`));
+    expect(result.compaction.firstKeptEntryId).toBe("u2");
+    expect(getLastCompactionStats()!.budgetCut).toBeUndefined();
+    expect(getLastCompactionStats()!.keepUserTurnsExplicit).toBe(true);
   });
 });

--- a/tests/before-compact-hook.test.ts
+++ b/tests/before-compact-hook.test.ts
@@ -83,6 +83,8 @@ const msg = (id: string, role: "user" | "assistant" | "toolResult", content = "x
   message: { role, content },
 });
 const comp = (id: string, firstKeptEntryId?: string) => ({ id, type: "compaction", firstKeptEntryId });
+const custom = (id: string, customType: string, content: string | unknown[], extra: Record<string, unknown> = {}) => ({ id, type: "custom_message", customType, content, display: false, timestamp: "2026-01-01T00:00:00.000Z", ...extra });
+const branchSummary = (id: string, summary: string, fromId = "f1") => ({ id, type: "branch_summary", summary, fromId, timestamp: "2026-01-01T00:00:00.000Z" });
  
 describe("registerBeforeCompactHook: cancel paths", () => {
   beforeEach(() => {
@@ -704,5 +706,126 @@ describe("registerBeforeCompactHook: budget-cut hook integration", () => {
     expect(result.compaction.firstKeptEntryId).toBe("u2");
     expect(getLastCompactionStats()!.budgetCut).toBeUndefined();
     expect(getLastCompactionStats()!.keepUserTurnsExplicit).toBe(true);
+  });
+});
+
+describe("collectLiveMessages: custom_message / branch_summary entries", () => {
+  test("custom_message in the summarized prefix is carried into the summarizer input", () => {
+    const entries = [
+      msg("u1", "user", "go"),
+      msg("a1", "assistant", "reply"),
+      custom("c1", "memory-inject", "CUSTOM_CTX_MARKER_123"),
+      msg("u2", "user", "next"),
+      msg("a2", "assistant", "done"),
+    ];
+    const cut = buildOwnCut(entries, 1);
+    expect(cut.ok).toBe(true);
+    if (!cut.ok) return;
+    // keep:1 → cut at u2, so the summarized prefix is [u1, a1, c1]
+    expect(cut.firstKeptEntryId).toBe("u2");
+    const summarized = cut.messages.map((m: any) => m.content);
+    expect(summarized).toContain("CUSTOM_CTX_MARKER_123");
+    const customMsg = cut.messages.find((m: any) => m.role === "custom");
+    expect(customMsg).toBeDefined();
+    expect(customMsg.customType).toBe("memory-inject");
+  });
+
+  test("custom_message is NOT counted as a user turn", () => {
+    const entries = [
+      msg("u1", "user", "one"),
+      custom("c1", "ctx", "injected"),
+      msg("a1", "assistant", "reply one"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", "reply two"),
+    ];
+    const cut = buildOwnCut(entries, 1);
+    expect(cut.ok).toBe(true);
+    if (!cut.ok) return;
+    expect(cut.totalUserTurns).toBe(2); // custom not counted
+    expect(cut.keptUserTurns).toBe(1);
+  });
+
+  test("branch_summary entry is included and not counted as a user turn", () => {
+    const entries = [
+      branchSummary("bs1", "BRANCH_SUMMARY_MARKER"),
+      msg("u1", "user", "one"),
+      msg("a1", "assistant", "reply one"),
+      msg("u2", "user", "two"),
+      msg("a2", "assistant", "reply two"),
+    ];
+    const cut = buildOwnCut(entries, 1);
+    expect(cut.ok).toBe(true);
+    if (!cut.ok) return;
+    expect(cut.totalUserTurns).toBe(2); // branch_summary not counted
+    const prefix = cut.messages.map((m: any) => m.content ?? m.summary);
+    expect(prefix).toContain("BRANCH_SUMMARY_MARKER");
+    const bsMsg = cut.messages.find((m: any) => m.role === "branchSummary");
+    expect(bsMsg).toBeDefined();
+    expect(bsMsg.summary).toBe("BRANCH_SUMMARY_MARKER");
+  });
+
+  test("budget cut may land on a custom message (valid non-toolResult boundary)", () => {
+    const entries = [
+      msg("u1", "user", "go"),
+      custom("c1", "ctx", "x".repeat(200_000)), // huge custom message
+      msg("a1", "assistant", "wrap"),
+    ];
+    const cut = buildOwnCut(entries, 1);
+    expect(cut.ok).toBe(true);
+    if (!cut.ok) return;
+    expect(cut.compactAll).toBe(true); // no user anchor → case A
+    const result = applyTailBudget(entries, cut, { charsPerToken: 4 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.budgetCut).toBe("no_anchor");
+    expect(result.firstKeptEntryId).toBe("c1"); // cut landed on the custom message
+    const keptFirst = entries.find((e: any) => e.id === result.firstKeptEntryId)!;
+    expect(keptFirst.type).toBe("custom_message");
+  });
+
+  test("orphan-recovery window containing custom_message keeps it in the live window", () => {
+    const entries = [
+      comp("pc", "ghost-id"), // prior compaction with a no-longer-valid kept id
+      custom("c1", "ctx", "ORPHAN_CUSTOM_MARKER"),
+      msg("a1", "assistant", "reply"),
+      msg("u1", "user", "go"),
+      msg("a2", "assistant", "done"),
+    ];
+    const cut = buildOwnCut(entries, 1);
+    expect(cut.ok).toBe(true);
+    if (!cut.ok) return;
+    // orphan recovery collects from after the last compaction → custom is included
+    const summarized = cut.messages.map((m: any) => m.content).join("");
+    expect(summarized).toContain("ORPHAN_CUSTOM_MARKER");
+    expect(cut.totalUserTurns).toBe(1);
+  });
+});
+
+describe("registerBeforeCompactHook: custom_message reaches the summarizer", () => {
+  beforeEach(() => {
+    if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
+  });
+  afterEach(() => {
+    if (existsSync(CONFIG_PATH)) unlinkSync(CONFIG_PATH);
+    if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
+  });
+
+  test("custom message content appears in the debug summarize-input preview", () => {
+    setConfig({ debug: true, overrideDefaultCompaction: false });
+    const { pi, invokeBefore } = createMockPi();
+    registerBeforeCompactHook(pi);
+    const entries = [
+      custom("c1", "memory-inject", "INJECTED_CTX_9999"),
+      msg("u1", "user", "go"),
+      msg("a1", "assistant", "reply"),
+      msg("u2", "user", "next"),
+      msg("a2", "assistant", "done"),
+    ];
+    const result = invokeBefore(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+    expect(result.cancel).toBeUndefined();
+    expect(existsSync(DEBUG_PATH)).toBe(true);
+    const snapshot = JSON.parse(readFileSync(DEBUG_PATH, "utf-8"));
+    expect(snapshot.usedOwnCut).toBe(true);
+    expect(JSON.stringify(snapshot)).toContain("INJECTED_CTX_9999");
   });
 });

--- a/tests/invisible-continue.test.ts
+++ b/tests/invisible-continue.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, test } from "bun:test";
+import {
+  registerBeforeCompactHook,
+  triggerInvisibleContinue,
+  buildOwnCut,
+  AUTO_CONTINUE_CUSTOM_TYPE,
+} from "../src/hooks/before-compact";
+
+describe("invisible auto-continue: trigger + context filter", () => {
+  it("triggerInvisibleContinue sends a hidden custom message with followUp delivery", () => {
+    const calls: { m: any; o: any }[] = [];
+    const pi = { sendMessage: (m: any, o: any) => calls.push({ m, o }) } as any;
+    triggerInvisibleContinue(pi);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].o).toEqual({ triggerTurn: true, deliverAs: "followUp" });
+    expect(calls[0].m).toMatchObject({
+      customType: AUTO_CONTINUE_CUSTOM_TYPE,
+      content: [],
+      display: false,
+    });
+  });
+
+  it("context hook filters ONLY our customType; other custom messages pass through untouched", () => {
+    let handler: ((event: any) => unknown) | undefined;
+    const pi = { on: (e: string, h: any) => { if (e === "context") handler = h; } } as any;
+    registerBeforeCompactHook(pi);
+
+    const user = { role: "user", content: [{ type: "text", text: "keep" }] };
+    const own = { role: "custom", customType: AUTO_CONTINUE_CUSTOM_TYPE, content: [] };
+    const other = { role: "custom", customType: "some-other-ext", content: [{ type: "text", text: "ctx" }] };
+
+    const result = handler?.({ messages: [user, own, other] });
+    const filtered = ((result as any)?.messages ?? [user, own, other]) as any[];
+    expect(filtered).toEqual([user, other]);
+  });
+
+  it("context hook is a pure filter: returns undefined when nothing to remove", () => {
+    let handler: ((event: any) => unknown) | undefined;
+    const pi = { on: (e: string, h: any) => { if (e === "context") handler = h; } } as any;
+    registerBeforeCompactHook(pi);
+
+    const user = { role: "user", content: [{ type: "text", text: "hi" }] };
+    const other = { role: "custom", customType: "other-ext", content: [] };
+    const result = handler?.({ messages: [user, other] });
+    expect(result).toBeUndefined(); // no mutation, no return
+  });
+
+  it("filter is idempotent: removing our marker yields empty result deterministically", () => {
+    let handler: ((event: any) => unknown) | undefined;
+    const pi = { on: (e: string, h: any) => { if (e === "context") handler = h; } } as any;
+    registerBeforeCompactHook(pi);
+
+    const own = { role: "custom", customType: AUTO_CONTINUE_CUSTOM_TYPE, content: [] };
+    const once = handler?.({ messages: [own] });
+    const messages = ((once as any)?.messages ?? []) as any[];
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("invisible auto-continue: summarize-path noise", () => {
+  it("our continue custom message carries empty content → adds no noise to summarizer input", () => {
+    const entries = [
+      { id: "u1", type: "message", message: { role: "user", content: "go" } },
+      { id: "a1", type: "message", message: { role: "assistant", content: "reply" } },
+      {
+        id: "c1",
+        type: "custom_message",
+        customType: AUTO_CONTINUE_CUSTOM_TYPE,
+        content: [],
+        display: false,
+        timestamp: "2026-01-01T00:00:00.000Z",
+      },
+      { id: "u2", type: "message", message: { role: "user", content: "next" } },
+      { id: "a2", type: "message", message: { role: "assistant", content: "done" } },
+    ];
+    const cut = buildOwnCut(entries, 1);
+    expect(cut.ok).toBe(true);
+    if (!cut.ok) return;
+
+    // The continue message is collected into the live window (harmless) but its
+    // content is empty, so it contributes zero text/tokens to the summarizer.
+    const custom = cut.messages.find((m: any) => m.content && m.role === "custom");
+    expect(custom).toBeDefined();
+    const contentLen = Array.isArray(custom.content)
+      ? custom.content.length
+      : String(custom.content ?? "").length;
+    expect(contentLen).toBe(0);
+  });
+});

--- a/tests/recall-touched-drilldown.test.ts
+++ b/tests/recall-touched-drilldown.test.ts
@@ -253,3 +253,32 @@ describe("formatTouchedOutput", () => {
     expect(formatTouchedOutput([])).toContain("No file operations found in session history.");
   });
 });
+describe("drill-down scope", () => {
+  it("blocks #N:path on off-lineage entries by default, allows with scope all", async () => {
+    const entries = [
+      toolMsg("m0", "edit", { path: "src/on.ts", oldText: "x", newText: "y" }),
+      toolMsg("m1", "edit", { path: "src/off.ts", oldText: "secret-old", newText: "secret-new" }),
+      toolMsg("m2", "edit", { path: "src/on.ts", oldText: "a", newText: "b" }),
+    ];
+    const { dir, file, ids } = makeSession(entries);
+    try {
+      const tool = register();
+      const lineage = ["m0", "m2"];
+
+      // off-lineage entry blocked under default scope
+      const blocked = await invoke(tool, file, ids, { query: "#1:off.ts" }, lineage);
+      expect(blocked).toContain("Cannot expand indices outside active lineage: 1");
+      expect(blocked).not.toContain("secret-old");
+
+      // on-lineage entry still drills under default scope
+      const onOut = await invoke(tool, file, ids, { query: "#2:on.ts" }, lineage);
+      expect(onOut).toContain("src/on.ts");
+
+      // scope:'all' reaches the other branch
+      const allOut = await invoke(tool, file, ids, { query: "#1:off.ts", scope: "all" });
+      expect(allOut).toContain("src/off.ts");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/recall-touched-drilldown.test.ts
+++ b/tests/recall-touched-drilldown.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { registerRecallTool } from "../src/tools/recall";
+import { parseDrillDown } from "../src/core/drill-down";
+import { formatTouchedOutput, TOUCHED_PAGE_SIZE } from "../src/core/format-recall";
+import type { TouchedFile } from "../src/core/search-entries";
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+const toolMsg = (id: string, name: string, args: Record<string, unknown>) => ({
+  type: "message",
+  id,
+  message: {
+    role: "assistant",
+    content: [{ type: "toolCall", name, arguments: args }],
+  },
+});
+
+const userMsg = (id: string, content: string) => ({
+  type: "message",
+  id,
+  message: { role: "user", content },
+});
+
+let dirCount = 0;
+const makeSession = (entries: any[]) => {
+  const dir = mkdtempSync(join(tmpdir(), `pi-vcc-touched-${dirCount++}-`));
+  const file = join(dir, "session.jsonl");
+  writeFileSync(file, entries.map((e) => JSON.stringify(e)).join("\n") + "\n", "utf8");
+  return { dir, file, ids: entries.filter((e) => e.type === "message" && e.message).map((e) => e.id) };
+};
+
+const register = () => {
+  let tool: any;
+  registerRecallTool({ registerTool: (t: any) => { tool = t; } } as any);
+  return tool;
+};
+
+const invoke = async (
+  tool: any,
+  file: string,
+  ids: string[],
+  params: Record<string, unknown>,
+  branch?: string[],
+) => {
+  const result = await tool.execute("tool-call", params, undefined, undefined, {
+    sessionManager: {
+      getSessionFile: () => file,
+      getBranch: () => (branch ?? ids).map((id) => ({ id })),
+      getEntries: () => ids.map((id) => ({ id })),
+    },
+  });
+  return result.content[0].text as string;
+};
+
+// ── mode:touched ─────────────────────────────────────────────────────────
+
+describe("vcc_recall mode:touched", () => {
+  it("aggregates multiple edits on the same file into one line with chronological indices", async () => {
+    const entries = [
+      toolMsg("m0", "edit", { path: "src/a.ts", oldText: "x", newText: "y" }),
+      toolMsg("m1", "quick_edit", { path: "src/a.ts", edits: [{ oldText: "a", newText: "b" }] }),
+      toolMsg("m2", "write", { path: "src/b.ts", content: "line1\nline2" }),
+    ];
+    const { dir, file, ids } = makeSession(entries);
+    try {
+      const tool = register();
+      const out = await invoke(tool, file, ids, { mode: "touched" });
+      expect(out).toContain("src/a.ts");
+      expect(out).toContain("#0 (edit), #1 (quick_edit)");
+      expect(out).toContain("src/b.ts");
+      expect(out).toContain("#2 (write)");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies by shape: custom tool with path+content counts; Read with path-only args is excluded", async () => {
+    const entries = [
+      toolMsg("m0", "my_custom_tool", { path: "src/custom.ts", content: "hello\nworld" }),
+      toolMsg("m1", "read", { path: "src/readonly.ts" }),
+    ];
+    const { dir, file, ids } = makeSession(entries);
+    try {
+      const tool = register();
+      const out = await invoke(tool, file, ids, { mode: "touched" });
+      expect(out).toContain("src/custom.ts");
+      expect(out).toContain("#0 (my_custom_tool)");
+      expect(out).not.toContain("src/readonly.ts");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("empty session has no touchable files", async () => {
+    const entries = [userMsg("m0", "hello"), userMsg("m1", "world")];
+    const { dir, file, ids } = makeSession(entries);
+    try {
+      const tool = register();
+      const out = await invoke(tool, file, ids, { mode: "touched" });
+      expect(out).toContain("No file operations found in session history.");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("respects scope: file on another branch only with scope all, indices unshifted", async () => {
+    const entries = [
+      toolMsg("m0", "edit", { path: "src/on.ts", oldText: "x", newText: "y" }),
+      toolMsg("m1", "edit", { path: "src/off.ts", oldText: "x", newText: "y" }),
+      toolMsg("m2", "edit", { path: "src/on.ts", oldText: "a", newText: "b" }),
+    ];
+    const { dir, file, ids } = makeSession(entries);
+    try {
+      const tool = register();
+      const lineage = ["m0", "m2"];
+
+      const defaultOut = await invoke(tool, file, ids, { mode: "touched" }, lineage);
+      expect(defaultOut).toContain("src/on.ts");
+      expect(defaultOut).toContain("#0 (edit), #2 (edit)");
+      expect(defaultOut).not.toContain("src/off.ts");
+
+      const allOut = await invoke(tool, file, ids, { mode: "touched", scope: "all" });
+      expect(allOut).toContain("src/off.ts");
+      expect(allOut).toContain("#1 (edit)");
+      expect(allOut).toContain("src/on.ts");
+      expect(allOut).toContain("#2 (edit)"); // index unshifted
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("pages when more files than page size", async () => {
+    const entries = Array.from({ length: 7 }, (_, i) =>
+      toolMsg(`m${i}`, "write", { path: `src/f${i}.ts`, content: "x" }),
+    );
+    const { dir, file, ids } = makeSession(entries);
+    try {
+      const tool = register();
+      const page1 = await invoke(tool, file, ids, { mode: "touched" });
+      expect(page1).toContain("Page 1/2 (7 total files)");
+      expect(page1).toContain("--- Use page:2 for more results ---");
+      expect(page1).toContain("src/f0.ts");
+      expect(page1).not.toContain("src/f5.ts");
+
+      const page2 = await invoke(tool, file, ids, { mode: "touched", page: 2 });
+      expect(page2).toContain("Page 2/2 (7 total files)");
+      expect(page2).toContain("src/f5.ts");
+      expect(page2).not.toContain("--- Use page:3");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── #N:path drill-down ────────────────────────────────────────────────────
+
+describe("vcc_recall drill-down", () => {
+  const bigContent = Array.from({ length: 40 }, (_, i) => `line ${i}`).join("\n");
+
+  it("expands an entry index from touched output", async () => {
+    const entries = [
+      toolMsg("m0", "edit", { path: "src/a.ts", oldText: "x", newText: "y" }),
+      toolMsg("m1", "write", { path: "src/b.ts", content: "line1\nline2" }),
+    ];
+    const { dir, file, ids } = makeSession(entries);
+    try {
+      const tool = register();
+      const touched = await invoke(tool, file, ids, { mode: "touched" });
+      // #1 from touched output points at m1 (src/b.ts)
+      expect(touched).toContain("#1 (write)");
+      const expanded = await invoke(tool, file, ids, { expand: [1] });
+      expect(expanded).toContain("src/b.ts");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("#N:path previews file content", async () => {
+    const entries = [toolMsg("m1", "write", { path: "src/big.ts", content: bigContent })];
+    const { dir, file, ids } = makeSession(entries);
+    try {
+      const tool = register();
+      const out = await invoke(tool, file, ids, { query: "#0:src/big.ts" });
+      expect(out).toContain("File: src/big.ts");
+      expect(out).toContain("line 0");
+      expect(out).not.toContain("line 39"); // preview truncates at 30 lines
+      expect(out).toContain("more lines");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("#N:path:full returns the complete content", async () => {
+    const entries = [toolMsg("m1", "write", { path: "src/big.ts", content: bigContent })];
+    const { dir, file, ids } = makeSession(entries);
+    try {
+      const tool = register();
+      const out = await invoke(tool, file, ids, { query: "#0:src/big.ts:full" });
+      expect(out).toContain("File: src/big.ts");
+      expect(out).toContain("line 39");
+      expect(out).not.toContain("more lines");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("inline mention is treated as a normal search, not drill-down", async () => {
+    const entries = [toolMsg("m1", "write", { path: "src/big.ts", content: bigContent })];
+    const { dir, file, ids } = makeSession(entries);
+    try {
+      const tool = register();
+      const out = await invoke(tool, file, ids, { query: "see #1:src/big.ts" });
+      expect(out).not.toContain("File: src/big.ts");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Unit: parseDrillDown anchoring ────────────────────────────────────────
+
+describe("parseDrillDown", () => {
+  it("anchors on ^ so inline mentions are not drill-down", () => {
+    expect(parseDrillDown("#42:auth.ts")).not.toBeNull();
+    expect(parseDrillDown("#42:auth.ts:full")).not.toBeNull();
+    expect(parseDrillDown("check #42:auth.ts")).toBeNull();
+    expect(parseDrillDown("see #42:auth.ts here")).toBeNull();
+  });
+
+  it("parses full / offset / offset:limit suffixes", () => {
+    expect(parseDrillDown("#42:auth.ts:full")).toMatchObject({ index: 42, pathPattern: "auth.ts", full: true });
+    expect(parseDrillDown("#42:auth.ts:30")).toMatchObject({ index: 42, pathPattern: "auth.ts", full: false, offset: 30 });
+    expect(parseDrillDown("#42:auth.ts:30:20")).toMatchObject({ index: 42, pathPattern: "auth.ts", full: false, offset: 30, limit: 20 });
+  });
+});
+
+// ── Unit: formatTouchedOutput paging ──────────────────────────────────────
+
+describe("formatTouchedOutput", () => {
+  const tf = (path: string, index: number): TouchedFile => ({ path, entries: [{ index, toolName: "edit" }] });
+
+  it("shows page header and footer when there are more pages", () => {
+    const files = Array.from({ length: TOUCHED_PAGE_SIZE + 2 }, (_, i) => tf(`src/f${i}.ts`, i));
+    const out = formatTouchedOutput(files, 1);
+    expect(out).toContain(`Page 1/2 (${files.length} total files)`);
+    expect(out).toContain("--- Use page:2 for more results ---");
+  });
+
+  it("returns empty-state message when no files", () => {
+    expect(formatTouchedOutput([])).toContain("No file operations found in session history.");
+  });
+});


### PR DESCRIPTION
## Summary

Three feature groups, all validated on 755 real sessions from hf-datasets.

### Compaction: autonomous-session tail fixes
- **Token-budget tail cut** (`bdbebfc`): default path now rescues two degenerate cases of user-turn anchoring — `no_anchor` (autonomous runs with a single user prompt previously fell into perpetual compact-all, losing the entire tail) and `oversized_tail` (tails >62.5k tok re-cut to ~25k at a non-toolResult boundary). Explicit `keep:N` unchanged.
- **custom_message/branch_summary in live window** (`fdc4c86`): extension-injected content no longer silently evaporates from summaries.
- **Budget-cut toast** (`9ac3e06`): leads with kept tail tokens instead of misleading `0/N turns`.

### Recall: file-activity index + drill-down
- `mode:"touched"` (`cee7fc6`, `22ce216`): aggregated file-operations index (`#155 (edit), #157 (quick_edit)`), shape-based classification, chronological indices aligned with `expand`.
- `#N:path` / `#N:path:full` drill-down into the exact edit content of a file within an entry.

### Invisible auto-continue (`fb8e58d`)
Auto-continue after compaction is now a context-filtered custom message (`triggerTurn` + `deliverAs:"followUp"`, empty content) — zero context pollution per compaction.

## Bench evidence (755 sessions, 4 repos)

| Metric | Old | New |
|---|---|---|
| Sessions losing entire tail (compact-all) | 21.7% | 0% of rescuable cases (43/43 rescued, median tail 21.7k tok) |
| Giant tails (>62.5k) kept whole | 17 | 16/17 re-cut, median 73k -> 20k tok |
| Weighted fact recall, no_anchor group | 0.558 | 0.909 (+0.301 median) |
| Unaffected sessions (n=682) | — | delta 0.000 (bit-identical) |

Known tradeoff: oversized_tail group median -0.049 recall (facts living in tool_results are structurally inexpressible in the brief; Failures section planned for v0.7). Known rare edge (0.13%): a single message >= budget defeats the cut; under-cap fix designed, deferred.

## Tests

233 -> 260, all passing.

Credits: recall touched-mode and #N:path drill-down ported from @k0valik's
pi-blackhole (who also suggested the feature); invisible auto-continue
pattern from @monotykamary's fork (tom branch).
