### PR TITLE
Fix recall for sessions larger than V8's string limit

### DIFF
--- a/src/core/load-messages.ts
+++ b/src/core/load-messages.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { closeSync, openSync, readSync } from "fs";
 import type { Message } from "@earendil-works/pi-ai";
 import { renderMessage, type RenderedEntry } from "./render-entries";
 
@@ -7,49 +7,74 @@ export interface LoadedMessages {
   rawMessages: Message[];
 }
 
-/**
- * Read the session transcript, treating "file not written yet" as empty history.
- *
- * Pi only creates the session JSONL once it persists the first entry, so a
- * brand-new session has no file on disk. That is an empty current-session
- * history, not a failure. Every other error (permissions, I/O, a path that is
- * not a file) still propagates - silently reporting corruption as "no history"
- * would hide a real problem.
- */
-const readSessionFile = (sessionFile: string): string => {
-  try {
-    return readFileSync(sessionFile, "utf-8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return "";
-    throw err;
-  }
-};
-
 export const loadAllMessages = (
   sessionFile: string,
   full: boolean,
   allowedEntryIds?: Set<string>,
 ): LoadedMessages => {
-  const content = readSessionFile(sessionFile);
-  const entries: any[] = [];
-  for (const line of content.split("\n")) {
-    if (!line.trim()) continue;
-    try { entries.push(JSON.parse(line)); } catch {}
-  }
   const rendered: RenderedEntry[] = [];
   const rawMessages: Message[] = [];
-
   let messageIndex = 0;
-  for (const e of entries) {
-    const isMessage = e.type === "message" && e.message;
-    if (!isMessage) continue;
 
-    const allowed = !allowedEntryIds || allowedEntryIds.has(e.id);
+  const processLine = (line: Buffer) => {
+    if (line.length === 0) return;
+    let entry: any;
+    try { entry = JSON.parse(line.toString("utf8")); } catch { return; }
+    if (entry.type !== "message" || !entry.message) return;
+
+    const allowed = !allowedEntryIds || allowedEntryIds.has(entry.id);
     if (allowed) {
-      rendered.push(renderMessage(e.message, messageIndex, full));
-      rawMessages.push(e.message);
+      rendered.push(renderMessage(entry.message, messageIndex, full));
+      rawMessages.push(entry.message);
     }
     messageIndex++;
+  };
+
+  // Avoid materializing the entire JSONL file as one string. Large sessions can
+  // exceed V8's maximum string length before parsing even starts.
+  let fd: number;
+  try {
+    fd = openSync(sessionFile, "r");
+  } catch (err) {
+    // Pi does not create a new session's JSONL until its first persisted entry.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return { rendered, rawMessages };
+    throw err;
+  }
+
+  const chunk = Buffer.allocUnsafe(64 * 1024);
+  let pending: Buffer[] = [];
+  let pendingLength = 0;
+
+  try {
+    let bytesRead: number;
+    while ((bytesRead = readSync(fd, chunk, 0, chunk.length, null)) > 0) {
+      let start = 0;
+      for (let i = 0; i < bytesRead; i++) {
+        if (chunk[i] !== 0x0a) continue;
+
+        const segment = chunk.subarray(start, i);
+        if (pendingLength > 0) {
+          pending.push(segment);
+          processLine(Buffer.concat(pending, pendingLength + segment.length));
+          pending = [];
+          pendingLength = 0;
+        } else {
+          processLine(segment);
+        }
+        start = i + 1;
+      }
+
+      if (start < bytesRead) {
+        const remainder = Buffer.from(chunk.subarray(start, bytesRead));
+        pending.push(remainder);
+        pendingLength += remainder.length;
+      }
+    }
+
+    // JSONL files normally end with a newline, but preserve a final partial line.
+    if (pendingLength > 0) processLine(Buffer.concat(pending, pendingLength));
+  } finally {
+    closeSync(fd);
   }
 
   return { rendered, rawMessages };

--- a/tests/load-messages.test.ts
+++ b/tests/load-messages.test.ts
@@ -27,6 +27,27 @@ describe("loadAllMessages", () => {
     }
   });
 
+  it("loads JSONL incrementally across read-chunk boundaries", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-vcc-load-chunked-"));
+    const file = join(dir, "session.jsonl");
+    try {
+      const largeText = `${"x".repeat(70_000)} unicode: λ`;
+      const lines = [
+        JSON.stringify({ type: "message", id: "m1", message: { role: "user", content: largeText } }),
+        JSON.stringify({ type: "message", id: "m2", message: { role: "user", content: "after boundary" } }),
+      ];
+      // Deliberately omit the final newline to cover the buffered tail as well.
+      writeFileSync(file, lines.join("\n"), "utf8");
+
+      const loaded = loadAllMessages(file, true);
+      expect(loaded.rendered).toHaveLength(2);
+      expect(loaded.rendered[0].summary).toBe(largeText);
+      expect(loaded.rendered[1].summary).toBe("after boundary");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("treats a not-yet-written session file as empty history instead of throwing ENOENT", () => {
     // Fresh session: pi has not persisted any entry, so the JSONL does not exist.
     const dir = mkdtempSync(join(tmpdir(), "pi-vcc-load-missing-"));


### PR DESCRIPTION
## Summary

- parse session JSONL incrementally instead of reading the entire file into one UTF-8 string
- preserve message indices, lineage filtering, missing-file behavior, malformed-line handling, and final lines without a trailing newline
- add regression coverage for records spanning read chunks

## Why

`readFileSync(sessionFile, "utf-8")` fails before parsing when a session exceeds V8's maximum string length:

```
Cannot create a string longer than 0x1fffffe8 characters
```

This made `vcc_recall` unusable on long-running sessions.

## Verification

- `bun test` — 309 passed, 0 failed
- successfully ran `vcc_recall` for `49-frame proof clip LTX` against a 698,838,735-byte real session JSONL
