### PR TITLE
feat(recall): pinned-range form (from/to/limit) with lean even-budget rendering

### DIFF
--- a/src/core/format-recall.ts
+++ b/src/core/format-recall.ts
@@ -85,7 +85,7 @@ export const formatRecallOutput = (
   }
 
   const header = headerOverride
-    ? `${headerOverride} for "${query}":`
+    ? `${headerOverride}${query ? ` for "${query}"` : ""}:`
     : query
       ? `Found ${entries.length} matches for "${query}":`
       : `Session history (${entries.length} entries):`;

--- a/src/core/render-entries.ts
+++ b/src/core/render-entries.ts
@@ -26,12 +26,15 @@ const extractFilesFromContent = (content: Message["content"]): string[] => {
     .filter((p): p is string => p !== null);
 };
 
-export const renderMessage = (msg: Message, index: number, full = false): RenderedEntry => {
+const clipCap = (maxChars: number | undefined, dflt: number): number =>
+  maxChars !== undefined ? Math.min(maxChars, dflt) : dflt;
+
+export const renderMessage = (msg: Message, index: number, full = false, maxChars?: number): RenderedEntry => {
   if (msg.role === "user") {
-    return { index, role: "user", summary: full ? textOf(msg.content) : clip(textOf(msg.content), 300) };
+    return { index, role: "user", summary: full ? textOf(msg.content) : clip(textOf(msg.content), clipCap(maxChars, 300)) };
   }
   if (msg.role === "toolResult") {
-    const text = full ? textOf(msg.content) : clip(textOf(msg.content), 200);
+    const text = full ? textOf(msg.content) : clip(textOf(msg.content), clipCap(maxChars, 200));
     return {
       index, role: "tool_result",
       summary: `[${msg.toolName}] ${text}`,
@@ -41,13 +44,16 @@ export const renderMessage = (msg: Message, index: number, full = false): Render
   if ((msg as any).role === "bashExecution") {
     const cmd = (msg as any).command ?? "";
     const out = (msg as any).output ?? "";
-    const text = full ? `$ ${cmd}\n${out}` : clip(`$ ${cmd}\n${out}`, 300);
+    const text = full ? `$ ${cmd}\n${out}` : clip(`$ ${cmd}\n${out}`, clipCap(maxChars, 300));
     return { index, role: "bash", summary: text };
   }
-  const text = full ? textOf(msg.content) : clip(textOf(msg.content), 300);
+  const text = full ? textOf(msg.content) : clip(textOf(msg.content), clipCap(maxChars, 300));
   const tools = toolCalls(msg.content);
   const files = extractFilesFromContent(msg.content);
-  const summary = tools ? `${tools}\n${text}` : text;
+  const combined = tools ? `${tools}\n${text}` : text;
+  // When a maxChars cap is in effect, bound the whole summary (tool args
+  // included) so tool-heavy ranges actually stay lean.
+  const summary = !full && maxChars !== undefined ? clip(combined, Math.min(maxChars, 300)) : combined;
   return { index, role: "assistant", summary, ...(files.length > 0 && { files }) };
 };
 

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -1,8 +1,11 @@
 import { Type } from "typebox";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { Message } from "@earendil-works/pi-ai";
 import { loadAllMessages } from "../core/load-messages";
 import { searchEntries, getTouchedFiles } from "../core/search-entries";
 import { formatRecallOutput, formatTouchedOutput } from "../core/format-recall";
+import { renderMessage } from "../core/render-entries";
+import type { RenderedEntry } from "../core/render-entries";
 import { getActiveLineageEntryIds } from "../core/lineage";
 import { normalizeRecallScope, normalizeRecallMode } from "../core/recall-scope";
 import { parseDrillDown, expandEntryFile } from "../core/drill-down";
@@ -10,8 +13,121 @@ import { parseDrillDown, expandEntryFile } from "../core/drill-down";
 const DEFAULT_RECENT = 25;
 const PAGE_SIZE = 5;
 
+/** Default total character budget for a pinned-range digest (~1.5k tokens). */
+export const RANGE_BUDGET_CHARS = 6000;
+/** Per-entry readability floor; below this entries degrade to unreadable stubs. */
+export const RANGE_MIN_CHARS = 50;
+
+/**
+ * Nth harmonic number H_n = Σ 1/i, the normalization constant for gradient
+ * allocation. Precompute once per call and pass to rangeCap.
+ */
+export const harmonicSum = (n: number): number => {
+  let s = 0;
+  for (let i = 1; i <= n; i++) s += 1 / i;
+  return s;
+};
+
+/**
+ * Gradient per-entry character cap for the pinned-range digest. The head of the
+ * range (oldest entries — the ones compaction erases first) gets full detail,
+ * decaying as 1/(position+1) toward a readability floor at the tail. renderMessage
+ * applies role ceilings (prose 300 / tool output 200) on top, so small ranges
+ * render exactly as today while large ranges self-bound in a single call.
+ */
+export const rangeCap = (
+  position: number,
+  total: number,
+  hSum: number,
+  budget = RANGE_BUDGET_CHARS,
+  minChars = RANGE_MIN_CHARS,
+): number => {
+  if (total <= 0) return 0;
+  const raw = (budget / (position + 1)) / hSum;
+  return Math.max(minChars, Math.min(300, Math.floor(raw)));
+};
+
 export const invalidExpandIndices = (requested: number[], available: Set<number>): number[] =>
   requested.filter((i) => !Number.isInteger(i) || !available.has(i));
+
+/**
+ * Validate the pinned-range form (from/to/limit). Returns an error string, or
+ * null when the params are usable. from/to are inclusive message indices, not
+ * turn numbers; both must be present together. 'limit' caps results and only
+ * applies to the pinned-range form.
+ */
+export const validateRangeParams = (
+  from: number | undefined,
+  to: number | undefined,
+  limit: number | undefined,
+): string | null => {
+  const hasFrom = from !== undefined;
+  const hasTo = to !== undefined;
+  if (hasFrom !== hasTo) {
+    return "Pinned-range recall requires both 'from' and 'to' (inclusive message indices). Example: vcc_recall({ from: 170, to: 217 })";
+  }
+  if (!hasFrom) {
+    if (limit !== undefined) {
+      return "'limit' only applies to the pinned-range form and must be paired with 'from' and 'to'.";
+    }
+    return null;
+  }
+  if (!Number.isInteger(from) || !Number.isInteger(to)) {
+    return "'from' and 'to' must be integer message indices.";
+  }
+  const f = from as number;
+  const t = to as number;
+  if (f > t) {
+    return `Invalid range: from (${f}) is greater than to (${t}). Indices are inclusive.`;
+  }
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
+    return "'limit' must be a positive integer.";
+  }
+  return null;
+};
+
+export interface RangeRecallResult {
+  /** Global message indices within [from..to], capped by 'limit' when provided. */
+  indices: number[];
+  /** Entries in the full range before any cap. */
+  total: number;
+  /** Expand indices that fall outside the range (or are non-integers). */
+  invalidExpand: number[];
+  /** True when 'limit' cut the range short. */
+  truncated: boolean;
+  /** Next 'from' index to continue from when truncated (last shown + 1). */
+  nextFrom: number | undefined;
+}
+
+/**
+ * Select the inclusive message-index range [from..to] from rendered entries.
+ * Returns global indices in ascending order. 'expand' indices are validated
+ * against the range. When 'limit' caps the result, nextFrom reports the index
+ * to continue from on the next call.
+ */
+export const selectRangeEntries = (
+  msgs: RenderedEntry[],
+  from: number,
+  to: number,
+  limit?: number,
+  expand?: number[],
+): RangeRecallResult => {
+  const ranged = msgs.filter((m) => m.index >= from && m.index <= to);
+  const rangedIndices = new Set(ranged.map((m) => m.index));
+  const invalidExpand = invalidExpandIndices(expand ?? [], rangedIndices);
+
+  const total = ranged.length;
+  const capped = limit !== undefined ? ranged.slice(0, limit) : ranged;
+  const truncated = limit !== undefined && capped.length < total;
+  const last = capped[capped.length - 1];
+  return {
+    indices: capped.map((m) => m.index),
+    total,
+    invalidExpand,
+    truncated,
+    nextFrom: truncated && last ? last.index + 1 : undefined,
+  };
+};
 
 export const registerRecallTool = (pi: ExtensionAPI) => {
   pi.registerTool({
@@ -25,20 +141,36 @@ export const registerRecallTool = (pi: ExtensionAPI) => {
       "list files worked on in this session with their entry indices, and #N:path to drill into a file's " +
       "content from an entry (#N:path:full for all lines). Note: apply_patch paths (inside the diff " +
       "payload) and bash redirects do not appear in the touched index. Only the current session is " +
-      "searchable — earlier sessions are not.",
+      "searchable — earlier sessions are not. Pinned-range form: vcc_recall({ from, to, limit?, expand?, " +
+      "scope? }) returns the inclusive message-index range [from..to] (indices, not turn numbers). If " +
+      "capped by 'limit', continue from the returned 'continue from' index. Range output is lean by " +
+      "default: one call returns the whole range as a digest, with detail decaying from the head of " +
+      "the range to the tail (older entries get more characters; expand returns verbatim content for " +
+      "specific indices).",
     promptSnippet:
       "vcc_recall: recall earlier parts of this session before saying the context is gone. " +
       "Plain keywords work best; scope:'all' widens to other conversation branches. " +
-      "mode:'touched' lists files worked on; #N:path drills into a file's content from an entry.",
+      "mode:'touched' lists files worked on; #N:path drills into a file's content from an entry. " +
+      "Pinned range: vcc_recall({ from, to, limit? }) — inclusive message indices; one-call digest with " +
+      "detail decaying head-to-tail; if capped, continue from the returned index.",
     parameters: Type.Object({
+      from: Type.Optional(
+        Type.Number({ description: "Inclusive start message index for pinned-range recall. Must be paired with 'to'. Indices are message indices, not turn numbers." }),
+      ),
+      to: Type.Optional(
+        Type.Number({ description: "Inclusive end message index for pinned-range recall. Must be paired with 'from'. Indices are message indices, not turn numbers." }),
+      ),
+      limit: Type.Optional(
+        Type.Number({ description: "Optional cap on entries returned for pinned-range recall. When capped, output includes a 'continue from' index to pass as 'from' on the next call." }),
+      ),
       query: Type.Optional(
-        Type.String({ description: "What to recall, in plain keywords (e.g. 'redis cache decision'). Multi-word queries are ranked by relevance. A regex pattern also works." }),
+        Type.String({ description: "What to recall, in plain keywords (e.g. 'redis cache decision'). Multi-word queries are ranked by relevance. A regex pattern also works. Ignored when the pinned-range form ('from'/'to') is used." }),
       ),
       expand: Type.Optional(
-        Type.Array(Type.Number(), { description: "Entry indices to return full untruncated content for" }),
+        Type.Array(Type.Number(), { description: "Entry indices to return full untruncated content for. In the pinned-range form, must fall within the requested range." }),
       ),
       page: Type.Optional(
-        Type.Number({ description: "Page number (1-based) for paginated search results. Default: 1." }),
+        Type.Number({ description: "Page number (1-based) for paginated search results. Default: 1. Not used in the pinned-range form (use 'limit' instead)." }),
       ),
       scope: Type.Optional(
         Type.Union([
@@ -66,6 +198,74 @@ export const registerRecallTool = (pi: ExtensionAPI) => {
       const lineageEntryIds = scope === "lineage"
         ? getActiveLineageEntryIds(ctx.sessionManager)
         : undefined;
+
+      // Pinned-range form: vcc_recall({ from, to, limit?, expand?, scope? }).
+      // from/to are inclusive message indices, not turn numbers. When capped by
+      // 'limit', the output reports a 'continue from' index for the next call.
+      const from = params.from ?? undefined;
+      const to = params.to ?? undefined;
+      const limit = params.limit ?? undefined;
+      const rangeError = validateRangeParams(from, to, limit);
+      if (rangeError) {
+        return { content: [{ type: "text", text: rangeError }], details: undefined };
+      }
+
+      if (from !== undefined && to !== undefined) {
+        const { rendered: msgs, rawMessages } = loadAllMessages(sessionFile, false, lineageEntryIds);
+        const expandArr = params.expand ?? [];
+        const expandSet = new Set(expandArr);
+        const { indices, total, invalidExpand, truncated, nextFrom } = selectRangeEntries(
+          msgs, from, to, limit, expandArr,
+        );
+
+        if (invalidExpand.length > 0) {
+          return {
+            content: [{ type: "text", text: `Cannot expand indices outside range ${from}..${to}: ${invalidExpand.join(", ")}` }],
+            details: undefined,
+          };
+        }
+
+        if (indices.length === 0) {
+          if (scope === "lineage") {
+            const { rendered: allMsgs } = loadAllMessages(sessionFile, false);
+            if (allMsgs.some((m) => m.index >= from && m.index <= to)) {
+              return {
+                content: [{ type: "text", text: `Indices ${from}..${to} exist but lie outside the active lineage. Use scope:'all' to reach them.` }],
+                details: undefined,
+              };
+            }
+          }
+          return {
+            content: [{ type: "text", text: `No messages found with indices ${from}..${to} in session history.` }],
+            details: undefined,
+          };
+        }
+
+        // Lean by default: gradient allocation gives the head of the range full
+        // detail and decays toward a readability floor at the tail, so a single
+        // call returns the whole range without pagination (role ceilings applied
+        // in renderMessage).
+        const hSum = harmonicSum(indices.length);
+        const rawByIndex = new Map<number, Message>();
+        msgs.forEach((m, i) => { rawByIndex.set(m.index, rawMessages[i]); });
+        const entries = indices.map((idx, position) => {
+          const raw = rawByIndex.get(idx);
+          if (!raw) return { index: idx, role: "unknown", summary: "[message unavailable]" } as RenderedEntry;
+          return expandSet.has(idx)
+            ? renderMessage(raw, idx, true)
+            : renderMessage(raw, idx, false, rangeCap(position, indices.length, hSum));
+        });
+
+        const scopeNote = scope === "all" ? ", scope: all" : "";
+        const header = `Pinned range #${from}..#${to} (${total} messages${scopeNote}${truncated ? `, showing ${entries.length}` : ""})`;
+        let output = formatRecallOutput(entries, undefined, header);
+        if (truncated && nextFrom !== undefined) {
+          const limitArg = limit !== undefined ? `, limit: ${limit}` : "";
+          const scopeArg = scope === "all" ? ', scope: "all"' : "";
+          output += `\n\n--- Capped at limit:${limit} (${entries.length} of ${total} shown). Continue from: ${nextFrom} — call vcc_recall({ from: ${nextFrom}, to: ${to}${limitArg}${scopeArg} }) for the rest ---`;
+        }
+        return { content: [{ type: "text", text: output }], details: undefined };
+      }
 
       // Drill-down: #N:path resolves to file-scoped tool content. Anchored so
       // inline mentions like "see #42:auth.ts" are never treated as drill-down.

--- a/tests/recall-range.test.ts
+++ b/tests/recall-range.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "bun:test";
+import type { RenderedEntry } from "../src/core/render-entries";
+import { renderMessage } from "../src/core/render-entries";
+import {
+  validateRangeParams,
+  selectRangeEntries,
+  rangeCap,
+  harmonicSum,
+  RANGE_BUDGET_CHARS,
+  RANGE_MIN_CHARS,
+} from "../src/tools/recall";
+
+const entry = (index: number, summary = `summary ${index}`): RenderedEntry => ({
+  index,
+  role: "user",
+  summary,
+});
+
+describe("validateRangeParams", () => {
+  it("accepts a valid pinned range", () => {
+    expect(validateRangeParams(170, 217, undefined)).toBeNull();
+    expect(validateRangeParams(170, 217, 80)).toBeNull();
+  });
+
+  it("requires both from and to", () => {
+    expect(validateRangeParams(170, undefined, undefined)).toContain("both 'from' and 'to'");
+    expect(validateRangeParams(undefined, 217, undefined)).toContain("both 'from' and 'to'");
+    expect(validateRangeParams(undefined, undefined, undefined)).toBeNull();
+  });
+
+  it("rejects limit without the range form", () => {
+    expect(validateRangeParams(undefined, undefined, 80)).toContain("'limit'");
+  });
+
+  it("rejects non-integer or inverted ranges", () => {
+    expect(validateRangeParams(1.5, 10, undefined)).toContain("integer");
+    expect(validateRangeParams(10, 1, undefined)).toContain("greater than to");
+  });
+
+  it("rejects non-positive limits", () => {
+    expect(validateRangeParams(1, 10, 0)).toContain("positive");
+    expect(validateRangeParams(1, 10, 2.5)).toContain("positive");
+  });
+});
+
+describe("harmonicSum / rangeCap", () => {
+  it("computes harmonic numbers", () => {
+    expect(harmonicSum(1)).toBe(1);
+    expect(harmonicSum(2)).toBe(1.5);
+    expect(harmonicSum(3)).toBeCloseTo(1.8333, 3);
+  });
+
+  it("clamps small ranges to full detail (head and tail)", () => {
+    const H = harmonicSum(3);
+    expect(rangeCap(0, 3, H)).toBe(300);
+    expect(rangeCap(2, 3, H)).toBe(300);
+  });
+
+  it("decays head-to-tail for large ranges", () => {
+    const H = harmonicSum(48);
+    expect(rangeCap(0, 48, H)).toBe(300); // clamped max
+    expect(rangeCap(10, 48, H)).toBe(Math.floor(RANGE_BUDGET_CHARS / 11 / H));
+    expect(rangeCap(47, 48, H)).toBe(RANGE_MIN_CHARS); // floored
+    expect(rangeCap(0, 48, H)).toBeGreaterThan(rangeCap(20, 48, H));
+  });
+
+  it("is monotonically non-increasing", () => {
+    const H = harmonicSum(100);
+    let prev = rangeCap(0, 100, H);
+    for (let i = 1; i < 100; i++) {
+      const c = rangeCap(i, 100, H);
+      expect(c).toBeLessThanOrEqual(prev);
+      prev = c;
+    }
+  });
+
+  it("returns 0 for empty ranges", () => {
+    expect(rangeCap(0, 0, harmonicSum(0))).toBe(0);
+  });
+});
+
+describe("renderMessage with maxChars", () => {
+  const longUser = { role: "user", content: "word ".repeat(500) } as const;
+  const longTool = {
+    role: "toolResult",
+    toolName: "bash",
+    content: "out ".repeat(500),
+  } as const;
+
+  it("clips prose to the allocation when it binds", () => {
+    const r = renderMessage(longUser, 7, false, 120);
+    expect(r.index).toBe(7);
+    expect(r.summary.length).toBeLessThanOrEqual(120);
+    expect(r.summary.length).toBeGreaterThan(60); // clipped but not a stub
+  });
+
+  it("keeps the default role ceiling when the allocation is generous", () => {
+    const r = renderMessage(longUser, 7, false, 600);
+    expect(r.summary.length).toBeLessThanOrEqual(300); // prose ceiling
+    expect(r.summary.length).toBeGreaterThan(200);
+  });
+
+  it("caps tool output at its tighter role ceiling", () => {
+    const r = renderMessage(longTool, 8, false, 600);
+    const body = r.summary.slice("[bash] ".length);
+    expect(body.length).toBeLessThanOrEqual(200); // tool ceiling
+    expect(r.summary.startsWith("[bash]")).toBe(true);
+  });
+
+  it("ignores maxChars when full content is requested", () => {
+    const r = renderMessage(longUser, 7, true, 50);
+    expect(r.summary.length).toBeGreaterThan(1000);
+  });
+
+  it("clips tool-call args when maxChars is set", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        { type: "toolCall", id: "tc", name: "bash", arguments: { command: "echo " + "x".repeat(500) } },
+        { type: "text", text: "done" },
+      ],
+    } as any;
+    const r = renderMessage(msg, 9, false, 80);
+    expect(r.summary.length).toBeLessThanOrEqual(80);
+    expect(r.summary).toContain("bash(command=echo");
+  });
+
+  it("renders short content unchanged", () => {
+    const r = renderMessage({ role: "user", content: "hi" }, 7, false, 50);
+    expect(r.summary).toBe("hi");
+  });
+});
+
+describe("selectRangeEntries", () => {
+  const msgs = Array.from({ length: 10 }, (_, i) => entry(i));
+
+  it("selects an inclusive range by global index", () => {
+    const r = selectRangeEntries(msgs, 3, 6);
+    expect(r.indices).toEqual([3, 4, 5, 6]);
+    expect(r.total).toBe(4);
+    expect(r.truncated).toBe(false);
+    expect(r.nextFrom).toBeUndefined();
+    expect(r.invalidExpand).toEqual([]);
+  });
+
+  it("returns empty for a range with no messages", () => {
+    const r = selectRangeEntries(msgs, 100, 200);
+    expect(r.indices).toEqual([]);
+    expect(r.total).toBe(0);
+  });
+
+  it("caps results and reports a continue-from index", () => {
+    const r = selectRangeEntries(msgs, 0, 9, 3);
+    expect(r.indices).toEqual([0, 1, 2]);
+    expect(r.truncated).toBe(true);
+    expect(r.nextFrom).toBe(3);
+    expect(r.total).toBe(10);
+  });
+
+  it("does not cap when limit covers the whole range", () => {
+    const r = selectRangeEntries(msgs, 2, 5, 10);
+    expect(r.truncated).toBe(false);
+    expect(r.nextFrom).toBeUndefined();
+    expect(r.indices.length).toBe(4);
+  });
+
+  it("reports expand indices outside the range as invalid", () => {
+    const r = selectRangeEntries(msgs, 2, 4, undefined, [7]);
+    expect(r.invalidExpand).toEqual([7]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a pinned-range form to `vcc_recall`, alongside the existing query/recent/touched/expand modes:

```ts
vcc_recall({ from: 170, to: 217 })                       // inclusive message indices
vcc_recall({ from: 170, to: 217, limit: 80, expand: [181, 193] })
vcc_recall({ from: 170, to: 217, scope: "all" })
```

- `from`/`to` are **inclusive global message indices** (not turn numbers); both are required together. Out-of-range `expand` indices error clearly; indices that exist but lie off the active lineage get a `scope:'all'` hint.
- `scope` (lineage/all) is honored like every other recall path.

## One call = the whole range (no pagination needed)

A pinned-range call returns the **entire range as a single digest**, so agents don't have to page through it. Token efficiency comes from a **head-weighted gradient**, not from paging: a fixed **6000-char budget** is allocated with harmonic decay (`1/(position+1)`), so the oldest entries — the ones compaction erases first — get full detail, while the tail collapses to one-line summaries (50-char floor; role ceilings of 300 prose / 200 tool output preserved).

| Range size | Head entries | Tail entries |
|---|---|---|
| ≤ ~20 entries | 300/200 (full) | same — identical to current rendering |
| 48 entries | 300 → ~120 | 50-char one-liners |
| 200+ entries | 300 → ~90 | 50-char one-liners |

`expand` still returns verbatim full content for specific indices (the escape hatch). `limit` remains an explicit opt-in: when passed, output reports **`Continue from: Y`** (`Y` = last shown + 1) with a ready-to-call snippet — no overlap on the next call.

## Files

- `src/tools/recall.ts` — range form: schema (`from`/`to`/`limit`), validation, selection, gradient allocation (`harmonicSum`/`rangeCap`)
- `src/core/render-entries.ts` — optional `maxChars` on `renderMessage`; when set it bounds the **whole** summary (tool-call args included — previously unclipped, so tool-heavy ranges weren't actually lean); default behavior unchanged
- `src/core/format-recall.ts` — header override no longer appends `for "undefined"` when no query is passed
- `tests/recall-range.test.ts` — new: validation, selection, gradient allocation, capped rendering

## Verification

- `bun test`: **275 pass / 0 fail** (up from 254 before this feature)
- `tsc --noEmit` (strict) on modified files: clean
- No build step — extension loads `index.ts` via jiti as before