### PR TITLE
feat(recall): improve search coverage and result quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@sting8k/pi-vcc` are documented in this file.
 
+## [0.7.0]
+
+### Features
+
+- **Recall searches bounded tool-call arguments** — commands, write content, edit text, queries, and other string arguments that previously existed in the session but were invisible to search are now indexed under one shared 2,000-character budget per message. Search snippets come from the same bounded text, while `vcc_recall` excludes its own invocation and output to prevent repeat-query feedback loops. File paths, global `#N` indices, lineage scope, `expand`, `mode:"touched"`, and `#N:path` keep their existing semantics.
+
+### Changes
+
+- **Recall trims noisy result tails and bounds pagination** — multi-term natural-language searches drop hits below 20% of the top BM25 score; single-term and regex searches skip that floor. Every search path is capped at 50 results (10 pages), with explicit `showing 50 of N matches` and out-of-range page messages instead of silently understating or misreporting results. On two real-session benchmark runs, the combined policy produced zero new empty searches and zero top-result changes, reduced median result counts from 32→18 and 29.5→20, and bounded p90 at 50.
+
 ## [0.6.1]
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sting8k/pi-vcc",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Algorithmic conversation compactor for pi - transcript-preserving structured summaries, no LLM calls",
   "main": "index.ts",
   "keywords": [

--- a/scripts/benchmark-recall-quality.ts
+++ b/scripts/benchmark-recall-quality.ts
@@ -1,0 +1,184 @@
+/**
+ * Phase 2 (vcc_recall noise floor + hard cap) constant selection evidence.
+ *
+ * Runs the REAL production `searchEntriesDetailed` (via its bench-only
+ * `tuning` override) against real session transcripts, comparing candidate
+ * relative-floor and hard-cap values. Not a duplicate scoring
+ * implementation — this exercises the exact code path that ships.
+ *
+ * Production policy baked into `searchEntriesDetailed` itself (not
+ * controlled by `tuning`): the relative floor only applies when the query
+ * has >=2 effective terms after stopword filtering. Single-term runs below
+ * therefore show identical counts across every floor candidate — that's the
+ * policy working, not a bug in this script.
+ *
+ * Usage: bun run scripts/benchmark-recall-quality.ts [sessionCount]
+ */
+import { renderMessage } from "../src/core/render-entries";
+import { searchEntriesDetailed, type SearchHit } from "../src/core/search-entries";
+import { prepareSessionSamples } from "../tests/support/real-sessions";
+import { loadSessionMessages } from "../tests/support/load-session";
+
+// Inlined (not imported from research/audit/metrics.ts) so this script has
+// no dependency on the gitignored research/ tree and stays reproducible from
+// a plain checkout.
+const quantile = (values: number[], q: number): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+  const pos = (sorted.length - 1) * q;
+  const lower = Math.floor(pos);
+  const upper = Math.ceil(pos);
+  if (lower === upper) return sorted[lower]!;
+  return sorted[lower]! + (sorted[upper]! - sorted[lower]!) * (pos - lower);
+};
+const median = (values: number[]): number => quantile(values, 0.5);
+
+const SESSION_COUNT = Number(process.argv[2] ?? 25);
+
+const STOPWORDS = new Set([
+  "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+  "have", "has", "had", "do", "does", "did", "will", "would", "could",
+  "should", "may", "might", "can", "shall", "of", "in", "to", "for",
+  "with", "on", "at", "from", "by", "as", "into", "through", "and", "that",
+  "this", "what", "which", "who", "you", "your", "i", "we", "it", "its",
+]);
+
+interface Query {
+  session: string;
+  kind: "single" | "multi";
+  text: string;
+}
+
+/** Pull candidate queries out of a session's own content — no synthetic corpus. */
+const queriesOf = (label: string, messages: ReturnType<typeof loadSessionMessages>["messages"]): Query[] => {
+  const words = new Set<string>();
+  const phrases: string[] = [];
+  for (const msg of messages) {
+    if (msg.role !== "user" && msg.role !== "assistant") continue;
+    const content = msg.content;
+    if (typeof content !== "string" && !Array.isArray(content)) continue;
+    const text = typeof content === "string"
+      ? content
+      : content.filter((p: any) => p.type === "text").map((p: any) => p.text).join(" ");
+    if (!text) continue;
+    const tokens = text.toLowerCase().match(/[a-z][a-z0-9_-]{3,}/g) ?? [];
+    const meaningful = tokens.filter((t) => !STOPWORDS.has(t));
+    for (const t of meaningful.slice(0, 6)) words.add(t);
+    if (msg.role === "user" && meaningful.length >= 2) {
+      phrases.push(meaningful.slice(0, 4).join(" "));
+    }
+  }
+  const singles = [...words].slice(0, 4).map((text): Query => ({ session: label, kind: "single", text }));
+  const multis = phrases.slice(0, 4).map((text): Query => ({ session: label, kind: "multi", text }));
+  return [...singles, ...multis];
+};
+
+interface RunResult {
+  hits: SearchHit[];
+  totalBeforeCap: number;
+  zero: boolean;
+  top1: number | undefined;
+  top5: number[];
+}
+
+const run = (rendered: any[], messages: any[], q: string, tuning: { relativeFloor?: number; cap?: number }): RunResult => {
+  const r = searchEntriesDetailed(rendered, messages, q, tuning);
+  return {
+    hits: r.hits,
+    totalBeforeCap: r.totalBeforeCap,
+    zero: r.hits.length === 0,
+    top1: r.hits[0]?.index,
+    top5: r.hits.slice(0, 5).map((h) => h.index),
+  };
+};
+
+const sameArr = (a: number[], b: number[]): boolean =>
+  a.length === b.length && a.every((v, i) => v === b[i]);
+
+async function main() {
+  console.log(`Sampling ${SESSION_COUNT} largest real sessions...`);
+  const samples = await prepareSessionSamples(SESSION_COUNT);
+
+  const allQueries: { label: string; rendered: any[]; messages: any[]; q: Query }[] = [];
+  for (const sample of samples) {
+    let loaded;
+    try {
+      loaded = loadSessionMessages(sample.copy);
+    } catch {
+      continue;
+    }
+    if (loaded.messages.length < 20) continue;
+    const rendered = loaded.messages.map((m, i) => renderMessage(m, i));
+    const label = sample.source.split("/").slice(-2).join("/");
+    for (const q of queriesOf(label, loaded.messages)) {
+      allQueries.push({ label, rendered, messages: loaded.messages, q });
+    }
+  }
+  console.log(`Sessions usable: ${new Set(allQueries.map((x) => x.label)).size}, queries generated: ${allQueries.length}`);
+  console.log("(counts vary with whatever real sessions happen to be available locally — treat exact numbers as one data point, not a fixed target.)");
+
+  // ── Floor comparison (cap disabled so it isolates the floor's effect) ──
+  const floorCandidates = [0, 0.1, 0.2, 0.25];
+  const baselineFloor = 0;
+
+  for (const kind of ["single", "multi"] as const) {
+    console.log(`\n=== Relative floor comparison — ${kind}-term queries ===`);
+    if (kind === "single") {
+      console.log("  Production policy applies the floor only to queries with >=2 effective terms;");
+      console.log("  for single-term queries every floor candidate below should be identical to floor=0 (no-op by design).");
+    }
+    const subset = allQueries.filter((x) => x.q.kind === kind);
+    console.log(`  queries: ${subset.length}`);
+    const baseRuns = subset.map((x) => run(x.rendered, x.messages, x.q.text, { relativeFloor: baselineFloor, cap: 1e9 }));
+    for (const floor of floorCandidates) {
+      const runs = subset.map((x) => run(x.rendered, x.messages, x.q.text, { relativeFloor: floor, cap: 1e9 }));
+      const counts = runs.map((r) => r.hits.length);
+      const baseCounts = baseRuns.map((r) => r.hits.length);
+      const zeroBefore = baseRuns.filter((r) => r.zero).length;
+      const zeroAfter = runs.filter((r) => r.zero).length;
+      const newZero = runs.filter((r, i) => !baseRuns[i].zero && r.zero).length;
+      const top1Changed = runs.filter((r, i) => baseRuns[i].top1 !== undefined && r.top1 !== baseRuns[i].top1).length;
+      const top5Changed = runs.filter((r, i) => !sameArr(r.top5, baseRuns[i].top5)).length;
+      console.log(
+        `  floor=${floor.toFixed(2)}: median ${median(counts)} (base ${median(baseCounts)}), ` +
+        `p90 ${quantile(counts, 0.9)} (base ${quantile(baseCounts, 0.9)}), ` +
+        `zero-hit ${zeroAfter}/${subset.length} (base ${zeroBefore}), newly-zeroed(should be 0)=${newZero}, ` +
+        `top1 changed ${top1Changed}/${subset.length}, top5 changed ${top5Changed}/${subset.length}`,
+      );
+    }
+  }
+
+  // ── Cap comparison (floor disabled so it isolates the cap's effect) ──
+  console.log(`\n=== Hard cap comparison (all queries, floor disabled) ===`);
+  const capCandidates = [1e9, 25, 50];
+  console.log(`  queries: ${allQueries.length}`);
+  for (const cap of capCandidates) {
+    const runs = allQueries.map((x) => run(x.rendered, x.messages, x.q.text, { relativeFloor: 0, cap }));
+    const counts = runs.map((r) => r.hits.length);
+    const totalBefore = runs.map((r) => r.totalBeforeCap);
+    console.log(
+      `  cap=${cap === 1e9 ? "none" : cap}: median ${median(counts)}, p90 ${quantile(counts, 0.9)}, ` +
+      `max ${Math.max(...counts)}, median-uncapped-total ${median(totalBefore)}, ` +
+      `queries truncated by this cap: ${runs.filter((r) => r.totalBeforeCap > r.hits.length).length}/${allQueries.length}`,
+    );
+  }
+
+  // ── Combined PRODUCTION POLICY (floor=0.20 for multi-term only, cap=50)
+  //    vs raw baseline (no floor, no cap) ──
+  console.log(`\n=== Combined production policy (floor=0.20 multi-term-only, cap=50) vs raw baseline ===`);
+  // No script-side gating needed here: searchEntriesDetailed itself only
+  // applies relativeFloor when the query has >=2 effective terms, so calling
+  // it with {relativeFloor: 0.2, cap: 50} already reflects exactly what
+  // ships — including the single-term no-op.
+  const combined = allQueries.map((x) => run(x.rendered, x.messages, x.q.text, { relativeFloor: 0.2, cap: 50 }));
+  const baseline = allQueries.map((x) => run(x.rendered, x.messages, x.q.text, { relativeFloor: 0, cap: 1e9 }));
+  const zeroBefore = baseline.filter((r) => r.zero).length;
+  const zeroAfter = combined.filter((r) => r.zero).length;
+  const top1Changed = combined.filter((r, i) => baseline[i].top1 !== undefined && r.top1 !== baseline[i].top1).length;
+  const top5Changed = combined.filter((r, i) => !sameArr(r.top5, baseline[i].top5)).length;
+  console.log(`  zero-hit before: ${zeroBefore}/${allQueries.length}, after: ${zeroAfter}/${allQueries.length}`);
+  console.log(`  top1 changed: ${top1Changed}/${allQueries.length}, top5 changed: ${top5Changed}/${allQueries.length}`);
+  console.log(`  median result count before: ${median(baseline.map((r) => r.hits.length))}, after: ${median(combined.map((r) => r.hits.length))}`);
+  console.log(`  p90 result count before: ${quantile(baseline.map((r) => r.hits.length), 0.9)}, after: ${quantile(combined.map((r) => r.hits.length), 0.9)}`);
+}
+
+main();

--- a/src/commands/vcc-recall.ts
+++ b/src/commands/vcc-recall.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { loadAllMessages } from "../core/load-messages";
-import { searchEntries } from "../core/search-entries";
+import { searchEntriesDetailed } from "../core/search-entries";
 import { formatRecallOutput } from "../core/format-recall";
 import { getActiveLineageEntryIds } from "../core/lineage";
 import { parseRecallScope } from "../core/recall-scope";
@@ -46,17 +46,48 @@ export const registerVccRecallCommand = (pi: ExtensionAPI) => {
       }
 
       const { rendered, rawMessages } = loadAllMessages(sessionFile, false, lineageEntryIds);
-      const allResults = searchEntries(rendered, rawMessages, query);
+      const { hits, totalBeforeCap, truncated } = searchEntriesDetailed(rendered, rawMessages, query);
+      // Single source of truth for page count: hits.length, the same array
+      // that's actually paginated below (already floor-filtered and capped).
+      const totalPages = Math.ceil(hits.length / PAGE_SIZE);
+      const scopeSuffix = parsed.scope === "all" ? " (scope: all)" : "";
+      const scopeArg = parsed.scope === "all" ? " scope:all" : "";
+      // The hard cap can discard genuine matches; hits.length alone would
+      // then understate the real total. Say so explicitly instead of
+      // reporting the capped count as if it were everything. Neutral
+      // wording ("showing", not "showing top"): regex-path hits are
+      // boolean/chronological matches with no relevance score, so "top"
+      // would falsely imply a ranking that only the BM25 path has.
+      const truncationNote = truncated
+        ? ` — showing ${hits.length} of ${totalBeforeCap} matches, refine your query for more precise results`
+        : "";
+
+      // The hard cap creates a fixed reachable page range (1..totalPages).
+      // A page beyond it isn't "no matches" — matches exist, the page just
+      // isn't reachable. Say so explicitly instead of falling through to
+      // formatRecallOutput's zero-hit message, which would be false here.
+      if (hits.length > 0 && page > totalPages) {
+        // truncationNote already ends in "...refine your query" when the hard
+        // cap kicked in — don't repeat that suggestion here, just say which
+        // pages exist. Only add "or refine your query" when there's no
+        // truncation note to have said it already.
+        const guidance = truncated
+          ? `Use /pi-vcc-recall ${query}${scopeArg} page:N with N between 1 and ${totalPages}.`
+          : `Use /pi-vcc-recall ${query}${scopeArg} page:N with N between 1 and ${totalPages}, or refine your query.`;
+        const text =
+          `Page ${page} is outside the available range 1-${totalPages} ` +
+          `(${hits.length} matches${scopeSuffix}${truncationNote}). ${guidance}`;
+        pi.sendMessage({ customType: "vcc-recall", content: text, display: true }, { triggerTurn: true });
+        return;
+      }
 
       const start = (page - 1) * PAGE_SIZE;
-      const pageResults = allResults.slice(start, start + PAGE_SIZE);
-      const totalPages = Math.ceil(allResults.length / PAGE_SIZE);
-      const scopeSuffix = parsed.scope === "all" ? " (scope: all)" : "";
+      const pageResults = hits.slice(start, start + PAGE_SIZE);
       const header = totalPages > 1
-        ? `Page ${page}/${totalPages} (${allResults.length} total matches${scopeSuffix})`
-        : `${allResults.length} matches${scopeSuffix}`;
+        ? `Page ${page}/${totalPages} (${hits.length} total matches${scopeSuffix}${truncationNote})`
+        : `${hits.length} matches${scopeSuffix}${truncationNote}`;
       const footer = page < totalPages
-        ? `\n--- /pi-vcc-recall ${query}${parsed.scope === "all" ? " scope:all" : ""} page:${page + 1} ---`
+        ? `\n--- /pi-vcc-recall ${query}${scopeArg} page:${page + 1} ---`
         : "";
       const output = formatRecallOutput(pageResults, query, header) + footer;
       pi.sendMessage({ customType: "vcc-recall", content: output, display: true }, { triggerTurn: true });

--- a/src/core/content.ts
+++ b/src/core/content.ts
@@ -114,6 +114,36 @@ export const extractToolCallText = (args: Record<string, unknown>): string => {
   return text;
 };
 
+/**
+ * Extract every scalar string argument from a tool call for search indexing
+ * — command, query, content, oldText/newText, etc. Generic value walk (no
+ * tool-name allowlist): top-level strings plus strings one level into
+ * array-of-object fields (e.g. `edits`). Unbounded by design — a single
+ * toolCall's raw argument text — so a message with several toolCalls doesn't
+ * silently multiply an internal cap. The caller (search-entries.ts) applies
+ * one shared budget across all toolCalls in a message.
+ */
+export const extractToolCallArgsText = (args: Record<string, unknown>): string => {
+  if (!args || typeof args !== "object") return "";
+  const parts: string[] = [];
+  for (const value of Object.values(args)) {
+    if (typeof value === "string") {
+      parts.push(value);
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === "string") {
+          parts.push(item);
+        } else if (item && typeof item === "object") {
+          for (const v of Object.values(item)) {
+            if (typeof v === "string") parts.push(v);
+          }
+        }
+      }
+    }
+  }
+  return parts.join("\n");
+};
+
 /** Extract a snippet of ~`radius` chars around the first match of `term` in `text`. */
 export const snippet = (text: string, term: string, radius = 60): string | null => {
   const idx = text.toLowerCase().indexOf(term.toLowerCase());

--- a/src/core/search-entries.ts
+++ b/src/core/search-entries.ts
@@ -454,9 +454,19 @@ const applyRelativeFloor = (
   return scored.filter((s) => s.score >= topScore * floor);
 };
 
-/** Bound `hits` to `cap` entries (order preserved), reporting the pre-cap
- *  count so callers can signal truncation honestly instead of understating
- *  "total matches". */
+/**
+ * Bound `hits` to `cap` entries, reporting the pre-cap count so callers can
+ * signal truncation honestly instead of understating "total matches".
+ *
+ * Order preserved, never re-sorted: for the BM25 path that's already
+ * highest-score-first, so `slice(0, cap)` keeps the top `cap` hits. For the
+ * regex path there is no score — hits are collected in entry/chronological
+ * iteration order, so `slice(0, cap)` keeps the OLDEST `cap` matches, not
+ * the most recent or most relevant ones. That is an explicit, documented
+ * preservation choice for this change, not a new selection/ranking policy —
+ * changing which matches a truncated regex search keeps (e.g. newest-first)
+ * is a separate decision, out of scope here.
+ */
 const capHits = (hits: SearchHit[], cap: number): SearchResult => {
   const totalBeforeCap = hits.length;
   const capped = totalBeforeCap > cap ? hits.slice(0, cap) : hits;

--- a/src/core/search-entries.ts
+++ b/src/core/search-entries.ts
@@ -1,6 +1,6 @@
 import type { Message } from "@earendil-works/pi-ai";
 import type { RenderedEntry } from "./render-entries";
-import { textOf, isContentBearing, extractToolCallText } from "./content";
+import { textOf, isContentBearing, extractToolCallText, extractToolCallArgsText, clip } from "./content";
 
 export interface SearchHit extends RenderedEntry {
   /** Context snippet around the first matched term (only when query provided) */
@@ -222,12 +222,71 @@ const lineSnippet = (text: string, regex: RegExp, contextLines = 2): string | un
   return parts.join("\n");
 };
 
-/** Build full searchable text for a message. */
+/**
+ * Aggregate character budget for ALL toolCall arguments appended to one
+ * message's searchable text — a single shared budget across every toolCall
+ * in the message, not per call, so N toolCalls can't multiply the bound and
+ * make one message's contribution to the BM25 doc corpus unbounded.
+ *
+ * Head-only cap: content past this budget is not indexed via toolCall
+ * arguments at all. This is an honest tradeoff, not a proxy for full
+ * coverage — a Write/Edit tool result commonly only acknowledges success
+ * (e.g. "wrote 400 lines"), so a fact buried past the cap in a giant
+ * argument is not guaranteed to be searchable elsewhere either.
+ */
+const TOOL_ARGS_BUDGET = 2000;
+
+/**
+ * Tool name of the recall tool itself (src/tools/recall.ts). A search
+ * operation must not match its own query or its own prior output: the
+ * vcc_recall invocation is persisted as an ordinary assistant toolCall (its
+ * `{ query }` argument, excluded below in `toolCallArgsText`) followed by an
+ * ordinary toolResult message (its `N matches for "<query>"` text, excluded
+ * in `fullText`) — without both exclusions a repeated query keeps matching
+ * its own prior invocation/output and the hit count grows on every search.
+ * This is a targeted introspection invariant for one named tool, not a
+ * general allowlist/blocklist over tool names or tool results.
+ */
+const RECALL_TOOL_NAME = "vcc_recall";
+
+/** Text of every toolCall's arguments in a message's content, for search —
+ *  bounded once, in aggregate, by TOOL_ARGS_BUDGET. Excludes the recall
+ *  tool's own arguments (see RECALL_TOOL_NAME). */
+const toolCallArgsText = (content: Message["content"]): string => {
+  if (!content || typeof content === "string") return "";
+  const raw = content
+    .filter((part) => part.type === "toolCall")
+    .filter((part) => part.name?.toLowerCase() !== RECALL_TOOL_NAME)
+    .map((part) => extractToolCallArgsText(part.arguments))
+    .filter(Boolean)
+    .join("\n");
+  return clip(raw, TOOL_ARGS_BUDGET);
+};
+
+/**
+ * Build full searchable text for a message: text parts plus toolCall
+ * arguments (bash command, Write/Edit content, etc.) so a match that only
+ * exists in a tool call's arguments is still findable and its snippet is
+ * derived from the same text.
+ *
+ * The recall tool's own toolResult is excluded (searchable text ""): it
+ * echoes back `N matches for "<query>"` from the *previous* recall call, so
+ * indexing it would make a repeated query self-match and grow with every
+ * search. This only affects search indexing — browse/no-query returns
+ * entries before fullText runs (see `searchEntries`), and #N expand reads
+ * the message/entry directly, not through this function, so the toolResult
+ * is still fully visible there.
+ */
 const fullText = (msg: Message): string => {
   if ((msg as any).role === "bashExecution") {
     return `${(msg as any).command ?? ""} ${(msg as any).output ?? ""}`;
   }
-  return textOf(msg.content);
+  if (msg.role === "toolResult" && msg.toolName?.toLowerCase() === RECALL_TOOL_NAME) {
+    return "";
+  }
+  const text = textOf(msg.content);
+  const argsText = toolCallArgsText(msg.content);
+  return argsText ? `${text}\n${argsText}` : text;
 };
 
 /**

--- a/src/core/search-entries.ts
+++ b/src/core/search-entries.ts
@@ -8,6 +8,20 @@ export interface SearchHit extends RenderedEntry {
   /** Number of query terms matched (for ranking) */
   matchCount?: number;
 }
+
+/**
+ * Result of a search, with enough metadata for a caller to report truncation
+ * honestly (see `searchEntriesDetailed`). `searchEntries` stays `SearchHit[]`
+ * for existing call sites that only need the hits themselves.
+ */
+export interface SearchResult {
+  hits: SearchHit[];
+  /** Genuine matches found before the hard cap was applied (after any
+   *  relative-floor noise filtering). May exceed `hits.length`. */
+  totalBeforeCap: number;
+  /** True when the hard cap discarded matches (`totalBeforeCap > hits.length`). */
+  truncated: boolean;
+}
 /** A file touched in one entry — used by mode:touched aggregation. */
 export interface FileTouch {
   index: number;
@@ -342,13 +356,128 @@ export function getTouchedFiles(
   return Array.from(map.values());
 }
 
-export const searchEntries = (
+/**
+ * Relative BM25 noise floor for MULTI-TERM natural-language queries only:
+ * after sorting by score, drop hits scoring below this fraction of the top
+ * score. Relative (not absolute) because BM25 magnitudes vary with corpus
+ * size and document length, so a fixed score threshold would behave
+ * inconsistently across short vs. long sessions.
+ *
+ * Applied only when the query has >=2 DISTINCT effective terms after
+ * stopword filtering and case/duplicate normalization (see the
+ * `effectiveTermCount >= 2` gate below `searchEntriesDetailed` uses before
+ * calling `applyRelativeFloor`). Distinct, not raw count: "auth auth" or
+ * "Auth AUTH" is semantically a single-term query and must bypass the floor
+ * like any other single term — repeating or casing a word doesn't turn it
+ * into the multi-term OR-tail noise this floor targets. The normalization is
+ * gate-only; it doesn't change `terms` or the BM25 scoring itself, which
+ * already matches case-insensitively. For a genuine single term, every hit's
+ * occurrence already satisfies the whole query — its BM25 score differences
+ * reflect term frequency and document length, not multi-term OR-tail noise,
+ * so filtering by it there risks real matches for no corresponding noise
+ * reduction. Evidence below confirmed this rather than assuming it.
+ *
+ * Evidence (scripts/benchmark-recall-quality.ts, run through this exact
+ * production function via its `tuning` override — not a duplicate scoring
+ * implementation). Two independent runs against real session corpora (23
+ * sessions/161 queries and 31 sessions/222 queries; exact counts vary with
+ * whatever real sessions are available locally, so both are reported rather
+ * than treating one as a fixed target):
+ *   - floor=0.20 on multi-term queries: median result count 49→23 (run 1,
+ *     n=69) and 60.5→23.5 (run 2, n=98); p90 142.8→81 and 126.2→75.3.
+ *     Zero-hit count stayed 0 in both runs, top-1 never changed (0/69,
+ *     0/98). Top-5 membership shifted in 5/69 (7%) and 5/98 (5%).
+ *   - floor=0.10 was too weak to "meaningfully" remove the tail (multi-term
+ *     median only 49→39 / 60.5→42); floor=0.25 removed more but roughly
+ *     doubled the multi-term top-5 disruption (8/69, run 1) for little extra
+ *     median gain over 0.20. 0.20 is the least aggressive setting that
+ *     meaningfully thinned the tail.
+ *   - Single-term queries with the floor gated off: every floor candidate
+ *     (0, 0.10, 0.20, 0.25) produced byte-identical results — 0/92 and
+ *     0/124 top-5 changes in both runs, confirming the gate is a true no-op
+ *     rather than an untested assumption. Before this gate existed, applying
+ *     0.20 unconditionally still changed single-term top-5 in a small but
+ *     non-zero fraction of queries (1/140 in this repo's own rerun, 1/124 in
+ *     an independent reviewer rerun) for negligible median movement — real
+ *     false-negative risk for no real noise benefit, which is why the gate
+ *     exists.
+ *
+ * The top-scoring hit always survives by construction, independent of the
+ * evidence above: its own score always satisfies `score >= topScore * floor`
+ * for any floor <= 1, so a non-empty scored[] can never be filtered to zero.
+ */
+const BM25_RELATIVE_FLOOR = 0.2;
+
+/**
+ * Hard cap on total SEARCH results, applied to both the natural-language
+ * (post-floor) and regex result paths so pagination stays bounded regardless
+ * of how noisy or broad a query is.
+ *
+ * Evidence (same bench/corpora as BM25_RELATIVE_FLOOR, floor disabled to
+ * isolate the cap's effect; run 1 = 161 queries, run 2 = 222 queries):
+ * uncapped result counts ranged up to 380 (median 32 / 29.5, p90 119 /
+ * 115.9). cap=50 sits ABOVE the corpus's own median in both runs but BELOW
+ * its p90 — it leaves the typical (median) query unclipped while still
+ * bounding the long tail: only 46/161 (29%) and 66/222 (30%) of queries were
+ * truncated by it, versus 90/161 (56%) and 124/222 (56%) for cap=25, which
+ * would also clip plenty of unremarkable ~30-match queries well under what
+ * "noisy" implies. cap=50 also bounds the worst case (380) down by 87%.
+ * Combined with the floor (production policy: floor=0.20 multi-term-only,
+ * cap=50, vs. no filtering at all): 0 zero-hit regressions and 0 top-1
+ * changes in both runs; top-5 changed in 5/161 (3%) and 5/222 (2%); median
+ * result count 32→18 and 29.5→20; p90 119→50 and 115.9→50.
+ */
+const SEARCH_RESULT_CAP = 50;
+
+/**
+ * Tuning overrides for `searchEntriesDetailed`. Exists only so the offline
+ * bench (scripts/benchmark-recall-quality.ts) and targeted tests can
+ * exercise the real scoring/capping pipeline against candidate constants —
+ * production call sites (`searchEntries`, the recall tool) never pass this
+ * and always get `BM25_RELATIVE_FLOOR`/`SEARCH_RESULT_CAP`.
+ */
+export interface SearchTuning {
+  relativeFloor?: number;
+  cap?: number;
+}
+
+/** Drop scored hits below `floor` of the top score. The top hit's own score
+ *  always passes (score >= score * floor for floor <= 1), so this can never
+ *  turn a non-empty `scored` into an empty result. */
+const applyRelativeFloor = (
+  scored: Array<{ hit: SearchHit; score: number }>,
+  floor: number,
+): Array<{ hit: SearchHit; score: number }> => {
+  if (scored.length === 0) return scored;
+  const topScore = scored[0].score;
+  if (topScore <= 0) return scored;
+  return scored.filter((s) => s.score >= topScore * floor);
+};
+
+/** Bound `hits` to `cap` entries (order preserved), reporting the pre-cap
+ *  count so callers can signal truncation honestly instead of understating
+ *  "total matches". */
+const capHits = (hits: SearchHit[], cap: number): SearchResult => {
+  const totalBeforeCap = hits.length;
+  const capped = totalBeforeCap > cap ? hits.slice(0, cap) : hits;
+  return { hits: capped, totalBeforeCap, truncated: capped.length < totalBeforeCap };
+};
+
+/**
+ * Full search with truncation metadata. `searchEntries` below is a thin
+ * `.hits`-only wrapper kept for existing call sites; use this directly when
+ * a caller (the recall tool) needs to report a capped result set honestly.
+ */
+export const searchEntriesDetailed = (
   entries: RenderedEntry[],
   messages: Message[],
   query?: string,
-): SearchHit[] => {
-  if (!query?.trim()) return entries;
+  tuning?: SearchTuning,
+): SearchResult => {
+  if (!query?.trim()) return { hits: entries, totalBeforeCap: entries.length, truncated: false };
 
+  const relativeFloor = tuning?.relativeFloor ?? BM25_RELATIVE_FLOOR;
+  const cap = tuning?.cap ?? SEARCH_RESULT_CAP;
   const rawQuery = query.trim();
   const checkBudget = startBudget();
 
@@ -360,6 +489,9 @@ export const searchEntries = (
   // verbatim. On real sessions that path returned nothing 47.5% of the time
   // versus 1.1% for term search. Mode detection must never silently lose
   // results, so an empty regex result falls through to term search below.
+  //
+  // No relative-floor filtering here: regex matches are boolean (matched or
+  // not), there's no score to be relative to. Only the hard cap applies.
   if (looksLikeRegex(rawQuery)) {
     const regex = safeRegex(rawQuery);
     const hits: SearchHit[] = [];
@@ -375,7 +507,7 @@ export const searchEntries = (
         hits.push({ ...e, snippet: snip, matchCount: 1 });
       }
     }
-    if (hits.length > 0) return hits;
+    if (hits.length > 0) return capHits(hits, cap);
   }
 
   // Natural language / multi-word query: BM25 scoring
@@ -411,7 +543,23 @@ export const searchEntries = (
     });
   }
 
-  // Sort by BM25 score desc
+  // Sort by BM25 score desc, then drop the noisy long tail relative to the
+  // top score (multi-term queries only — see BM25_RELATIVE_FLOOR), then
+  // apply the hard cap.
   scored.sort((a, b) => b.score - a.score);
-  return scored.map((s) => s.hit);
+  // Gate on DISTINCT normalized terms, not raw term count: "auth auth" or
+  // "Auth AUTH" is semantically a single-term query and must bypass the
+  // floor like any other single term — repeating/casing a word doesn't turn
+  // it into the multi-term OR-tail noise this floor targets. This is a
+  // gate-only normalization; it does not change `terms` itself or the BM25
+  // scoring above, which already matches case-insensitively.
+  const effectiveTermCount = new Set(terms.map((t) => t.toLowerCase())).size;
+  const floored = effectiveTermCount >= 2 ? applyRelativeFloor(scored, relativeFloor) : scored;
+  return capHits(floored.map((s) => s.hit), cap);
 };
+
+export const searchEntries = (
+  entries: RenderedEntry[],
+  messages: Message[],
+  query?: string,
+): SearchHit[] => searchEntriesDetailed(entries, messages, query).hits;

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -157,10 +157,16 @@ export const registerRecallTool = (pi: ExtensionAPI) => {
         // isn't reachable. Say so explicitly instead of falling through to
         // formatRecallOutput's zero-hit message, which would be false here.
         if (hits.length > 0 && page > totalPages) {
+          // truncationNote already ends in "...refine your query" when the
+          // hard cap kicked in — don't repeat that suggestion here, just say
+          // which pages exist. Only add "or refine your query" when there's
+          // no truncation note to have said it already.
+          const guidance = truncated
+            ? `Use a page between 1 and ${totalPages}.`
+            : `Use a page between 1 and ${totalPages}, or refine your query.`;
           const text =
             `Page ${page} is outside the available range 1-${totalPages} ` +
-            `(${hits.length} matches${scopeSuffix}${truncationNote}). ` +
-            `Use a page between 1 and ${totalPages}, or refine your query.`;
+            `(${hits.length} matches${scopeSuffix}${truncationNote}). ${guidance}`;
           return {
             content: [{ type: "text", text }],
             details: undefined,

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -1,7 +1,7 @@
 import { Type } from "typebox";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { loadAllMessages } from "../core/load-messages";
-import { searchEntries, getTouchedFiles } from "../core/search-entries";
+import { searchEntriesDetailed, getTouchedFiles } from "../core/search-entries";
 import { formatRecallOutput, formatTouchedOutput } from "../core/format-recall";
 import { getActiveLineageEntryIds } from "../core/lineage";
 import { normalizeRecallScope, normalizeRecallMode } from "../core/recall-scope";
@@ -134,19 +134,44 @@ export const registerRecallTool = (pi: ExtensionAPI) => {
       }
 
       const { rendered: msgs, rawMessages } = loadAllMessages(sessionFile, false, lineageEntryIds);
-      const allResults = params.query?.trim()
-        ? searchEntries(msgs, rawMessages, params.query)
-        : msgs.slice(-DEFAULT_RECENT);
 
       if (params.query?.trim()) {
+        const { hits, totalBeforeCap, truncated } = searchEntriesDetailed(msgs, rawMessages, params.query);
         const page = Math.max(1, params.page ?? 1);
-        const start = (page - 1) * PAGE_SIZE;
-        const pageResults = allResults.slice(start, start + PAGE_SIZE);
-        const totalPages = Math.ceil(allResults.length / PAGE_SIZE);
+        // Single source of truth for page count: hits.length, the same array
+        // that's actually paginated below (already floor-filtered and capped).
+        const totalPages = Math.ceil(hits.length / PAGE_SIZE);
         const scopeSuffix = scope === "all" ? " (scope: all)" : "";
+        // The hard cap can discard genuine matches; hits.length alone would
+        // then understate the real total. Say so explicitly instead of
+        // reporting the capped count as if it were everything. Neutral
+        // wording ("showing", not "showing top"): regex-path hits are
+        // boolean/chronological matches with no relevance score, so "top"
+        // would falsely imply a ranking that only the BM25 path has.
+        const truncationNote = truncated
+          ? ` — showing ${hits.length} of ${totalBeforeCap} matches, refine your query for more precise results`
+          : "";
+
+        // The hard cap creates a fixed reachable page range (1..totalPages).
+        // A page beyond it isn't "no matches" — matches exist, the page just
+        // isn't reachable. Say so explicitly instead of falling through to
+        // formatRecallOutput's zero-hit message, which would be false here.
+        if (hits.length > 0 && page > totalPages) {
+          const text =
+            `Page ${page} is outside the available range 1-${totalPages} ` +
+            `(${hits.length} matches${scopeSuffix}${truncationNote}). ` +
+            `Use a page between 1 and ${totalPages}, or refine your query.`;
+          return {
+            content: [{ type: "text", text }],
+            details: undefined,
+          };
+        }
+
+        const start = (page - 1) * PAGE_SIZE;
+        const pageResults = hits.slice(start, start + PAGE_SIZE);
         const header = totalPages > 1
-          ? `Page ${page}/${totalPages} (${allResults.length} total matches${scopeSuffix})`
-          : `${allResults.length} matches${scopeSuffix}`;
+          ? `Page ${page}/${totalPages} (${hits.length} total matches${scopeSuffix}${truncationNote})`
+          : `${hits.length} matches${scopeSuffix}${truncationNote}`;
         const footer = page < totalPages
           ? `\n--- Use page:${page + 1}${scope === "all" ? " with scope:'all'" : ""} for more results ---`
           : "";
@@ -157,7 +182,7 @@ export const registerRecallTool = (pi: ExtensionAPI) => {
         };
       }
 
-      const output = (scope === "all" ? "Scope: all\n\n" : "") + formatRecallOutput(allResults, params.query);
+      const output = (scope === "all" ? "Scope: all\n\n" : "") + formatRecallOutput(msgs.slice(-DEFAULT_RECENT), params.query);
       return {
         content: [{ type: "text", text: output }],
         details: undefined,

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { textParts, textOf, clip, firstLine } from "../src/core/content";
+import { textParts, textOf, clip, firstLine, extractToolCallArgsText } from "../src/core/content";
 
 describe("textParts", () => {
   it("returns [] for undefined content", () => {
@@ -27,5 +27,33 @@ describe("textParts", () => {
 describe("textOf", () => {
   it("returns empty string for undefined content", () => {
     expect(textOf(undefined as any)).toBe("");
+  });
+});
+
+describe("extractToolCallArgsText", () => {
+  it("extracts top-level string scalars (e.g. bash command)", () => {
+    expect(extractToolCallArgsText({ command: "grep -rn foo src" })).toBe("grep -rn foo src");
+  });
+
+  it("extracts strings from array-of-object fields (e.g. edits[])", () => {
+    const args = { path: "a.ts", edits: [{ oldText: "old", newText: "new" }] };
+    const text = extractToolCallArgsText(args);
+    expect(text).toContain("a.ts");
+    expect(text).toContain("old");
+    expect(text).toContain("new");
+  });
+
+  it("ignores non-string scalars (numbers/booleans)", () => {
+    expect(extractToolCallArgsText({ limit: 50, verbose: true })).toBe("");
+  });
+
+  it("returns '' for missing/invalid args", () => {
+    expect(extractToolCallArgsText(undefined as any)).toBe("");
+    expect(extractToolCallArgsText(null as any)).toBe("");
+  });
+
+  it("does not clip on its own — extraction is unbounded; the caller (search-entries.ts) owns the budget", () => {
+    const text = extractToolCallArgsText({ content: "x".repeat(10_000) });
+    expect(text.length).toBe(10_000);
   });
 });

--- a/tests/recall-quality.test.ts
+++ b/tests/recall-quality.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { registerRecallTool } from "../src/tools/recall";
+
+// ── Helpers (mirrors tests/recall-tool-scope.test.ts) ──────────────────────
+
+const userMsg = (id: string, content: string) => ({
+  type: "message",
+  id,
+  message: { role: "user", content },
+});
+
+let dirCount = 0;
+const makeSession = (n: number, textOf: (i: number) => string) => {
+  const dir = mkdtempSync(join(tmpdir(), `pi-vcc-recall-quality-${dirCount++}-`));
+  const file = join(dir, "session.jsonl");
+  const ids = Array.from({ length: n }, (_, i) => `m${i}`);
+  const lines = ids.map((id, i) => JSON.stringify(userMsg(id, textOf(i))));
+  writeFileSync(file, lines.join("\n") + "\n", "utf8");
+  return { dir, file, ids };
+};
+
+const register = () => {
+  let tool: any;
+  registerRecallTool({ registerTool: (t: any) => { tool = t; } } as any);
+  return tool;
+};
+
+const invoke = async (tool: any, file: string, ids: string[], params: Record<string, unknown>) => {
+  const result = await tool.execute("tool-call", params, undefined, undefined, {
+    sessionManager: {
+      getSessionFile: () => file,
+      getBranch: () => ids.map((id) => ({ id })),
+      getEntries: () => ids.map((id) => ({ id })),
+    },
+  });
+  return result.content[0].text as string;
+};
+
+describe("vcc_recall pagination and hard-cap truncation signaling", () => {
+  it("reports a capped page count and an explicit truncation message when raw hits exceed the cap", async () => {
+    // "." makes this a regex-mode query, matching every one of the 60
+    // messages deterministically (no BM25/floor involved) — isolates the
+    // hard cap's effect on the tool-facing header/footer.
+    const { dir, file, ids } = makeSession(60, (i) => `zebra_query_tag entry number ${i}`);
+    try {
+      const tool = register();
+      const output = await invoke(tool, file, ids, { query: "zebra_query_tag.*entry" });
+
+      // 60 raw matches capped to 50 → 10 pages of 5.
+      expect(output).toContain("Page 1/10");
+      expect(output).toContain("50 total matches");
+      // Truthful truncation signal: must not claim 50 is the whole story.
+      // Neutral wording ("showing", not "showing top") — this is the regex
+      // path, which has no relevance ranking, so "top" would be a false claim.
+      expect(output).toContain("showing 50 of 60 matches");
+      expect(output).not.toContain("showing top");
+      expect(output).toContain("refine your query");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not show a truncation message when raw hits are under the cap", async () => {
+    const { dir, file, ids } = makeSession(3, (i) => `zebra_query_tag entry number ${i}`);
+    try {
+      const tool = register();
+      const output = await invoke(tool, file, ids, { query: "zebra_query_tag.*entry" });
+
+      expect(output).toContain("3 matches");
+      expect(output).not.toContain("showing");
+      expect(output).not.toContain("refine your query");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports an explicit out-of-range page instead of a false 'no matches' when hits exist but the page isn't reachable", async () => {
+    // 60 raw matches capped to 50 → pages 1-10 exist. Page 11 has no rows to
+    // slice, but hits.length (50) is > 0 — must not claim "No matches".
+    const { dir, file, ids } = makeSession(60, (i) => `zebra_query_tag entry number ${i}`);
+    try {
+      const tool = register();
+      const output = await invoke(tool, file, ids, { query: "zebra_query_tag.*entry", page: 11 });
+
+      expect(output).toContain("Page 11 is outside the available range 1-10");
+      expect(output).toContain("50 matches");
+      expect(output).not.toContain("No matches");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps normal zero-hit behavior unchanged for an out-of-range page with no matches at all", async () => {
+    const { dir, file, ids } = makeSession(3, (i) => `entry number ${i}`);
+    try {
+      const tool = register();
+      const output = await invoke(tool, file, ids, { query: "NO_SUCH_MARKER_ANYWHERE", page: 5 });
+
+      expect(output).toContain("No matches");
+      expect(output).not.toContain("is outside the available range");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/recall-quality.test.ts
+++ b/tests/recall-quality.test.ts
@@ -88,6 +88,10 @@ describe("vcc_recall pagination and hard-cap truncation signaling", () => {
       expect(output).toContain("Page 11 is outside the available range 1-10");
       expect(output).toContain("50 matches");
       expect(output).not.toContain("No matches");
+      // Cosmetic: this result IS truncated, so "refine your query" comes
+      // once from the truncation note — the out-of-range guidance must not
+      // repeat it.
+      expect(output.match(/refine your query/g)?.length).toBe(1);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -101,6 +105,25 @@ describe("vcc_recall pagination and hard-cap truncation signaling", () => {
 
       expect(output).toContain("No matches");
       expect(output).not.toContain("is outside the available range");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("suggests refining the query (once) for an out-of-range page on a NON-truncated result set", async () => {
+    // 12 raw hits, all under the cap (not truncated) — no truncation note to
+    // already say "refine your query", so the out-of-range guidance must
+    // supply it, exactly once. totalPages = ceil(12/5) = 3; page 5 is out of range.
+    const { dir, file, ids } = makeSession(12, (i) => `zebra_query_tag entry number ${i}`);
+    try {
+      const tool = register();
+      const output = await invoke(tool, file, ids, { query: "zebra_query_tag.*entry", page: 5 });
+
+      expect(output).toContain("Page 5 is outside the available range 1-3");
+      expect(output).toContain("12 matches");
+      expect(output).not.toContain("No matches");
+      expect(output).not.toContain("showing"); // not truncated — no truncation note at all
+      expect(output.match(/refine your query/g)?.length).toBe(1);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/search-entries.test.ts
+++ b/tests/search-entries.test.ts
@@ -203,3 +203,199 @@ describe("searchEntries mode fallback", () => {
     expect(searchEntries(entries, messages, "kubernetes").length).toBe(0);
   });
 });
+
+describe("searchEntries toolCall arguments", () => {
+  it("finds a bash command that exists only in toolCall arguments", () => {
+    const e: RenderedEntry[] = [{ index: 0, role: "assistant", summary: "Running the test suite" }];
+    const m: Message[] = [{
+      role: "assistant",
+      content: [{ type: "toolCall", name: "bash", arguments: { command: "grep -rn UNIQUEMARKER42 src" } }],
+    } as any];
+    const r = searchEntries(e, m, "UNIQUEMARKER42");
+    expect(r).toHaveLength(1);
+    expect(r[0].index).toBe(0);
+    expect(r[0].snippet).toContain("UNIQUEMARKER42");
+    expect(r[0].snippet).toContain("grep");
+  });
+
+  it("finds Write content that exists only in toolCall arguments", () => {
+    const e: RenderedEntry[] = [{ index: 0, role: "assistant", summary: "Writing config" }];
+    const m: Message[] = [{
+      role: "assistant",
+      content: [{
+        type: "toolCall", name: "Write",
+        arguments: { path: "config.json", content: '{ "featureFlag": "ZEBRA_STRIPE_MODE" }' },
+      }],
+    } as any];
+    const r = searchEntries(e, m, "ZEBRA_STRIPE_MODE");
+    expect(r).toHaveLength(1);
+    expect(r[0].snippet).toContain("ZEBRA_STRIPE_MODE");
+  });
+
+  it("finds Edit oldText/newText that exist only in toolCall arguments", () => {
+    const e: RenderedEntry[] = [{ index: 0, role: "assistant", summary: "Editing file" }];
+    const m: Message[] = [{
+      role: "assistant",
+      content: [{
+        type: "toolCall", name: "Edit",
+        arguments: { path: "a.ts", oldText: "const x = 1;", newText: "const QUOKKA_TOKEN = 2;" },
+      }],
+    } as any];
+    const r = searchEntries(e, m, "QUOKKA_TOKEN");
+    expect(r).toHaveLength(1);
+    expect(r[0].snippet).toContain("QUOKKA_TOKEN");
+  });
+
+  it("finds edits[] array oldText/newText that exist only in toolCall arguments", () => {
+    const e: RenderedEntry[] = [{ index: 0, role: "assistant", summary: "Editing file" }];
+    const m: Message[] = [{
+      role: "assistant",
+      content: [{
+        type: "toolCall", name: "Edit",
+        arguments: { path: "a.ts", edits: [{ oldText: "old", newText: "const NARWHAL_FLAG = true;" }] },
+      }],
+    } as any];
+    const r = searchEntries(e, m, "NARWHAL_FLAG");
+    expect(r).toHaveLength(1);
+    expect(r[0].snippet).toContain("NARWHAL_FLAG");
+  });
+
+  it("does not index a toolCall argument past the aggregate message budget (head-only cap)", () => {
+    // Needle sits ~5000 chars into a single arg field, well past the ~2000-char
+    // per-message toolCall-args budget — it must not be indexed.
+    const giant = "A".repeat(5000) + " NEEDLE_PAST_THE_CAP";
+    const e: RenderedEntry[] = [{ index: 0, role: "assistant", summary: "Writing large file" }];
+    const m: Message[] = [{
+      role: "assistant",
+      content: [{ type: "toolCall", name: "Write", arguments: { content: giant } }],
+    } as any];
+    expect(searchEntries(e, m, "NEEDLE_PAST_THE_CAP")).toHaveLength(0);
+  });
+
+  it("aggregates multiple toolCalls under ONE message-level budget, not per-call", () => {
+    // Two toolCalls, each individually well under a 2000-char cap (~1500
+    // chars), so a *per-call* cap would let both through in full. Only an
+    // *aggregate* per-message budget clips the combined text — proving the
+    // fix for the reviewed invariant (N toolCalls must not multiply the bound).
+    const call1 = { command: "EARLY_MARKER " + "A".repeat(1490) }; // ~1503 chars
+    const call2 = { command: "B".repeat(1490) + " LATE_MARKER_XYZ" }; // ~1507 chars
+    const e: RenderedEntry[] = [{ index: 0, role: "assistant", summary: "Two big bash calls" }];
+    const m: Message[] = [{
+      role: "assistant",
+      content: [
+        { type: "toolCall", name: "bash", arguments: call1 },
+        { type: "toolCall", name: "bash", arguments: call2 },
+      ],
+    } as any];
+    const early = searchEntries(e, m, "EARLY_MARKER");
+    expect(early).toHaveLength(1);
+    expect(early[0].snippet).toContain("EARLY_MARKER");
+    // Combined raw text (call1 + "\n" + call2) is ~3011 chars; LATE_MARKER_XYZ
+    // sits at the tail of call2, past the shared 2000-char budget.
+    expect(searchEntries(e, m, "LATE_MARKER_XYZ")).toHaveLength(0);
+  });
+
+  it("keeps a giant toolCall argument's indexed/snippet contribution bounded", () => {
+    // Needle sits near the start (within the cap) — it's found, and the
+    // snippet built from that indexed text stays bounded even though the
+    // underlying argument is 20k+ chars.
+    const giant = "NEEDLE_NEAR_START " + "B".repeat(20_000);
+    const e: RenderedEntry[] = [{ index: 0, role: "assistant", summary: "Writing large file" }];
+    const m: Message[] = [{
+      role: "assistant",
+      content: [{ type: "toolCall", name: "Write", arguments: { content: giant } }],
+    } as any];
+    const r = searchEntries(e, m, "NEEDLE_NEAR_START");
+    expect(r).toHaveLength(1);
+    expect(r[0].snippet).toContain("NEEDLE_NEAR_START");
+    // Bounded: the snippet must never approach the raw 20k-char argument size.
+    expect(r[0].snippet!.length).toBeLessThan(2500);
+  });
+
+  it("excludes the recall tool's own arguments from search (no self-hit)", () => {
+    // A vcc_recall invocation is persisted as an ordinary assistant toolCall.
+    // Its own { query } argument must not echo the search term back as a
+    // guaranteed self-hit — that would pollute every search's result count.
+    const e: RenderedEntry[] = [{ index: 0, role: "assistant", summary: "Searching" }];
+    const m: Message[] = [{
+      role: "assistant",
+      content: [{ type: "toolCall", name: "vcc_recall", arguments: { query: "SELF_HIT_MARKER" } }],
+    } as any];
+    expect(searchEntries(e, m, "SELF_HIT_MARKER")).toHaveLength(0);
+  });
+
+  it("excludes only the recall tool call, not a sibling toolCall in the same message", () => {
+    const e: RenderedEntry[] = [{ index: 0, role: "assistant", summary: "Searching then running" }];
+    const m: Message[] = [{
+      role: "assistant",
+      content: [
+        { type: "toolCall", name: "vcc_recall", arguments: { query: "SELF_HIT_MARKER" } },
+        { type: "toolCall", name: "bash", arguments: { command: "echo SIBLING_MARKER" } },
+      ],
+    } as any];
+    expect(searchEntries(e, m, "SELF_HIT_MARKER")).toHaveLength(0);
+    const r = searchEntries(e, m, "SIBLING_MARKER");
+    expect(r).toHaveLength(1);
+    expect(r[0].snippet).toContain("SIBLING_MARKER");
+  });
+
+  it("excludes the recall tool call case-insensitively", () => {
+    const e: RenderedEntry[] = [{ index: 0, role: "assistant", summary: "Searching" }];
+    const m: Message[] = [{
+      role: "assistant",
+      content: [{ type: "toolCall", name: "VCC_Recall", arguments: { query: "SELF_HIT_MARKER_2" } }],
+    } as any];
+    expect(searchEntries(e, m, "SELF_HIT_MARKER_2")).toHaveLength(0);
+  });
+
+  it("does not regress plain text search when toolCall args are also present", () => {
+    const r = searchEntries(entries, messages, "login");
+    expect(r).toHaveLength(1);
+    expect(r[0].index).toBe(0);
+  });
+});
+
+describe("searchEntries recall toolResult exclusion", () => {
+  // A vcc_recall call is [toolCall args (assistant)] -> [toolResult text].
+  // The toolCall-args side is covered above; these cover the toolResult side
+  // — its "N matches for \"<query>\">" text must not self-match a repeat query.
+
+  it("excludes the recall tool's own toolResult from search (no growth on repeat query)", () => {
+    const e: RenderedEntry[] = [{ index: 0, role: "tool_result", summary: '[vcc_recall] 1 matches for "MARKER"' }];
+    const m: Message[] = [{
+      role: "toolResult", toolName: "vcc_recall",
+      content: [{ type: "text", text: '1 matches for "MARKER" (page 1/1)' }],
+    } as any];
+    expect(searchEntries(e, m, "MARKER")).toHaveLength(0);
+  });
+
+  it("keeps an ordinary (non-recall) toolResult searchable", () => {
+    const e: RenderedEntry[] = [{ index: 0, role: "tool_result", summary: "[Read] file contents" }];
+    const m: Message[] = [{
+      role: "toolResult", toolName: "Read",
+      content: [{ type: "text", text: "export const MARKER_VALUE = 1;" }],
+    } as any];
+    const r = searchEntries(e, m, "MARKER_VALUE");
+    expect(r).toHaveLength(1);
+    expect(r[0].snippet).toContain("MARKER_VALUE");
+  });
+
+  it("does not affect browse/no-query results — entries are returned unchanged", () => {
+    const e: RenderedEntry[] = [{ index: 0, role: "tool_result", summary: '[vcc_recall] 1 matches for "MARKER"' }];
+    const m: Message[] = [{
+      role: "toolResult", toolName: "vcc_recall",
+      content: [{ type: "text", text: '1 matches for "MARKER"' }],
+    } as any];
+    expect(searchEntries(e, m)).toEqual(e);
+    expect(searchEntries(e, m, "")).toEqual(e);
+  });
+
+  it("excludes the recall toolResult case-insensitively", () => {
+    const e: RenderedEntry[] = [{ index: 0, role: "tool_result", summary: '[VCC_Recall] 1 matches for "MARKER2"' }];
+    const m: Message[] = [{
+      role: "toolResult", toolName: "VCC_Recall",
+      content: [{ type: "text", text: '1 matches for "MARKER2"' }],
+    } as any];
+    expect(searchEntries(e, m, "MARKER2")).toHaveLength(0);
+  });
+});

--- a/tests/search-entries.test.ts
+++ b/tests/search-entries.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { searchEntries } from "../src/core/search-entries";
+import { searchEntries, searchEntriesDetailed } from "../src/core/search-entries";
 import type { RenderedEntry } from "../src/core/render-entries";
 import type { Message } from "@earendil-works/pi-ai";
 
@@ -397,5 +397,126 @@ describe("searchEntries recall toolResult exclusion", () => {
       content: [{ type: "text", text: '1 matches for "MARKER2"' }],
     } as any];
     expect(searchEntries(e, m, "MARKER2")).toHaveLength(0);
+  });
+});
+
+describe("searchEntriesDetailed relative noise floor", () => {
+  // Query matches all 4 terms multiple times in entry 0, all 4 terms once
+  // in entry 1, and only 1 of 4 terms once each in entries 2-4 — a clear
+  // score cliff between {0,1} and {2,3,4} under multi-term BM25 OR scoring.
+  const graded = [
+    "alpha beta gamma delta alpha beta gamma delta alpha beta gamma delta discussion of the redis cache design",
+    "alpha beta gamma delta talked about this pairing once in a design review",
+    "alpha mentioned once in passing during a long unrelated conversation about something else entirely",
+    "beta appears here only one time in a sentence about nothing important at all today",
+    "gamma shows up once too in this otherwise unrelated paragraph of text about weather",
+  ];
+  const gradedEntries: RenderedEntry[] = graded.map((t, i) => ({ index: i, role: "user", summary: t }));
+  const gradedMessages: Message[] = graded.map((t) => ({ role: "user", content: t } as any));
+  const query = "alpha beta gamma delta";
+
+  it("drops a clearly low-score tail but preserves the surviving hits' order (default floor)", () => {
+    // Baseline (floor disabled): every entry matches at least one term.
+    const baseline = searchEntriesDetailed(gradedEntries, gradedMessages, query, { relativeFloor: 0, cap: 1e9 });
+    expect(baseline.hits.map((h) => h.index)).toEqual([0, 1, 2, 4, 3]);
+
+    // Default floor (no tuning override — the real production constant):
+    // the low-score tail (2, 3, 4) is dropped, top order (0, 1) preserved.
+    const r = searchEntriesDetailed(gradedEntries, gradedMessages, query);
+    expect(r.hits.map((h) => h.index)).toEqual([0, 1]);
+    expect(r.totalBeforeCap).toBe(2);
+    expect(r.truncated).toBe(false); // floor-filtered, not cap-truncated
+  });
+
+  it("never zeroes a non-empty result — a sole, low-score hit still survives", () => {
+    const texts = ["nothing relevant here at all", "the redis cache invalidation kept failing in staging"];
+    const e: RenderedEntry[] = texts.map((t, i) => ({ index: i, role: "user", summary: t }));
+    const m: Message[] = texts.map((t) => ({ role: "user", content: t } as any));
+    const r = searchEntriesDetailed(e, m, "redis cache invalidation");
+    expect(r.hits).toHaveLength(1);
+    expect(r.hits[0].index).toBe(1);
+  });
+
+  it("never applies the relative floor to single-term queries — structural, not fixture-specific", () => {
+    // Effective term count (after stopword filtering) gates the floor: <2
+    // terms skips it entirely, regardless of how aggressive the floor is.
+    // Proven with an aggressive floor override (0.9) and a corpus shaped so
+    // the low-scoring hit WOULD be cut if the floor applied — it survives
+    // only because the single-term gate bypasses filtering altogether.
+    const singleTermTexts = [
+      "auth ".repeat(20) + "flow rewritten", // 20x occurrences — high score
+      "one mention of auth here in an otherwise unrelated changelog entry", // 1x — low score
+    ];
+    const e: RenderedEntry[] = singleTermTexts.map((t, i) => ({ index: i, role: "user", summary: t }));
+    const m: Message[] = singleTermTexts.map((t) => ({ role: "user", content: t } as any));
+    const r = searchEntriesDetailed(e, m, "auth", { relativeFloor: 0.9, cap: 1e9 });
+    expect(r.hits.map((h) => h.index)).toEqual([0, 1]); // both survive: gate bypassed floor entirely
+
+    // Control: the SAME floor override on an equivalent MULTI-term corpus
+    // does filter the low-score hit — proving the override mechanism itself
+    // works, and that single-term survival above is the gate, not a fluke.
+    const multiTermTexts = [
+      "alpha beta gamma delta ".repeat(3) + "design review",
+      "alpha mentioned once in an unrelated paragraph",
+    ];
+    const e2: RenderedEntry[] = multiTermTexts.map((t, i) => ({ index: i, role: "user", summary: t }));
+    const m2: Message[] = multiTermTexts.map((t) => ({ role: "user", content: t } as any));
+    const r2 = searchEntriesDetailed(e2, m2, "alpha beta gamma delta", { relativeFloor: 0.9, cap: 1e9 });
+    expect(r2.hits.map((h) => h.index)).toEqual([0]); // low-score hit filtered
+  });
+
+  it("gates on DISTINCT normalized terms — duplicate/case-duplicate words stay single-term", () => {
+    // "auth auth" / "Auth AUTH" is semantically ONE term repeated/recased,
+    // not a multi-term query. Same aggressive floor (0.9) and corpus shape
+    // as above: the low-score hit must still survive every variant.
+    const texts = [
+      "auth ".repeat(20) + "flow rewritten",
+      "one mention of auth here in an otherwise unrelated changelog entry",
+    ];
+    const e: RenderedEntry[] = texts.map((t, i) => ({ index: i, role: "user", summary: t }));
+    const m: Message[] = texts.map((t) => ({ role: "user", content: t } as any));
+
+    for (const q of ["auth auth", "Auth AUTH", "auth Auth auth"]) {
+      const r = searchEntriesDetailed(e, m, q, { relativeFloor: 0.9, cap: 1e9 });
+      expect(r.hits.map((h) => h.index).sort()).toEqual([0, 1]);
+    }
+  });
+});
+
+describe("searchEntriesDetailed hard result cap", () => {
+  const size = 60;
+  const bm25Entries: RenderedEntry[] = Array.from({ length: size }, (_, i) => ({
+    index: i, role: "user", summary: `zebra_query_tag entry number ${i}`,
+  }));
+  const bm25Messages: Message[] = bm25Entries.map((e) => ({ role: "user", content: e.summary } as any));
+
+  it("bounds the BM25/natural-language path to SEARCH_RESULT_CAP (50)", () => {
+    // Disable the floor so the cap's effect is isolated — all 60 entries
+    // are equally strong single-term matches, so none would be floor-filtered.
+    const r = searchEntriesDetailed(bm25Entries, bm25Messages, "zebra_query_tag", { relativeFloor: 0 });
+    expect(r.totalBeforeCap).toBe(60);
+    expect(r.hits).toHaveLength(50);
+    expect(r.truncated).toBe(true);
+  });
+
+  it("bounds the regex path to SEARCH_RESULT_CAP (50), with default tuning (no override)", () => {
+    const regexEntries: RenderedEntry[] = Array.from({ length: size }, (_, i) => ({
+      index: i, role: "user", summary: `zebra_query_tag entry number ${i}`,
+    }));
+    const regexMessages: Message[] = regexEntries.map((e) => ({ role: "user", content: e.summary } as any));
+    // "." makes this a regex-mode query (looksLikeRegex), no BM25/floor involved.
+    const r = searchEntriesDetailed(regexEntries, regexMessages, "zebra_query_tag.*entry");
+    expect(r.totalBeforeCap).toBe(60);
+    expect(r.hits).toHaveLength(50);
+    expect(r.truncated).toBe(true);
+  });
+
+  it("does not truncate when raw hits are under the cap", () => {
+    const small = bm25Entries.slice(0, 10);
+    const smallMsgs = bm25Messages.slice(0, 10);
+    const r = searchEntriesDetailed(small, smallMsgs, "zebra_query_tag");
+    expect(r.hits).toHaveLength(10);
+    expect(r.totalBeforeCap).toBe(10);
+    expect(r.truncated).toBe(false);
   });
 });

--- a/tests/vcc-recall-command.test.ts
+++ b/tests/vcc-recall-command.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { registerVccRecallCommand } from "../src/commands/vcc-recall";
+
+// ── Helpers (mirrors tests/recall-quality.test.ts, adapted for the command's
+//    sendMessage-based API instead of the tool's return-value API) ─────────
+
+const userMsg = (id: string, content: string) => ({
+  type: "message",
+  id,
+  message: { role: "user", content },
+});
+
+let dirCount = 0;
+const makeSession = (n: number, textOf: (i: number) => string) => {
+  const dir = mkdtempSync(join(tmpdir(), `pi-vcc-recall-command-${dirCount++}-`));
+  const file = join(dir, "session.jsonl");
+  const ids = Array.from({ length: n }, (_, i) => `m${i}`);
+  const lines = ids.map((id, i) => JSON.stringify(userMsg(id, textOf(i))));
+  writeFileSync(file, lines.join("\n") + "\n", "utf8");
+  return { dir, file, ids };
+};
+
+const register = () => {
+  let handler: ((args: string, ctx: any) => Promise<void>) | undefined;
+  const sent: Array<{ customType: string; content: string; display: boolean }> = [];
+  const pi = {
+    registerCommand: (name: string, command: { handler: typeof handler }) => {
+      expect(name).toBe("pi-vcc-recall");
+      handler = command.handler;
+    },
+    sendMessage: (msg: any) => {
+      sent.push(msg);
+    },
+  } as any;
+  registerVccRecallCommand(pi);
+  return { handler: handler!, sent };
+};
+
+const invoke = async (handler: (args: string, ctx: any) => Promise<void>, file: string, ids: string[], args: string) => {
+  await handler(args, {
+    sessionManager: {
+      getSessionFile: () => file,
+      getBranch: () => ids.map((id) => ({ id })),
+      getEntries: () => ids.map((id) => ({ id })),
+    },
+    ui: { notify: () => {} },
+  });
+};
+
+describe("/pi-vcc-recall command pagination and hard-cap truncation signaling", () => {
+  it("reports a capped page count and an explicit truncation message when raw hits exceed the cap", async () => {
+    // "." makes this a regex-mode query, matching every one of the 60
+    // messages deterministically (no BM25/floor involved) — isolates the
+    // hard cap's effect on the command-facing message.
+    const { dir, file, ids } = makeSession(60, (i) => `zebra_query_tag entry number ${i}`);
+    try {
+      const { handler, sent } = register();
+      await invoke(handler, file, ids, "zebra_query_tag.*entry");
+
+      expect(sent).toHaveLength(1);
+      const content = sent[0].content;
+      // 60 raw matches capped to 50 → 10 pages of 5.
+      expect(content).toContain("Page 1/10");
+      expect(content).toContain("50 total matches");
+      // Truthful, neutral truncation signal (no "top" — regex hits aren't ranked).
+      expect(content).toContain("showing 50 of 60 matches");
+      expect(content).not.toContain("showing top");
+      expect(content).toContain("refine your query");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not show a truncation message when raw hits are under the cap", async () => {
+    const { dir, file, ids } = makeSession(3, (i) => `zebra_query_tag entry number ${i}`);
+    try {
+      const { handler, sent } = register();
+      await invoke(handler, file, ids, "zebra_query_tag.*entry");
+
+      const content = sent[0].content;
+      expect(content).toContain("3 matches");
+      expect(content).not.toContain("showing");
+      expect(content).not.toContain("refine your query");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports an explicit out-of-range page (not a false 'No matches') using /pi-vcc-recall syntax, without duplicating 'refine your query'", async () => {
+    // 60 raw matches capped to 50 → pages 1-10 exist. Page 11 has no rows to
+    // slice, but hits.length (50) is > 0 — must not claim "No matches", and
+    // since this IS a truncated result, the guidance must not repeat the
+    // "refine your query" suggestion the truncation note already gave.
+    const { dir, file, ids } = makeSession(60, (i) => `zebra_query_tag entry number ${i}`);
+    try {
+      const { handler, sent } = register();
+      await invoke(handler, file, ids, "zebra_query_tag.*entry page:11");
+
+      const content = sent[0].content;
+      expect(content).toContain("Page 11 is outside the available range 1-10");
+      expect(content).toContain("50 matches");
+      expect(content).not.toContain("No matches");
+      expect(content).toContain("/pi-vcc-recall");
+      expect(content).toContain("page:N");
+      // "refine your query" must appear exactly once (from the truncation
+      // note), not again in the out-of-range guidance.
+      expect(content.match(/refine your query/g)?.length).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps normal zero-hit behavior unchanged for an out-of-range page with no matches at all", async () => {
+    const { dir, file, ids } = makeSession(3, (i) => `entry number ${i}`);
+    try {
+      const { handler, sent } = register();
+      await invoke(handler, file, ids, "NO_SUCH_MARKER_ANYWHERE page:5");
+
+      const content = sent[0].content;
+      expect(content).toContain("No matches");
+      expect(content).not.toContain("is outside the available range");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("carries the scope:all label through an out-of-range page response", async () => {
+    const { dir, file, ids } = makeSession(60, (i) => `zebra_query_tag entry number ${i}`);
+    try {
+      const { handler, sent } = register();
+      await invoke(handler, file, ids, "zebra_query_tag.*entry scope:all page:11");
+
+      const content = sent[0].content;
+      expect(content).toContain("(scope: all)");
+      expect(content).toContain("scope:all");
+      expect(content).toContain("Page 11 is outside the available range 1-10");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- index bounded tool-call arguments so recall can find commands, write content, and edit text that were previously invisible
- prevent `vcc_recall` from matching its own invocation/output on repeated searches
- trim low-relevance BM25 tails for distinct multi-term queries and cap all search paths at 50 results
- report truncation and out-of-range pages honestly in both the tool and `/pi-vcc-recall` command
- bump package version to `0.7.0`

## Design invariants

- one shared 2,000-character tool-argument budget per message
- snippets use the same augmented text that search indexes
- single-term and regex queries bypass the BM25 relative floor
- multi-term floor is relative to the top score (`0.20`), never absolute, and cannot remove the top hit
- global `#N`, lineage/all scope, `expand`, `mode:"touched"`, and `#N:path` semantics are unchanged
- regex result order remains chronological; the cap preserves the first 50 matches

## Evidence

Real-session benchmark (`scripts/benchmark-recall-quality.ts`):

- two runs: 23 sessions / 161 queries and 31 sessions / 222 queries
- zero new empty searches
- zero top-result changes
- median result count: `32 → 18` and `29.5 → 20`
- p90 bounded at `50`

Live validation:

- tool-only bash/write markers were searchable with matching snippets
- repeated query remained stable at `1 → 1` hit (no recall feedback loop)
- broad regex search reported `50 of 322 matches` across 10 pages
- `page:11` returned an explicit available-range message instead of `No matches`

## Validation

- `bun test`: **299 pass, 0 fail** (791 expectations)
- focused recall/search/command tests: **52 pass, 0 fail**
- independent pre-PR review by Mark: **APPROVE**, no blockers; slash-command parity finding addressed before this PR
